### PR TITLE
fix(backup): pg_dump 18 to match prod server, fail loudly on partial dumps

### DIFF
--- a/infra/helm/benger/templates/cronjob-backup.yaml
+++ b/infra/helm/benger/templates/cronjob-backup.yaml
@@ -30,7 +30,7 @@ spec:
             runAsUser: 0
           containers:
             - name: backup
-              image: {{ .Values.backup.image | default "postgres:15-alpine" | quote }}
+              image: {{ .Values.backup.image | default "postgres:18-alpine" | quote }}
               imagePullPolicy: IfNotPresent
               env:
                 - name: PGHOST
@@ -71,6 +71,7 @@ spec:
                 - -c
                 - |
                   set -e
+                  set -o pipefail
 
                   DATE=$(date +%Y-%m-%d_%H-%M-%S)
                   DAY_OF_WEEK=$(date +%u)
@@ -107,6 +108,7 @@ spec:
 
                   if [ "${DUMP_TABLE_COUNT}" -lt 5 ]; then
                     echo "[$(date)] ERROR: Dump contains fewer than 5 tables - backup may be incomplete!"
+                    rm -f "${BACKUP_FILE}"
                     exit 1
                   fi
 

--- a/infra/helm/benger/values.yaml
+++ b/infra/helm/benger/values.yaml
@@ -332,7 +332,12 @@ backup:
   enabled: true
   # Cron schedule (default: daily at 02:00 UTC)
   schedule: "0 2 * * *"
-  image: "postgres:15-alpine"
+  # pg_dump version must be >= the running server's major version, otherwise
+  # backups silently produce a 0-table dump (we caught this on 2026-04-28 after
+  # the server move bumped the runtime binary to PG 18 while the chart still
+  # shipped postgres:15-alpine). Keep this in sync with the bitnami postgresql
+  # image's actual binary version, not the image tag.
+  image: "postgres:18-alpine"
   # Host path on the node to store backups
   hostPath: "/opt/benger-backups"
   # Retention policy


### PR DESCRIPTION
## Summary

Prod backup CronJob has been silently producing **0-table dumps** since the 2026-04-27 server move bumped the running Postgres binary to 18.3.

- ``pg_dump 15.17`` in ``postgres:15-alpine`` refuses to dump a server that's a major version newer than itself ("aborting because of server version mismatch"), so the gzipped output ended up containing only the pg_dump error line.
- The existing 5-table sanity check fired the right error log but left the corrupt artifact on disk and the cron kept exiting "successfully" from the orchestration's perspective until the next sanity check happened.

## Changes

- ``values.yaml`` + ``cronjob-backup.yaml`` default: ``postgres:18-alpine``.
- ``set -o pipefail`` so ``pg_dump | gzip`` exits non-zero when pg_dump fails rather than silently masking it.
- ``rm`` the partial backup file when the table-count check fails, so retention doesn't have to clean up corrupt artifacts.

## Related — separate concern

The prod ``benger-postgresql-0`` pod is labeled ``bitnami/postgresql:15.3.0-debian-11-r17`` but runs ``PostgreSQL 18.3`` + ``OpenSSL 3.5.6`` (FIPS-restricted) at runtime. That's the upstream cause of:
- This backup failure (which this PR fixes).
- The ``func.md5()`` 500s in hotfix PR #10 (separately fixed there).

The runtime/image mismatch itself isn't addressed by this PR — needs its own infra ticket: pin a known-good bitnami image digest, OR officially migrate to a Postgres 18 chart and align tooling deliberately.

## Test plan

- [ ] Apply on staging, trigger a manual job (``kubectl create job --from=cronjob/benger-staging-backup --namespace benger-staging dryrun-2026-04-28``) and confirm the dump contains all expected tables.
- [ ] Re-run on prod tomorrow at 02:00 UTC; confirm dump size jumps from 4.0K (broken) to actual DB size and tables-in-dump matches live count.