### PR TITLE
fix: bump CORE_API_VERSION to 2.0 to match extended

### DIFF
--- a/services/api/extensions.py
+++ b/services/api/extensions.py
@@ -12,7 +12,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-CORE_API_VERSION = "1.0"
+CORE_API_VERSION = "2.0"
 
 _extended = None
 


### PR DESCRIPTION
PR #11 (Korrektur rename) described a ``CORE_API_VERSION`` bump but the commit never touched ``extensions.py``. Result on prod: extended package fails the version handshake at startup — ``requires core API ['2.0'], but core is 1.0. Extended features disabled`` — so:

- Klausurloesung wizard template missing.
- ``<Angabe>`` / ``<Notizen>`` / ``<Gliederung>`` / ``<Loesung>`` tags are not whitelisted by ``LabelConfigValidator`` (so ``POST /api/projects`` 422s again).
- Korrektur router and other extended hooks don't load.

Bumping core to ``"2.0"`` matches what extended already declares; the surface justifying the bump (rename of ``feedback_*`` schemas → ``korrektur_*``, plus the new ``register_field_types`` extension hook) is already on main.

## Test plan
- [ ] After merge, on prod ``kubectl exec deployment/benger-api -n benger -- python -c 'import sys; sys.path.insert(0, \"/app\"); import extensions; print(extensions.load_extended())'`` returns ``True``.
- [ ] Wizard shows the Klausurlösung card; creating a Klausurlösung project succeeds (no 422).