### PR TITLE
ci: build workers-base in platform repo and serve from public namespace

### DIFF
--- a/.github/workflows/build-workers-base.yml
+++ b/.github/workflows/build-workers-base.yml
@@ -1,0 +1,60 @@
+name: Build Workers Base Image
+
+# Builds the workers base image (Python deps + ML models + NLTK data) and
+# publishes it to ghcr.io/sebastiannagl/benger-platform/workers-base:latest.
+# This image is consumed by:
+#   - benger-platform's nightly-tests.yml (via make test-build)
+#   - OSS contributors running make test-build locally
+#   - benger-extended's cicd.yml (FROM ${WORKERS_BASE_IMAGE} in workers Dockerfile)
+# The package must be public on GHCR so anonymous pulls succeed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for rebuild (e.g., requirements.txt changed)'
+        required: false
+        type: string
+  schedule:
+    - cron: "0 4 * * 0"  # Weekly, Sunday 04:00 UTC
+  push:
+    branches: [main]
+    paths:
+      - services/workers/requirements.txt
+      - services/workers/Dockerfile.base
+      - .github/workflows/build-workers-base.yml
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/sebastiannagl/benger-platform/workers-base
+
+jobs:
+  build-base:
+    name: Build Workers Base (ML models + deps)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/share/powershell /usr/local/share/chromium || true
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push workers-base
+        working-directory: services/workers
+        run: |
+          docker build -f Dockerfile.base -t "$IMAGE:latest" .
+          docker push "$IMAGE:latest"
+          echo "Pushed $IMAGE:latest"

--- a/infra/docker-compose.alt-ports-extended.yml
+++ b/infra/docker-compose.alt-ports-extended.yml
@@ -66,7 +66,7 @@ services:
       context: ../services/workers
       dockerfile: Dockerfile
       args:
-        WORKERS_BASE_IMAGE: ghcr.io/sebastiannagl/benger/workers-base:latest
+        WORKERS_BASE_IMAGE: ghcr.io/sebastiannagl/benger-platform/workers-base:latest
     restart: unless-stopped
     volumes:
       - ../services/workers:/app:rw
@@ -93,7 +93,7 @@ services:
       context: ../services/workers
       dockerfile: Dockerfile
       args:
-        WORKERS_BASE_IMAGE: ghcr.io/sebastiannagl/benger/workers-base:latest
+        WORKERS_BASE_IMAGE: ghcr.io/sebastiannagl/benger-platform/workers-base:latest
     restart: unless-stopped
     working_dir: /tmp
     command: sh -c "export PYTHONPATH=/app:$$PYTHONPATH && celery -A tasks beat --loglevel=info"

--- a/infra/docker-compose.alt-ports.yml
+++ b/infra/docker-compose.alt-ports.yml
@@ -66,7 +66,7 @@ services:
       context: ../services/workers
       dockerfile: Dockerfile
       args:
-        WORKERS_BASE_IMAGE: ghcr.io/sebastiannagl/benger/workers-base:latest
+        WORKERS_BASE_IMAGE: ghcr.io/sebastiannagl/benger-platform/workers-base:latest
     restart: unless-stopped
     volumes:
       - ../services/workers:/app:rw
@@ -93,7 +93,7 @@ services:
       context: ../services/workers
       dockerfile: Dockerfile
       args:
-        WORKERS_BASE_IMAGE: ghcr.io/sebastiannagl/benger/workers-base:latest
+        WORKERS_BASE_IMAGE: ghcr.io/sebastiannagl/benger-platform/workers-base:latest
     restart: unless-stopped
     working_dir: /tmp
     command: sh -c "export PYTHONPATH=/app:$$PYTHONPATH && celery -A tasks beat --loglevel=info"

--- a/services/workers/Dockerfile
+++ b/services/workers/Dockerfile
@@ -1,7 +1,7 @@
 # Workers Application Image
 # Built on top of workers-base (which has Python deps + ML models).
 # Code-only changes rebuild in <2 min since deps/models are cached in base.
-ARG WORKERS_BASE_IMAGE=ghcr.io/sebastiannagl/benger-extended/workers-base:latest
+ARG WORKERS_BASE_IMAGE=ghcr.io/sebastiannagl/benger-platform/workers-base:latest
 FROM ${WORKERS_BASE_IMAGE}
 
 WORKDIR /app


### PR DESCRIPTION
Move workers-base ownership from ``benger-extended`` (private GHCR) to ``benger-platform`` (public GHCR), so OSS contributors can run ``make test-build`` and pull the image without GHCR auth, and so the image's lifecycle isn't tied to a private repo's release cadence.

- New ``.github/workflows/build-workers-base.yml`` builds ``services/workers/Dockerfile.base`` and pushes ``ghcr.io/sebastiannagl/benger-platform/workers-base:latest``. Triggers: ``requirements.txt`` or ``Dockerfile.base`` change on ``main``, weekly schedule (Sunday 04:00 UTC), and manual ``workflow_dispatch``.
- ``services/workers/Dockerfile`` ARG default repointed to the public namespace.
- ``infra/docker-compose.alt-ports{,-extended}.yml`` updated to match.

## Post-merge action (manual, one-time)

After this lands and the workflow has pushed the new image, mark the GHCR package public:
```
gh api -X PATCH /user/packages/container/benger-platform%2Fworkers-base/visibility -f visibility=public
```

Then merge the paired benger-extended PR https://github.com/SebastianNagl/benger-extended/pull/3 which repoints its workers build-arg to the public location and removes its local workers-base workflow.

## Test plan
- [ ] Workflow runs on merge (Dockerfile.base unchanged but path-filtered triggers fire on the workflow file itself).
- [ ] Manually run via ``gh workflow run "Build Workers Base Image"`` to seed the image. Verify ``ghcr.io/sebastiannagl/benger-platform/workers-base:latest`` exists.
- [ ] Mark the package public (command above).
- [ ] Merge extended PR #3, confirm next extended build pulls the new public image successfully.
- [ ] Pull anonymously (e.g. ``docker logout ghcr.io && docker pull ghcr.io/sebastiannagl/benger-platform/workers-base:latest``) to confirm public visibility.