### PR TITLE
fix(auth): orgManager no longer auto-picks first org (causes silent 403s)

### DIFF
--- a/services/frontend/src/lib/auth/__tests__/organizationManager.test.ts
+++ b/services/frontend/src/lib/auth/__tests__/organizationManager.test.ts
@@ -42,7 +42,10 @@ describe('OrganizationManager', () => {
       expect(manager.getOrganizations()).toEqual(orgs)
     })
 
-    it('should auto-select first organization when none is selected', () => {
+    it('does NOT auto-select an organization — caller decides', () => {
+      // Regression: silently auto-picking orgs[0] flipped the API context
+      // away from "private" while the UI still rendered "Privat", causing
+      // 403s on org-only endpoints.
       const orgs = [
         { id: 'org1', name: 'Org 1', slug: 'org1' },
         { id: 'org2', name: 'Org 2', slug: 'org2' },
@@ -50,35 +53,25 @@ describe('OrganizationManager', () => {
 
       manager.setOrganizations(orgs)
 
-      expect(manager.getCurrentOrganization()).toEqual(orgs[0])
+      expect(manager.getCurrentOrganization()).toBeNull()
+      expect(manager.getOrganizationContext()).toBe('private')
     })
 
-    it('should NOT auto-select if an organization is already selected', () => {
+    it('preserves an explicitly-set current org across setOrganizations', () => {
       const existingOrg = { id: 'existing', name: 'Existing', slug: 'existing' } as any
       manager.setCurrentOrganization(existingOrg)
 
-      const orgs = [
+      manager.setOrganizations([
         { id: 'org1', name: 'Org 1', slug: 'org1' },
-        { id: 'org2', name: 'Org 2', slug: 'org2' },
-      ] as any[]
+      ] as any[])
 
-      manager.setOrganizations(orgs)
-
-      // Should keep the existing org, not replace with org1
       expect(manager.getCurrentOrganization()).toEqual(existingOrg)
     })
 
-    it('should NOT auto-select when organizations list is empty', () => {
+    it('leaves currentOrganization null when given an empty list', () => {
       manager.setOrganizations([])
 
       expect(manager.getCurrentOrganization()).toBeNull()
-    })
-
-    it('should handle single organization', () => {
-      const orgs = [{ id: 'only', name: 'Only Org', slug: 'only' }] as any[]
-      manager.setOrganizations(orgs)
-
-      expect(manager.getCurrentOrganization()).toEqual(orgs[0])
     })
   })
 
@@ -115,7 +108,8 @@ describe('OrganizationManager', () => {
 
       expect(result).toEqual(mockOrgs)
       expect(manager.getOrganizations()).toEqual(mockOrgs)
-      expect(manager.getCurrentOrganization()).toEqual(mockOrgs[0])
+      // currentOrganization stays null — AuthContext picks based on subdomain.
+      expect(manager.getCurrentOrganization()).toBeNull()
     })
 
     it('should clear state on fetch failure', async () => {
@@ -158,8 +152,9 @@ describe('OrganizationManager', () => {
 
   describe('clear', () => {
     it('should clear all organization state', () => {
-      const orgs = [{ id: 'org1', name: 'Org 1', slug: 'org1' }] as any[]
-      manager.setOrganizations(orgs)
+      const org = { id: 'org1', name: 'Org 1', slug: 'org1' } as any
+      manager.setOrganizations([org])
+      manager.setCurrentOrganization(org)
 
       expect(manager.getOrganizations()).toHaveLength(1)
       expect(manager.getCurrentOrganization()).not.toBeNull()
@@ -218,12 +213,12 @@ describe('OrganizationManager', () => {
         getOrganizations: jest.fn().mockResolvedValue(mockOrgs),
       } as any
 
-      // Fetch sets orgs and auto-selects first
+      // Fetch sets orgs but does NOT auto-select — caller must pick.
       await manager.fetchOrganizations(mockApiClient)
       expect(manager.getOrganizations()).toEqual(mockOrgs)
-      expect(manager.getCurrentOrganization()?.id).toBe('org1')
+      expect(manager.getCurrentOrganization()).toBeNull()
 
-      // Switch to second org
+      // Caller picks an org explicitly
       manager.setCurrentOrganization(mockOrgs[1])
       expect(manager.getCurrentOrganization()?.id).toBe('org2')
 

--- a/services/frontend/src/lib/auth/organizationManager.ts
+++ b/services/frontend/src/lib/auth/organizationManager.ts
@@ -33,15 +33,17 @@ export class OrganizationManager {
   }
 
   /**
-   * Set organizations list
+   * Set organizations list.
+   *
+   * NOTE: This intentionally does NOT auto-select the first org. The caller
+   * (AuthContext) is the source of truth for `currentOrganization` and decides
+   * whether to enter private mode (null) or pick a specific org based on the
+   * subdomain / persisted state. Auto-picking here used to silently flip the
+   * API-side org context to the alphabetically-first org while the UI still
+   * displayed "Privat", causing 403s on org-only endpoints.
    */
   setOrganizations(organizations: Organization[]): void {
     this.state.organizations = organizations
-
-    // Auto-select first organization if none selected
-    if (!this.state.currentOrganization && organizations.length > 0) {
-      this.state.currentOrganization = organizations[0]
-    }
   }
 
   /**


### PR DESCRIPTION
## Summary

SebaN reported a 403 when trying to create a private project on prod. Network tab showed `X-Organization-Context: <Benchathon-id>` even though the dropdown clearly displayed "Privat". Repro on prod via puppeteer confirmed the divergence.

**Root cause:** `OrganizationManager.setOrganizations` silently auto-selected `organizations[0]` as `currentOrganization`. `AuthContext` calls `setOrganizations(orgs)` right after login, then **independently** sets its React state to \`null\` for private mode. Two state stores → divergence:

- UI reads from React state (\`null\` → "Privat") ✓
- API client reads from \`orgManager.getOrganizationContext()\` (returned the auto-picked org's id) ✗

The backend's create-project handler then ran the org-mode role check and rejected SebaN's \`ANNOTATOR\` role.

## Fix

Drop the auto-pick in \`OrganizationManager.setOrganizations\`. \`AuthContext\` is the only caller and already has correct branching logic for subdomain / private / last-org cases — it sets \`currentOrganization\` explicitly in every path (lines 322–356 + 478–483 of AuthContext.tsx).

## Test plan

- [x] \`organizationManager.test.ts\` — 18/18 pass; updated to encode the new contract (setOrganizations populates the list but never picks).
- [x] \`AuthContext.test.tsx\` — 91/91 pass (no behavior change in AuthContext).
- [ ] On prod after deploy: SebaN logs in on bare domain → dropdown shows "Privat" → POST /api/projects sends \`X-Organization-Context: private\` → 200 OK.
- [ ] Switching the dropdown to Benchathon → header switches to the org id (still works).
- [ ] On a subdomain (\`benchathon.what-a-benger.net\`) the subdomain-based init still picks the matching org (lines 322–331 of AuthContext.tsx).