### PR TITLE
fix(infra): pin Postgres image by digest to lock PG-18+FIPS runtime

### DIFF
--- a/infra/helm/benger/values.yaml
+++ b/infra/helm/benger/values.yaml
@@ -269,6 +269,20 @@ frontend:
 
 postgresql:
   enabled: true
+  image:
+    # Pin by digest. The bitnami/postgresql:15.3.0-debian-11-r17 tag was
+    # rewritten by Broadcom post-acquisition to ship Photon OS + PG 18 +
+    # FIPS-OpenSSL content (image revision 27, build 2026-02-14, vendor
+    # "Broadcom, Inc."). Pinning the digest makes the runtime immutable
+    # so a containerd cache eviction can't silently shift PG version
+    # again. Reverting to the original PG 15 content is destructive
+    # because the prod data directory is already in PG 18 format.
+    # See workspace CLAUDE.md → "Postgres image content drift" for
+    # context and the planned PG-version review.
+    repository: bitnami/postgresql
+    tag: "15.3.0-debian-11-r17"
+    digest: "sha256:e6d86d16516120a3a7a56268c663c8158cdffb77278f44c7adfd4cf8980810f2"
+    pullPolicy: IfNotPresent
   auth:
     username: postgres
     # password: # Generated automatically or set via external secrets


### PR DESCRIPTION
## Summary

The Bitnami subchart pulls ``bitnami/postgresql:15.3.0-debian-11-r17``, but Broadcom **silently rewrote** that tag post-acquisition to ship Photon OS + **PostgreSQL 18.3** + **FIPS-OpenSSL** content under the same label (image revision 27, build 2026-02-14, vendor ``Broadcom, Inc.``). Documented in workspace ``CLAUDE.md`` → *Postgres image content drift*.

Prod is **already** running this content since the 2026-04-27 server move re-pulled the rewritten image from Docker Hub. The data directory has been auto-upgraded to PG 18 format, so **reverting to the original PG 15 content is destructive** (would require pg_upgrade or restore-from-backup).

This PR pins the digest in ``values.yaml`` so the runtime is locked. A future containerd cache eviction or another upstream tag rewrite can't silently shift PG version again. **Non-destructive**: matches what the cluster is already running.

## Verification

Verified before opening this PR:
- ``kubectl describe pod benger-postgresql-0 -n benger | grep "Image ID:"`` returns ``sha256:e6d86d16516120a3a7a56268c663c8158cdffb77278f44c7adfd4cf8980810f2`` — matches the pin.
- ``helm get values benger -n benger`` confirms the prod release uses this chart's ``values.yaml``, so this change flows to prod via the next deploy.

## Already mitigated downstream

Knock-on issues from the rewrite were fixed earlier today:
- ``func.md5()`` → ``func.hashtext()`` in tasks.py routers (PR #10).
- ``pg_dump:18-alpine`` in backup CronJob (PR #12).

## Test plan
- [ ] Apply on staging first via the next CI deploy. ``kubectl describe pod benger-postgresql-0 -n benger-staging | grep "Image ID:"`` shows the same pinned digest.
- [ ] No pod restart needed — Helm sees the digest matches what's running.
- [ ] Smoke: existing API/workers behavior unchanged.

## Out of scope
- Migrating off PG 18 / FIPS / Photon. Tracked separately as a planned PG-version-review workstream.