### PR TITLE
test(auth): align duplicate orgManager test with PR #15 contract

### DIFF
--- a/services/frontend/src/__tests__/auth/organizationManager.test.ts
+++ b/services/frontend/src/__tests__/auth/organizationManager.test.ts
@@ -61,10 +61,12 @@ describe('OrganizationManager', () => {
       expect(orgManager.getOrganizations()).toEqual(mockOrgs)
     })
 
-    it('should auto-select first organization if none selected', () => {
+    it('does not auto-select after setOrganizations (caller picks)', () => {
       orgManager.setOrganizations(mockOrgs)
 
-      expect(orgManager.getCurrentOrganization()).toEqual(mockOrgs[0])
+      // PR #15: setOrganizations no longer silently picks the first org —
+      // AuthContext is the source of truth and decides private vs. picked.
+      expect(orgManager.getCurrentOrganization()).toBeNull()
     })
 
     it('should not change current organization if already selected', () => {
@@ -106,7 +108,8 @@ describe('OrganizationManager', () => {
       expect(mockApiClient.getOrganizations).toHaveBeenCalled()
       expect(result).toEqual(mockOrgs)
       expect(orgManager.getOrganizations()).toEqual(mockOrgs)
-      expect(orgManager.getCurrentOrganization()).toEqual(mockOrgs[0])
+      // PR #15: fetchOrganizations populates the list but does not auto-pick.
+      expect(orgManager.getCurrentOrganization()).toBeNull()
     })
 
     it('should handle fetch error gracefully', async () => {


### PR DESCRIPTION
PR #15 updated the canonical orgManager test (``src/lib/auth/__tests__/organizationManager.test.ts``) to encode the no-auto-pick contract, but a duplicate suite at ``src/__tests__/auth/organizationManager.test.ts`` kept the old assertions and broke main's CI (post-merge run #25068344270).

This flips the two stale assertions to match:
- ``setOrganizations`` test: ``getCurrentOrganization()`` is now ``null`` (was ``mockOrgs[0]``).
- ``fetchOrganizations`` test: same.

Unblocks all open PRs (#16 Postgres pin, plus pending #6 cross-repo extended).