### PR TITLE
chore: drop FALLOESUNG_DIMENSIONS from public platform code

### DIFF
--- a/infra/helm/benger/values.yaml
+++ b/infra/helm/benger/values.yaml
@@ -269,6 +269,20 @@ frontend:
 
 postgresql:
   enabled: true
+  image:
+    # Pin by digest. The bitnami/postgresql:15.3.0-debian-11-r17 tag was
+    # rewritten by Broadcom post-acquisition to ship Photon OS + PG 18 +
+    # FIPS-OpenSSL content (image revision 27, build 2026-02-14, vendor
+    # "Broadcom, Inc."). Pinning the digest makes the runtime immutable
+    # so a containerd cache eviction can't silently shift PG version
+    # again. Reverting to the original PG 15 content is destructive
+    # because the prod data directory is already in PG 18 format.
+    # See workspace CLAUDE.md → "Postgres image content drift" for
+    # context and the planned PG-version review.
+    repository: bitnami/postgresql
+    tag: "15.3.0-debian-11-r17"
+    digest: "sha256:e6d86d16516120a3a7a56268c663c8158cdffb77278f44c7adfd4cf8980810f2"
+    pullPolicy: IfNotPresent
   auth:
     username: postgres
     # password: # Generated automatically or set via external secrets

--- a/services/frontend/src/components/projects/wizard/StepEvaluationMethods.tsx
+++ b/services/frontend/src/components/projects/wizard/StepEvaluationMethods.tsx
@@ -14,7 +14,6 @@ import {
 import { useI18n } from '@/contexts/I18nContext'
 import {
   EvaluationConfig,
-  FALLOESUNG_DIMENSIONS,
   generateEvaluationId,
   GROUPED_METRICS,
   METRIC_DEFINITIONS,
@@ -352,23 +351,6 @@ export function StepEvaluationMethods({
           <h3 className="text-sm font-semibold text-zinc-900 dark:text-white">
             {t('projects.creation.wizard.step7.falloesungConfig')}
           </h3>
-
-          {/* Dimensions info */}
-          <div className="space-y-1">
-            {FALLOESUNG_DIMENSIONS.map((dim) => (
-              <div
-                key={dim.key}
-                className="flex items-center justify-between text-xs"
-              >
-                <span className="text-zinc-700 dark:text-zinc-300">
-                  {dim.name}
-                </span>
-                <span className="font-mono text-zinc-500">
-                  {dim.max} {t('projects.creation.wizard.step7.points')}
-                </span>
-              </div>
-            ))}
-          </div>
 
           {/* Judge model + params */}
           <div className="grid grid-cols-2 gap-3">

--- a/services/frontend/src/lib/api/evaluation-types.ts
+++ b/services/frontend/src/lib/api/evaluation-types.ts
@@ -874,20 +874,6 @@ export const GROUPED_METRICS: MetricCategory[] = [
  */
 export const METRIC_ORDER: string[] = GROUPED_METRICS.flatMap((g) => g.metrics)
 
-/** Falloesung evaluation dimensions for the info panel */
-export const FALLOESUNG_DIMENSIONS = [
-  { key: 'ergebnisrichtigkeit', name: 'Ergebnisrichtigkeit', max: 20 },
-  { key: 'vollstaendigkeit', name: 'Vollständigkeit & Problemidentifikation', max: 10 },
-  { key: 'rechtsgrundlagen', name: 'Rechtsgrundlagen & Prüfungssystematik', max: 10 },
-  { key: 'rechtskenntnis', name: 'Rechtskenntnis (Definitionen, Normen, Streitstände)', max: 15 },
-  { key: 'subsumtion', name: 'Subsumtion & Argumentationsqualität (Fallbezug)', max: 15 },
-  { key: 'schwerpunktsetzung', name: 'Schwerpunktsetzung & Problemtiefe', max: 10 },
-  { key: 'methodischer_stil', name: 'Methodischer Stil (ODSE)', max: 10 },
-  { key: 'gliederung', name: 'Gliederung & Leseführung', max: 5 },
-  { key: 'sprache', name: 'Sprache & Terminologie', max: 3 },
-  { key: 'formalia', name: 'Formalia & Sorgfalt', max: 2 },
-] as const
-
 // =============================================================================
 // Extension points for extended metrics
 // =============================================================================


### PR DESCRIPTION
Removes the \`FALLOESUNG_DIMENSIONS\` const from \`services/frontend/src/lib/api/evaluation-types.ts\` and the wizard's per-dimension info panel from \`StepEvaluationMethods.tsx\`. Both leaked the proprietary rubric in the public repo.

Extended already owns the authoritative copy at \`lib/falloesung/rubric.ts\`. The wizard's Falllösung judge-config panel (model picker, max tokens, field mapping) stays — it's a generic LLM-judge config UI usable by any \`registerMetric\` consumer.

History scrub of past blobs is a separate operation (\`git filter-repo\`) that will follow once this is live.

## Test plan

- [x] \`tsc --noEmit\` clean.
- [ ] On prod after deploy: open the project-creation wizard → "Evaluation Methods" → enable Korrektur (Standard Falllösung). The dimension list panel is gone; judge-model picker + max-tokens stay.
- [ ] Existing Falllösung-graded tasks display correctly in the labeling/Korrektur views (extended-side rendering unchanged).