### PR TITLE
fix(infra): remove broken postgres digest pin (PR #16 hotfix)

### DIFF
--- a/infra/helm/benger/values.yaml
+++ b/infra/helm/benger/values.yaml
@@ -270,18 +270,22 @@ frontend:
 postgresql:
   enabled: true
   image:
-    # Pin by digest. The bitnami/postgresql:15.3.0-debian-11-r17 tag was
-    # rewritten by Broadcom post-acquisition to ship Photon OS + PG 18 +
-    # FIPS-OpenSSL content (image revision 27, build 2026-02-14, vendor
-    # "Broadcom, Inc."). Pinning the digest makes the runtime immutable
-    # so a containerd cache eviction can't silently shift PG version
-    # again. Reverting to the original PG 15 content is destructive
-    # because the prod data directory is already in PG 18 format.
-    # See workspace CLAUDE.md → "Postgres image content drift" for
-    # context and the planned PG-version review.
+    # NOTE: the bitnami/postgresql:15.3.0-debian-11-r17 tag was rewritten by
+    # Broadcom post-acquisition to ship Photon OS + PG 18 + FIPS-OpenSSL
+    # under the same label. The cluster's data dir is already in PG 18
+    # format, so reverting to the original PG 15 content is destructive.
+    # See workspace CLAUDE.md → "Postgres image content drift".
+    #
+    # Earlier attempt to pin by digest (PR #16, sha256:e6d86d16…) used a
+    # digest that does not exist on Docker Hub and put prod into
+    # ImagePullBackOff. Until we either (a) discover a valid digest for
+    # the rewritten image, or (b) migrate to bitnamilegacy/postgresql
+    # explicitly, leave the tag floating — it resolves to whatever
+    # Broadcom currently ships under this label, which is the
+    # PG-18+FIPS variant we've already mitigated for in app code
+    # (func.hashtext + pg_dump 18-alpine).
     repository: bitnami/postgresql
     tag: "15.3.0-debian-11-r17"
-    digest: "sha256:e6d86d16516120a3a7a56268c663c8158cdffb77278f44c7adfd4cf8980810f2"
     pullPolicy: IfNotPresent
   auth:
     username: postgres


### PR DESCRIPTION
PR #16 pinned bitnami/postgresql to a digest (\`sha256:e6d86d16…\`) that **does not exist on Docker Hub**. The pull failed with "unexpected media type application/octet-stream" → \`ImagePullBackOff\` for ~40 minutes → auth/login 500-ed prod-wide because the api couldn't connect to the DB.

Hot-fix already applied live via:

\`\`\`
kubectl -n benger set image statefulset/benger-postgresql \\
  postgresql=docker.io/bitnami/postgresql:15.3.0-debian-11-r17
kubectl -n benger delete pod benger-postgresql-0   # force restart
\`\`\`

Pod is now \`Running\` on the floating tag — the Broadcom-rewritten PG-18+FIPS variant the cluster was already running pre-#16, with the \`func.md5→hashtext\` (PR #10) and \`pg_dump 18-alpine\` (PR #12) mitigations already in place.

This commit removes the bad digest from \`values.yaml\` so the next helm reconcile doesn't re-pin to the broken SHA. The comment block now documents what to do before re-attempting a digest pin (find a valid digest, or migrate to \`bitnamilegacy/postgresql\`).

## Test plan

- [x] Live verified: prod login as SebaN succeeds, dashboard loads.
- [ ] Next deploy doesn't re-introduce the digest pin (this PR).