### PR TITLE
fix(tailwind): correct content path for extended frontend

### DIFF
--- a/services/frontend/tailwind.config.js
+++ b/services/frontend/tailwind.config.js
@@ -4,13 +4,15 @@ module.exports = {
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
-    // Extended-edition components are mounted into the build via Docker
-    // (next.config.js maps `@benger/extended` to either
-    // `/app/node_modules/@benger/extended` in CI builds or
-    // `/app/benger-extended-frontend` in dev). Without these globs the
-    // JIT silently drops any Tailwind class only referenced by extended
-    // (e.g. `w-[96vw]` on the Klausurlösung modals → half-width modal).
-    './node_modules/@benger/extended/**/*.{js,ts,jsx,tsx,mdx}',
+    // Extended-edition components are mounted into the build via the
+    // extended cicd workflow (`cp -r extended/frontend
+    // platform/services/frontend/benger-extended-frontend`), so at
+    // `next build` time they live at this path inside the Docker
+    // build context. Without this glob the JIT silently drops any
+    // Tailwind class only referenced by extended (e.g. `w-[96vw]`
+    // on the Klausurlösung modals → half-width modal).
+    './benger-extended-frontend/**/*.{js,ts,jsx,tsx,mdx}',
+    // For local sibling-checkout development:
     '../../benger-extended/frontend/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   darkMode: ['class'],


### PR DESCRIPTION
PR #21 added `./node_modules/@benger/extended/**` but the extended cicd workflow stages files at `./benger-extended-frontend/` inside the frontend build context (`cp -r extended/frontend platform/services/frontend/benger-extended-frontend`). The wrong glob → JIT still misses `w-[96vw]` etc. → Klausurlösung modals still render at ~57% width on prod.

This PR fixes the path. Local-dev sibling-checkout glob kept as fallback.