### PR TITLE
fix(variant): bucket conditional instructions per (user, project), not per (user, task)

### DIFF
--- a/services/frontend/src/components/labeling/LabelingInterface.tsx
+++ b/services/frontend/src/components/labeling/LabelingInterface.tsx
@@ -356,19 +356,23 @@ export function LabelingInterface({ projectId }: LabelingInterfaceProps) {
     }
   }, [allTasksCompleted, projectId, router, resetAnnotationCompletion, TASK_POSITION_KEY, TASK_ID_KEY])
 
-  // Compute conditional instruction variant when task changes
+  // Compute conditional-instruction variant for this user. Bucket on
+  // (user, project) — NOT on task — so the assignment is stable for the
+  // whole project. Per-task bucketing would re-roll on every task and
+  // break the A/B experiment design (each user is expected to stay in
+  // exactly one cohort across all tasks).
   useEffect(() => {
-    if (!user?.id || !currentTask?.id || !currentProject?.conditional_instructions?.length) {
+    if (!user?.id || !currentProject?.id || !currentProject?.conditional_instructions?.length) {
       setSelectedVariantId(null)
       return
     }
     const variantId = selectVariant(
       user.id,
-      currentTask.id,
+      currentProject.id,
       currentProject.conditional_instructions as { id: string; weight: number }[]
     )
     setSelectedVariantId(variantId)
-  }, [user?.id, currentTask?.id, currentProject?.conditional_instructions])
+  }, [user?.id, currentProject?.id, currentProject?.conditional_instructions])
 
   // Show instructions modal on first load if enabled and not dismissed
   useEffect(() => {


### PR DESCRIPTION
selectVariant() was being called with currentTask.id, so each task re-rolled the variant assignment. For A/B-instruction experiments, every user should stay in exactly one cohort across all tasks of the project; per-task bucketing breaks that design.

Switch the bucketing key to currentProject.id. Same user + same project → same variant forever, persisting across page reloads, task navigation, and re-logins. djb2 hash + weighted selection unchanged.

Existing annotations keep whatever instruction_variant was stored at submit time — no historical data mutated.