### PR TITLE
fix(labeling): initial strict-timer phase = 'loading' to prevent premature start-timer

### DIFF
--- a/services/frontend/src/components/labeling/LabelingInterface.tsx
+++ b/services/frontend/src/components/labeling/LabelingInterface.tsx
@@ -99,7 +99,12 @@ export function LabelingInterface({ projectId }: LabelingInterfaceProps) {
   // returns below are gated on isStrictMode anyway, which requires both
   // strict_timer_enabled and annotation_time_limit_enabled — both extended).
   type StrictTimerPhase = 'loading' | 'pre_start' | 'annotating' | 'time_over'
-  const [strictTimerPhase, setStrictTimerPhase] = useState<StrictTimerPhase>('annotating')
+  // Start in 'loading' so TimerSlot doesn't briefly mount and fire a
+  // premature POST /start-timer before the init useEffect can route the
+  // user to pre_start. The init effect always resolves this to one of
+  // pre_start | annotating | time_over (or stays 'annotating' on error /
+  // community edition).
+  const [strictTimerPhase, setStrictTimerPhase] = useState<StrictTimerPhase>('loading')
   const pendingTimeOverRef = useRef(false)
   const isStrictMode = !!(
     currentProject?.strict_timer_enabled && currentProject?.annotation_time_limit_enabled


### PR DESCRIPTION
## Summary

Follow-up to PR #26. When the initial \`strictTimerPhase\` was \`'annotating'\`, the TimerSlot mounted briefly on first render and fired POST \`/start-timer\` before the init useEffect could route the user to pre_start. The session got created with the wrong \`started_at\`, so the user lost a few seconds before they even saw the Start button.

Initial phase = \`'loading'\` keeps TimerSlot unmounted in strict mode until the init useEffect resolves the phase. Verified locally on prod that pre_start now shows cleanly with no premature POST in the network panel.

## Test plan

- [ ] Skip to a fresh task on benchathon → pre_start shows, no POST /start-timer until Start clicked
- [ ] Click Start → POST /start-timer fires, pre_start dismissed, timer pill appears