### PR TITLE
fix(labeling): gate TimerSlot strictly on phase==='annotating'

### DIFF
--- a/services/frontend/src/components/labeling/LabelingInterface.tsx
+++ b/services/frontend/src/components/labeling/LabelingInterface.tsx
@@ -785,7 +785,7 @@ export function LabelingInterface({ projectId }: LabelingInterfaceProps) {
               )}
               {TimerSlot &&
               currentProject?.annotation_time_limit_enabled &&
-              (!isStrictMode || strictTimerPhase === 'annotating') ? (
+              strictTimerPhase === 'annotating' ? (
                 <TimerSlot
                   project={currentProject}
                   task={currentTask}


### PR DESCRIPTION
Follow-up to PRs #26 and #27. The previous gate `(!isStrictMode || phase==='annotating')` allowed TimerSlot to mount during the brief loading window where `currentProject` was null (so `isStrictMode` was false). TimerSlot fired POST /start-timer prematurely, creating the session before the user saw pre_start.

Tightening the gate to `phase === 'annotating'` alone. The init useEffect resolves to 'annotating' for all valid non-strict cases, so non-strict timer projects are unaffected.