### PR TITLE
fix(i18n): add missing strictTimer.* locale keys

### DIFF
--- a/services/frontend/src/locales/de/common.json
+++ b/services/frontend/src/locales/de/common.json
@@ -6129,6 +6129,16 @@
       "expired": "Zeit abgelaufen",
       "expiredToast": "Zeitlimit erreicht"
     },
+    "strictTimer": {
+      "readyTitle": "Bereit zu beginnen",
+      "readyDescription": "Sie haben {minutes} Minuten Zeit, um diese Annotation abzuschließen. Der Timer startet, wenn Sie auf Start klicken, und kann nicht pausiert oder neu gestartet werden.",
+      "readyWarning": "Ein Neuladen der Seite setzt den Timer nicht zurück.",
+      "startButton": "Starten",
+      "startError": "Timer konnte nicht gestartet werden",
+      "timeOverTitle": "Zeit abgelaufen",
+      "timeOverDescription": "Ihre Zeit ist abgelaufen. Ihre Arbeit wurde in der zuletzt gespeicherten Form abgesendet.",
+      "continueButton": "Weiter"
+    },
     "questionnaire": {
       "title": "Post-Annotations-Feedback",
       "description": "Bitte geben Sie Feedback zur soeben abgeschlossenen Annotation.",

--- a/services/frontend/src/locales/en/common.json
+++ b/services/frontend/src/locales/en/common.json
@@ -6149,6 +6149,16 @@
       "expired": "Time expired",
       "expiredToast": "Time limit reached"
     },
+    "strictTimer": {
+      "readyTitle": "Ready to Begin",
+      "readyDescription": "You will have {minutes} minutes to complete this annotation. The timer starts when you click Start and cannot be paused or restarted.",
+      "readyWarning": "Page refresh will not reset the timer.",
+      "startButton": "Start",
+      "startError": "Failed to start timer",
+      "timeOverTitle": "Time's Up",
+      "timeOverDescription": "Your time is over. Your work so far has been submitted in its latest form.",
+      "continueButton": "Continue"
+    },
     "questionnaire": {
       "title": "Post-Annotation Feedback",
       "description": "Please provide feedback on the annotation you just completed.",


### PR DESCRIPTION
Follow-up to PR #26. The i18n config returns raw keys when missing (defaultValue fallback isn't honored), so pre_start and time_over rendered raw key strings. Adds DE + EN translations.