### PR TITLE
fix(leaderboards+eval): plain-button tabs, aggregated metric dropdown, pseudonymized annotators

### DIFF
--- a/services/api/routers/evaluations/results.py
+++ b/services/api/routers/evaluations/results.py
@@ -755,12 +755,29 @@ async def get_results_by_task_model(
             annotation_ids = list(set(r.annotation_id for r in annotation_eval_results if r.annotation_id))
             if annotation_ids:
                 annotations_with_users = (
-                    db.query(Annotation.id, DBUser.username)
+                    db.query(
+                        Annotation.id,
+                        DBUser.username,
+                        DBUser.name,
+                        DBUser.pseudonym,
+                        DBUser.use_pseudonym,
+                    )
                     .join(DBUser, Annotation.completed_by == DBUser.id)
                     .filter(Annotation.id.in_(annotation_ids))
                     .all()
                 )
-                annotator_name_map = {a.id: a.username for a in annotations_with_users}
+                # Mirror the leaderboard's pseudonym resolution
+                # (benger_extended/api/routers/leaderboards_human.py:168) so
+                # annotators with use_pseudonym=true display under their
+                # pseudonym instead of their real name/username.
+                annotator_name_map = {
+                    a.id: (
+                        a.pseudonym
+                        if (a.use_pseudonym and a.pseudonym)
+                        else (a.name or a.username)
+                    )
+                    for a in annotations_with_users
+                }
 
                 # Deduplicate: keep latest per (task_id, annotation_id, field_name)
                 seen_task_annotations: dict = {}
@@ -768,15 +785,15 @@ async def get_results_by_task_model(
                     seen_task_annotations[(r.task_id, r.annotation_id, r.field_name)] = r
 
                 for r in seen_task_annotations.values():
-                    username = annotator_name_map.get(r.annotation_id, "Unknown")
-                    synthetic_model_id = f"annotator:{username}"
+                    display = annotator_name_map.get(r.annotation_id, "Unknown")
+                    synthetic_model_id = f"annotator:{display}"
                     score = _extract_primary_score(r.metrics)
 
                     if score is not None:
                         if synthetic_model_id not in model_scores_list:
                             model_scores_list[synthetic_model_id] = []
                             model_ids.append(synthetic_model_id)
-                        model_name_map[synthetic_model_id] = f"Annotator: {username}"
+                        model_name_map[synthetic_model_id] = f"Annotator: {display}"
 
                         if r.task_id not in task_model_scores:
                             task_model_scores[r.task_id] = {}
@@ -1053,12 +1070,27 @@ async def get_project_results_by_task_model(
             annotation_ids = list(set(r.annotation_id for r in annotation_eval_results if r.annotation_id))
             if annotation_ids:
                 annotations_with_users = (
-                    db.query(Annotation.id, DBUser.username)
+                    db.query(
+                        Annotation.id,
+                        DBUser.username,
+                        DBUser.name,
+                        DBUser.pseudonym,
+                        DBUser.use_pseudonym,
+                    )
                     .join(DBUser, Annotation.completed_by == DBUser.id)
                     .filter(Annotation.id.in_(annotation_ids))
                     .all()
                 )
-                annotator_name_map = {a.id: a.username for a in annotations_with_users}
+                # Mirror the leaderboard pseudonym resolution so users with
+                # use_pseudonym=true display under their pseudonym.
+                annotator_name_map = {
+                    a.id: (
+                        a.pseudonym
+                        if (a.use_pseudonym and a.pseudonym)
+                        else (a.name or a.username)
+                    )
+                    for a in annotations_with_users
+                }
 
                 # Deduplicate: keep latest per (task_id, annotation_id, field_name)
                 seen_task_annotations: dict = {}
@@ -1066,15 +1098,15 @@ async def get_project_results_by_task_model(
                     seen_task_annotations[(r.task_id, r.annotation_id, r.field_name)] = r
 
                 for r in seen_task_annotations.values():
-                    username = annotator_name_map.get(r.annotation_id, "Unknown")
-                    synthetic_model_id = f"annotator:{username}"
+                    display = annotator_name_map.get(r.annotation_id, "Unknown")
+                    synthetic_model_id = f"annotator:{display}"
                     score = _extract_primary_score(r.metrics)
 
                     if score is not None:
                         if synthetic_model_id not in model_scores:
                             model_scores[synthetic_model_id] = []
                             model_ids.append(synthetic_model_id)
-                        model_name_map[synthetic_model_id] = f"Annotator: {username}"
+                        model_name_map[synthetic_model_id] = f"Annotator: {display}"
 
                         if r.task_id not in task_scores:
                             task_scores[r.task_id] = {}

--- a/services/frontend/src/app/leaderboards/page.tsx
+++ b/services/frontend/src/app/leaderboards/page.tsx
@@ -6,13 +6,9 @@ import { Breadcrumb } from '@/components/shared/Breadcrumb'
 import { ResponsiveContainer } from '@/components/shared/ResponsiveContainer'
 import { useI18n } from '@/contexts/I18nContext'
 import { useSlot } from '@/lib/extensions/slots'
-import {
-  CpuChipIcon,
-  UserGroupIcon,
-  SparklesIcon,
-} from '@heroicons/react/24/outline'
-import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react'
-import { Suspense } from 'react'
+import { Suspense, useState } from 'react'
+
+type LeaderboardTab = 'human' | 'co-creation' | 'llm'
 
 function LeaderboardsContent() {
   const { t } = useI18n()
@@ -20,7 +16,18 @@ function LeaderboardsContent() {
   const AnnotatorLeaderboardTab = useSlot('AnnotatorLeaderboardTab')
   const CoCreationLeaderboardTab = useSlot('CoCreationLeaderboardTab')
 
-  const hasTabs = AnnotatorLeaderboardTab || CoCreationLeaderboardTab
+  // Default to 'human' to match the old monolith. Falls back to 'llm' in
+  // community edition where the human/co-creation slots aren't registered.
+  const [activeTab, setActiveTab] = useState<LeaderboardTab>(
+    AnnotatorLeaderboardTab ? 'human' : 'llm'
+  )
+
+  const tabClass = (tab: LeaderboardTab) =>
+    `border-b-2 py-3 text-sm font-medium transition ${
+      activeTab === tab
+        ? 'border-emerald-500 text-emerald-600 dark:text-emerald-400'
+        : 'border-transparent text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300'
+    }`
 
   return (
     <ResponsiveContainer size="xl" className="pb-10 pt-8">
@@ -44,68 +51,28 @@ function LeaderboardsContent() {
           {t('leaderboards.title') || 'Leaderboards'}
         </h1>
 
-        {hasTabs ? (
-          <TabGroup>
-            <div className="border-b border-zinc-200 dark:border-zinc-700">
-              <TabList className="-mb-px flex space-x-8">
-                <Tab
-                  className={({ selected }) =>
-                    `flex items-center gap-2 border-b-2 py-3 text-sm font-medium transition ${
-                      selected
-                        ? 'border-emerald-500 text-emerald-600 dark:text-emerald-400'
-                        : 'border-transparent text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300'
-                    }`
-                  }
-                >
-                  <CpuChipIcon className="h-5 w-5" />
-                  {t('leaderboards.llms') || 'LLMs'}
-                </Tab>
-                {AnnotatorLeaderboardTab && (
-                  <Tab
-                    className={({ selected }) =>
-                      `flex items-center gap-2 border-b-2 py-3 text-sm font-medium transition ${
-                        selected
-                          ? 'border-emerald-500 text-emerald-600 dark:text-emerald-400'
-                          : 'border-transparent text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300'
-                      }`
-                    }
-                  >
-                    <UserGroupIcon className="h-5 w-5" />
-                    {t('leaderboards.humanAnnotators') || 'Human Annotators'}
-                  </Tab>
-                )}
-                {CoCreationLeaderboardTab && (
-                  <Tab
-                    className={({ selected }) =>
-                      `flex items-center gap-2 border-b-2 py-3 text-sm font-medium transition ${
-                        selected
-                          ? 'border-emerald-500 text-emerald-600 dark:text-emerald-400'
-                          : 'border-transparent text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300'
-                      }`
-                    }
-                  >
-                    <SparklesIcon className="h-5 w-5" />
-                    {t('leaderboards.coCreation') || 'Co-Creation'}
-                  </Tab>
-                )}
-              </TabList>
-            </div>
-            <TabPanels className="mt-6">
-              <TabPanel>
-                <LLMLeaderboardTable />
-              </TabPanel>
-              {AnnotatorLeaderboardTab && (
-                <TabPanel>
-                  <AnnotatorLeaderboardTab />
-                </TabPanel>
-              )}
-              {CoCreationLeaderboardTab && (
-                <TabPanel>
-                  <CoCreationLeaderboardTab />
-                </TabPanel>
-              )}
-            </TabPanels>
-          </TabGroup>
+        <div className="mb-6 border-b border-zinc-200 dark:border-zinc-700">
+          <nav className="-mb-px flex space-x-8">
+            {AnnotatorLeaderboardTab && (
+              <button onClick={() => setActiveTab('human')} className={tabClass('human')}>
+                {t('leaderboards.humanAnnotators') || 'Human Annotators'}
+              </button>
+            )}
+            {CoCreationLeaderboardTab && (
+              <button onClick={() => setActiveTab('co-creation')} className={tabClass('co-creation')}>
+                {t('leaderboards.coCreation') || 'Co-Creation'}
+              </button>
+            )}
+            <button onClick={() => setActiveTab('llm')} className={tabClass('llm')}>
+              {t('leaderboards.llms') || 'LLMs'}
+            </button>
+          </nav>
+        </div>
+
+        {activeTab === 'human' && AnnotatorLeaderboardTab ? (
+          <AnnotatorLeaderboardTab />
+        ) : activeTab === 'co-creation' && CoCreationLeaderboardTab ? (
+          <CoCreationLeaderboardTab />
         ) : (
           <LLMLeaderboardTable />
         )}

--- a/services/frontend/src/components/evaluation/EvaluationResults.tsx
+++ b/services/frontend/src/components/evaluation/EvaluationResults.tsx
@@ -185,25 +185,55 @@ export function EvaluationResults({
   const [exportDropdownOpen, setExportDropdownOpen] = useState(false)
   const exportDropdownRef = useRef<HTMLDivElement>(null)
 
-  // Available completed metric runs (one per metric, filtered by top-level selectedMetrics)
-  // Sorted by the evaluation config order from the project page wizard
+  // Available metric methods — one entry per evaluation method (NOT per
+  // EvaluationRun). Multiple runs of the same metric (e.g. dozens of
+  // immediate-eval submissions) collapse into a single dropdown entry.
+  // Selecting a method passes ALL matching run IDs to the by-task-model
+  // endpoint, which already deduplicates to the latest result per
+  // (generation_id, field_name) via row_number() OVER ... — so the user
+  // sees the most recent score per cell across the entire metric history.
+  // Sorted by the evaluation config order from the project page wizard.
   const availableMetricRuns = useMemo(() => {
     if (!results?.evaluations) return []
-    const runs = results.evaluations
+
+    const completed = results.evaluations
       .filter((e) => e.status === 'completed')
       .filter((e) => {
         if (!selectedMetrics || selectedMetrics.length === 0) return true
         return e.evaluation_configs?.some((c: any) => selectedMetrics.includes(c.metric))
       })
-      .map((e) => ({
-        id: e.evaluation_id,
-        metric: e.evaluation_configs?.[0]?.metric || 'unknown',
-        configId: e.evaluation_configs?.[0]?.id || '',
-        displayName: e.evaluation_configs?.[0]?.display_name || e.evaluation_configs?.[0]?.metric || 'Unknown',
-        samplesEvaluated: e.samples_evaluated,
-      }))
+
+    type MetricEntry = {
+      id: string             // metric key (e.g. "llm_judge_falloesung")
+      metric: string         // same as id
+      configId: string
+      displayName: string
+      samplesEvaluated: number
+      runIds: string[]
+    }
+
+    const byMetric = new Map<string, MetricEntry>()
+    for (const e of completed) {
+      const cfg = e.evaluation_configs?.[0]
+      const metric = cfg?.metric || 'unknown'
+      const existing = byMetric.get(metric)
+      if (existing) {
+        existing.runIds.push(e.evaluation_id)
+        existing.samplesEvaluated = Math.max(existing.samplesEvaluated, e.samples_evaluated || 0)
+      } else {
+        byMetric.set(metric, {
+          id: metric,
+          metric,
+          configId: cfg?.id || '',
+          displayName: cfg?.display_name || metric || 'Unknown',
+          samplesEvaluated: e.samples_evaluated || 0,
+          runIds: [e.evaluation_id],
+        })
+      }
+    }
 
     // Sort by GROUPED_METRICS order (same order as the evaluation wizard)
+    const runs = Array.from(byMetric.values())
     const orderMap = new Map(METRIC_ORDER.map((m, i) => [m, i]))
     runs.sort((a, b) => {
       const orderA = orderMap.get(a.metric) ?? 999
@@ -502,7 +532,16 @@ export function EvaluationResults({
     }
   }, [results, fetchResults])
 
-  // Fetch per-task/model data — filtered by selected metric run
+  // Fetch per-task/model data — filtered by ALL EvaluationRun IDs that
+  // belong to the selected metric. The backend's row_number() OVER
+  // (PARTITION BY generation_id, field_name ORDER BY created_at DESC)
+  // collapses overlapping runs to the latest score per cell, so passing
+  // every run for the metric is the safe aggregation primitive.
+  const selectedRunIds = useMemo(() => {
+    if (!selectedMetricRunId) return undefined
+    return availableMetricRuns.find(r => r.id === selectedMetricRunId)?.runIds
+  }, [selectedMetricRunId, availableMetricRuns])
+
   useEffect(() => {
     const fetchTaskModelData = async () => {
       if (!projectId) {
@@ -512,10 +551,9 @@ export function EvaluationResults({
 
       setTaskModelLoading(true)
       try {
-        const evalIds = selectedMetricRunId ? [selectedMetricRunId] : undefined
         const data = await apiClient.getProjectResultsByTaskModel(
           String(projectId),
-          evalIds
+          selectedRunIds
         )
         setTaskModelData(data)
       } catch (err) {
@@ -527,7 +565,7 @@ export function EvaluationResults({
     }
 
     fetchTaskModelData()
-  }, [results, projectId, selectedMetricRunId])
+  }, [results, projectId, selectedRunIds])
 
   const handleRefresh = () => {
     setLoading(true)


### PR DESCRIPTION
Three regressions:

1. Leaderboards page reverted from Headless UI TabGroup with icons back to old plain-button strip in old order (Human / Co-Creation / LLM, Human default).
2. Eval dropdown collapses by metric — one entry per evaluation method instead of one per EvaluationRun. The backend's row_number() ranking on /results/by-task-model already returns the latest score per (generation, field) when given multiple eval IDs, so aggregation is well-defined.
3. Eval-results annotator columns now resolve via User.pseudonym when use_pseudonym is set (mirroring the leaderboard endpoint). Long-standing bug present in BenGer_old too — fixing forward.

## Test plan
- [ ] /leaderboards: three plain text tabs, Human active by default, no icons
- [ ] /evaluations dropdown: exactly one entry per method (Standard Falllösung / ROUGE / Korrektur), no duplicates
- [ ] /evaluations annotator columns: pseudonyms display for users with use_pseudonym=true
