### PR TITLE
fix(catalog): bump gpt-5.5-pro & gpt-5.4-pro max_tokens to 32k

### DIFF
--- a/services/shared/seeds/llm_models.yaml
+++ b/services/shared/seeds/llm_models.yaml
@@ -43,8 +43,13 @@ models:
         supported: false
         required_value: 1.0
         reason: OpenAI GPT-5 series enforces temperature=1.0 via API
+      # Pro reasoning tiers consume reasoning tokens against
+      # max_output_tokens; 8000 left zero room for visible text on a
+      # complex Sachverhalt (observed 2026-05-08: completion_tokens=8000,
+      # finish_reason=max_output_tokens, content=""). Matched to o3-pro's
+      # default for parity across Pro reasoning tiers.
       max_tokens:
-        default: 8000
+        default: 32000
       unsupported_params: [top_p, presence_penalty, frequency_penalty, logprobs, top_logprobs, logit_bias]
       reproducibility_impact: CRITICAL
       benchmark_notes: Run multiple iterations (n>=5) and report variance. Results cannot be deterministic.
@@ -53,10 +58,10 @@ models:
     recommended_parameters:
       default:
         temperature: 1.0
-        max_tokens: 8000
+        max_tokens: 32000
       provenance:
-        source: https://community.openai.com/t/temperature-in-gpt-5-models/1337133
-        retrieved: '2026-05-07'
+        source: https://platform.openai.com/docs/guides/reasoning
+        retrieved: '2026-05-08'
   - id: gpt-5
     name: GPT-5
     description: Flagship model with PhD-level intelligence and reasoning
@@ -183,8 +188,11 @@ models:
         supported: false
         required_value: 1.0
         reason: OpenAI GPT-5 series enforces temperature=1.0 via API
+      # See gpt-5.5-pro: Pro reasoning tiers need a much larger token
+      # budget than mini/non-reasoning models. Matched to o3-pro for
+      # parity across the Pro reasoning family.
       max_tokens:
-        default: 8000
+        default: 32000
       unsupported_params: [top_p, presence_penalty, frequency_penalty, logprobs, top_logprobs, logit_bias]
       reproducibility_impact: CRITICAL
       benchmark_notes: Run multiple iterations (n>=5) and report variance. Results cannot be deterministic.
@@ -193,10 +201,10 @@ models:
     recommended_parameters:
       default:
         temperature: 1.0
-        max_tokens: 8000
+        max_tokens: 32000
       provenance:
-        source: https://community.openai.com/t/temperature-in-gpt-5-models/1337133
-        retrieved: '2026-05-07'
+        source: https://platform.openai.com/docs/guides/reasoning
+        retrieved: '2026-05-08'
   - id: gpt-5.2
     name: GPT-5.2
     description: High-performance model with 400K context


### PR DESCRIPTION
## Summary
The `recommended_parameters.default.max_tokens: 8000` for `gpt-5.5-pro` and `gpt-5.4-pro` was wrong for Pro reasoning tiers — observed 2026-05-08: every gpt-5.5-pro call consumed all 8 000 output tokens on hidden reasoning, returning `content=""` and `finish_reason='max_output_tokens'`.

Bumped to **32 000** to match `o3-pro`'s existing default, the peer Pro reasoning tier in the catalog. Both `constraints.max_tokens.default` and `recommended_parameters.default.max_tokens` updated; provenance now points at OpenAI's reasoning-models guide.

Cost note: at \$180/M output, max-cost per call goes from \$1.44 → \$5.76. In return, you actually get the response.

## Test plan
- [ ] CI green (Catalog Drift workflow re-runs with new YAML)
- [ ] Post-deploy: re-trigger one gpt-5.5-pro generation; expect non-empty `output_text` and `completion_tokens` < 32 000 (with reasoning + visible text both populated)