### PR TITLE
fix(eval-cost-estimate): prediction-aware input + judge output cap

### DIFF
--- a/services/api/routers/cost_estimate.py
+++ b/services/api/routers/cost_estimate.py
@@ -23,7 +23,11 @@ from database import get_db
 from models import LLMModel, User
 from project_models import Project
 from routers.projects.helpers import check_project_accessible, get_org_context_from_request
-from services.token_estimation import estimate_tokens_for_calls, sample_task_texts
+from services.token_estimation import (
+    estimate_tokens_for_calls,
+    sample_prediction_inputs,
+    sample_task_texts,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +143,14 @@ def _is_reasoning_model(llm_model_row: LLMModel) -> bool:
 # pretending every call hits the cap exactly.
 _REASONING_OUTPUT_UTILIZATION = 0.9
 _DEFAULT_OUTPUT_UTILIZATION = 0.6
+
+# LLM judges output a structured score + short reasoning — typically
+# 500-2000 tokens regardless of how high max_tokens is configured. Using
+# the generation utilization (0.6 × 16K = 9.6K) over-counts the output
+# bill by ~5× for a judge call. We pick 0.15 because typical judge
+# `max_tokens` is 8K-16K and 0.15 × that = 1.2K-2.4K, the realistic band
+# for a GPT-5-family judge producing JSON-shaped scoring + rationale.
+_EVAL_OUTPUT_UTILIZATION = 0.15
 
 
 def _count_evaluation_judge_calls(
@@ -293,15 +305,27 @@ def estimate_cost(
     if not target_models:
         raise HTTPException(status_code=400, detail="model_ids required (or judge_models for evaluation)")
 
-    # Sample task texts for prompt-length estimation. For evaluation we use
-    # the same texts; the actual evaluation prompt wraps prediction +
-    # reference but the order of magnitude is similar.
-    sample_texts = sample_task_texts(
-        db=db,
-        project_id=request.project_id,
-        sample_size=request.task_sample_size,
-        seed=42,
-    )
+    # Sample texts to estimate input length.
+    # - generation: raw task data (Sachverhalt) is what fills the prompt.
+    # - evaluation: the judge sees `judge_prompt + reference + prediction`
+    #   where the prediction (prior generation output) is by far the
+    #   largest variable component. Sampling raw tasks here under-counts
+    #   eval input tokens by 3-5× on Gutachten-style outputs and
+    #   produces an embarrassingly small dollar figure.
+    if request.mode == "evaluation":
+        sample_texts = sample_prediction_inputs(
+            db=db,
+            project_id=request.project_id,
+            sample_size=request.task_sample_size,
+            seed=42,
+        )
+    else:
+        sample_texts = sample_task_texts(
+            db=db,
+            project_id=request.project_id,
+            sample_size=request.task_sample_size,
+            seed=42,
+        )
     if not sample_texts:
         sample_texts = [""]
 
@@ -331,9 +355,14 @@ def estimate_cost(
         )
         llm_model_row = db.query(LLMModel).filter(LLMModel.id == model_id).first()
         is_reasoning = bool(llm_model_row and _is_reasoning_model(llm_model_row))
-        utilization = (
-            _REASONING_OUTPUT_UTILIZATION if is_reasoning else _DEFAULT_OUTPUT_UTILIZATION
-        )
+        if request.mode == "evaluation":
+            # Judges emit a small structured score + reasoning, not the
+            # full max_tokens budget — see _EVAL_OUTPUT_UTILIZATION.
+            utilization = _EVAL_OUTPUT_UTILIZATION
+        elif is_reasoning:
+            utilization = _REASONING_OUTPUT_UTILIZATION
+        else:
+            utilization = _DEFAULT_OUTPUT_UTILIZATION
 
         # Cell count is per-model and per-mode:
         # - generation: count (task × structure) cells with no recent
@@ -427,13 +456,23 @@ def estimate_cost(
         if request.generation_mode == "missing"
         else " Counting every (task × structure) cell"
     )
+    if request.mode == "evaluation":
+        utilization_note = (
+            " For evaluation, input is sampled from recent generation outputs "
+            "(the prediction the judge sees) and output utilization is 15 % of "
+            "max_tokens — judges emit a short score + rationale, not a full "
+            "completion."
+        )
+    else:
+        utilization_note = (
+            " Output utilization is 90 % of max_tokens for reasoning-tier "
+            "models (Pro/o-series) and 60 % otherwise."
+        )
     note = (
         "Estimate accuracy ± ~20%. Token counts use cl100k_base as a proxy "
-        "for non-OpenAI models. Output utilization is 90% of max_tokens for "
-        "reasoning-tier models (Pro/o-series — hidden reasoning tokens are "
-        "billed as output) and 60% for non-reasoning models. Each model's "
-        "max_tokens is read from selected_configuration.model_configs, "
-        "falling back to the project default." + mode_note + "."
+        "for non-OpenAI models. Each model's max_tokens is read from "
+        "selected_configuration.model_configs, falling back to the project "
+        "default." + utilization_note + mode_note + "."
     )
 
     return CostEstimateResponse(

--- a/services/api/routers/cost_estimate.py
+++ b/services/api/routers/cost_estimate.py
@@ -160,58 +160,234 @@ def _count_evaluation_judge_calls(
     runs_per_call: int,
     generation_mode: Optional[str],
 ) -> int:
-    """Count (task × run_index) judge calls that would actually fire for
-    `judge_model_id`.
+    """Count LLM-judge API calls that would actually fire for
+    ``judge_model_id`` across all the project's enabled LLM-judge configs.
 
-    Each LLM-judge metric records one row per judge invocation in
-    `evaluation_judge_runs` (linked via `evaluation_id` to the
-    `evaluation_runs` row carrying the project + task). For an ensemble
-    of size N, every task fans out into N parallel judge runs at each
-    `run_index`. That's the API-call boundary, so it's also the cost
-    boundary.
+    The project's `evaluation_config.evaluation_configs` lists every
+    metric configured. Only configs whose `metric` starts with
+    `llm_judge_` cost API tokens — deterministic metrics (BERTScore,
+    BLEU, ROUGE, semsim, METEOR, MoverScore, coherence, exact_match)
+    are compute-only.
 
-    - mode in ('all', None): every (task × run_index) is one call.
-    - mode == 'missing': a call counts only when no completed
-      `evaluation_judge_runs` row exists for this (task, judge,
-      run_index). Mirrors the worker's `evaluate_missing_only` decision
-      in services/workers/tasks.py around line 2722, which skips a
-      task once a successful judge run is on file.
+    For each LLM-judge config that names this judge in its
+    `metric_parameters.judges[].judge_model_id`:
 
-    Deterministic metrics (BERTScore/BLEU/exact_match/etc.) do not
-    appear here — they don't go through `evaluation_judge_runs` and
-    incur compute time, not API cost.
+    - Resolve subjects per `prediction_fields` entry:
+        * `__all_model__`         → every completed generation
+        * `__all_human__`         → every annotation
+        * starts with `human:`    → every annotation (the suffix is the
+                                    field inside the annotation, not a
+                                    subject filter)
+        * any other plain string  → the worker auto-evaluates the field
+                                    on BOTH models AND humans (services/
+                                    workers/tasks.py around lines 234,
+                                    3289-3291) — so the cost has to as
+                                    well, otherwise the human-side bill
+                                    is invisible. Returns generations
+                                    AND annotations.
+    - Multiply by `runs` from the judge spec.
+    - For mode='missing', subtract subjects whose `task_evaluations`
+      row is already scored under the matching field_name pattern
+      `<metric>-<config_id>|<pred_field_normalized>|...`.
+
+    Returns the total API-call count across all judge configs that
+    target ``judge_model_id``.
     """
-    from project_models import Task
-    from models import EvaluationRun, EvaluationJudgeRun
-
-    task_ids = [r[0] for r in db.query(Task.id).filter(Task.project_id == project_id).all()]
-    if not task_ids or runs_per_call <= 0:
+    cfgs = _load_llm_judge_configs(db, project_id, judge_model_id)
+    if not cfgs:
         return 0
 
-    if generation_mode != "missing":
-        return len(task_ids) * runs_per_call
+    # Resolve the project's universe of subjects once.
+    gen_ids_by_field = _completed_generation_ids(db, project_id)
+    annotation_ids = _annotation_ids(db, project_id)
 
-    # Bulk-load all completed (task_id, run_index) pairs for this judge
-    # once per call instead of N×M individual queries.
-    done_rows = (
-        db.query(EvaluationRun.task_id, EvaluationJudgeRun.run_index)
-        .join(EvaluationJudgeRun, EvaluationJudgeRun.evaluation_id == EvaluationRun.id)
-        .filter(
-            EvaluationRun.project_id == project_id,
-            EvaluationJudgeRun.judge_model_id == judge_model_id,
-            EvaluationJudgeRun.status == "completed",
+    total = 0
+    for cfg in cfgs:
+        runs = cfg["runs"] * max(runs_per_call, 1)
+        # `runs_per_call` is the modal-level "runs across this trigger";
+        # `cfg["runs"]` is per-judge in this config. Multiply because
+        # each judge invocation is its own API call.
+        for pf in cfg["prediction_fields"]:
+            subj_keys = _subjects_for_pred_field(
+                pf, gen_ids_by_field=gen_ids_by_field,
+                annotation_ids=annotation_ids,
+            )
+            if generation_mode == "missing":
+                done = _already_scored_subjects(
+                    db, project_id, metric_id=cfg["metric"], pred_field=pf
+                )
+                missing = [s for s in subj_keys if s not in done]
+                total += len(missing) * runs
+            else:
+                total += len(subj_keys) * runs
+    return total
+
+
+def _load_llm_judge_configs(db: Session, project_id: str, judge_model_id: str) -> List[Dict[str, Any]]:
+    """Pull the project's enabled LLM-judge configs that name this
+    `judge_model_id` in their judges ensemble. Returns dicts with
+    `metric` (id), `prediction_fields`, and `runs` (for this judge)."""
+    from project_models import Project
+    proj = db.query(Project).filter(Project.id == project_id).first()
+    if not proj:
+        return []
+    eval_cfg = proj.evaluation_config or {}
+    if not isinstance(eval_cfg, dict):
+        try:
+            import json as _json
+            eval_cfg = _json.loads(eval_cfg)
+        except Exception:
+            return []
+    out: List[Dict[str, Any]] = []
+    for c in eval_cfg.get("evaluation_configs") or []:
+        if c.get("enabled") is False:
+            continue
+        metric = c.get("metric") or ""
+        if not metric.startswith("llm_judge_"):
+            continue
+        params = c.get("metric_parameters") or {}
+        # Two ensemble shapes the codebase uses:
+        # 1. judges: [{judge_model_id, runs}]            (preferred)
+        # 2. judge_model + runs_per_judge                (legacy single-judge)
+        runs_for_this_judge = 0
+        if isinstance(params.get("judges"), list):
+            for j in params["judges"]:
+                if (j or {}).get("judge_model_id") == judge_model_id:
+                    runs_for_this_judge = max(int(j.get("runs") or 1), 1)
+                    break
+        elif params.get("judge_model") == judge_model_id:
+            runs_for_this_judge = max(int(params.get("runs_per_judge") or 1), 1)
+        if runs_for_this_judge == 0:
+            continue
+        out.append(
+            {
+                "metric": metric,
+                "prediction_fields": list(c.get("prediction_fields") or []),
+                "runs": runs_for_this_judge,
+            }
         )
-        .distinct()
+    return out
+
+
+def _completed_generation_ids(db: Session, project_id: str) -> List[str]:
+    """All completed generation ids for the project. Cached scope —
+    helper resolves fields against this list rather than re-querying."""
+    from project_models import Task
+    from models import Generation
+    rows = (
+        db.query(Generation.id)
+        .join(Task, Task.id == Generation.task_id)
+        .filter(Task.project_id == project_id, Generation.status == "completed")
         .all()
     )
-    done = {(tid, ri) for tid, ri in done_rows}
+    return [r[0] for r in rows]
 
-    cells = 0
-    for tid in task_ids:
-        for ri in range(runs_per_call):
-            if (tid, ri) not in done:
-                cells += 1
-    return cells
+
+def _annotation_ids(db: Session, project_id: str) -> List[str]:
+    from project_models import Annotation, Task
+    rows = (
+        db.query(Annotation.id)
+        .join(Task, Task.id == Annotation.task_id)
+        .filter(Task.project_id == project_id)
+        .all()
+    )
+    return [r[0] for r in rows]
+
+
+def _subjects_for_pred_field(
+    pred_field: str,
+    *,
+    gen_ids_by_field: List[str],
+    annotation_ids: List[str],
+) -> List[tuple]:
+    """Return a list of subject keys for one `prediction_fields` entry.
+
+    Each key is `(kind, id)` where kind ∈ {'generation','annotation'}.
+
+    Mirrors the worker's resolution at services/workers/tasks.py:234
+    and the human-eval block around line 3289-3291: a plain field name
+    (no `model:`/`human:`/`__all_*__` prefix) gets auto-prefixed to
+    `human:<field>` for annotation context AND used as a model field —
+    so the cost includes both subject sets, matching what the worker
+    will actually run.
+    """
+    if pred_field == "__all_model__":
+        return [("generation", gid) for gid in gen_ids_by_field]
+    if pred_field == "__all_human__" or pred_field.startswith("human:"):
+        return [("annotation", aid) for aid in annotation_ids]
+    if pred_field.startswith("model:"):
+        return [("generation", gid) for gid in gen_ids_by_field]
+    # Plain field name — both sides.
+    return [("generation", gid) for gid in gen_ids_by_field] + [
+        ("annotation", aid) for aid in annotation_ids
+    ]
+
+
+def _already_scored_subjects(
+    db: Session, project_id: str, *, metric_id: str, pred_field: str
+) -> set:
+    """Return subject keys (`(kind, id)`) already scored for this
+    metric+pred_field combination — i.e. what the worker would skip
+    under `evaluate_missing_only`.
+
+    field_name in `task_evaluations` follows the convention
+    `<metric>-<config_id>|<pred_field_normalized>|<reference>`.
+    The `<config_id>` suffix is unique per metric instance, so we
+    match on prefix `<metric>-`. Per worker logic, plain field names
+    are recorded with the `human:` prefix in annotation context — so a
+    plain pred_field maps to two field_name patterns, one for each
+    subject kind.
+    """
+    from project_models import Task
+    from models import TaskEvaluation, EvaluationRun
+
+    if pred_field.startswith("human:") or pred_field == "__all_human__":
+        # Annotation-side field. Match the prefixed form on the
+        # annotation_id side only.
+        norm = pred_field
+        subject_col = TaskEvaluation.annotation_id
+    elif pred_field == "__all_model__" or pred_field.startswith("model:"):
+        norm = pred_field
+        subject_col = TaskEvaluation.generation_id
+    else:
+        # Plain — recorded both as `<pf>` (model side) and `human:<pf>`
+        # (annotation side). Run two queries and union.
+        model_done = _scored_for(
+            db, project_id, metric_id=metric_id, pred_field_norm=pred_field,
+            subject_col=TaskEvaluation.generation_id, kind="generation",
+        )
+        human_done = _scored_for(
+            db, project_id, metric_id=metric_id,
+            pred_field_norm=f"human:{pred_field}",
+            subject_col=TaskEvaluation.annotation_id, kind="annotation",
+        )
+        return model_done | human_done
+    return _scored_for(
+        db, project_id, metric_id=metric_id, pred_field_norm=norm,
+        subject_col=subject_col,
+        kind="annotation" if subject_col is TaskEvaluation.annotation_id else "generation",
+    )
+
+
+def _scored_for(
+    db: Session, project_id: str, *, metric_id: str, pred_field_norm: str,
+    subject_col, kind: str,
+) -> set:
+    from sqlalchemy import and_
+    from models import TaskEvaluation, EvaluationRun
+    rows = (
+        db.query(subject_col)
+        .join(EvaluationRun, EvaluationRun.id == TaskEvaluation.evaluation_id)
+        .filter(
+            EvaluationRun.project_id == project_id,
+            TaskEvaluation.field_name.like(f"{metric_id}-%|{pred_field_norm}|%"),
+            TaskEvaluation.metrics.isnot(None),
+            TaskEvaluation.error_message.is_(None),
+            subject_col.isnot(None),
+        )
+        .all()
+    )
+    return {(kind, r[0]) for r in rows if r[0] is not None}
 
 
 def _count_cells_to_generate(

--- a/services/api/services/token_estimation.py
+++ b/services/api/services/token_estimation.py
@@ -142,6 +142,60 @@ def estimate_tokens_for_calls(
     return estimate
 
 
+def sample_prediction_inputs(
+    *,
+    db,
+    project_id: str,
+    sample_size: int = 10,
+    seed: Optional[int] = None,
+) -> List[str]:
+    """Sample texts that approximate what an LLM judge actually sees.
+
+    The judge input is roughly:
+        judge_prompt_template (~500-1000 tokens, near-constant)
+      + reference_text         (~1000-3000 tokens, per-config)
+      + prediction             (~the model's full Gutachten — by far the
+                               dominant component on the BenGER prompts)
+
+    We return recent successful prediction texts because the prediction
+    is the largest and most variable component. Estimating eval cost
+    against the raw Sachverhalt (sample_task_texts) under-counts by
+    ~3-5× — Gutachten outputs are 4-15K tokens, the Sachverhalt is
+    ~1-3K. The estimator multiplies prompt length by token cost, so
+    that's a ~3-5× under-estimate of the input bill.
+
+    Falls back to sample_task_texts when the project has no successful
+    generations yet (cold start).
+    """
+    from project_models import Task
+    from models import Generation
+
+    rows = (
+        db.query(Generation.response_content)
+        .join(Task, Task.id == Generation.task_id)
+        .filter(Task.project_id == project_id)
+        .filter(Generation.status == "completed")
+        .filter(Generation.response_content.isnot(None))
+        .order_by(Generation.created_at.desc())
+        .limit(max(sample_size * 5, 50))
+        .all()
+    )
+    texts: List[str] = [r[0] for r in rows if r[0]]
+    if not texts:
+        return sample_task_texts(db=db, project_id=project_id, sample_size=sample_size, seed=seed)
+
+    if seed is not None:
+        rng = random.Random(seed)
+        if len(texts) > sample_size:
+            texts = rng.sample(texts, sample_size)
+        else:
+            texts = list(texts)
+    else:
+        texts = texts[:sample_size]
+
+    return texts
+
+
 def sample_task_texts(
     *,
     db,

--- a/services/frontend/src/components/evaluation/EvaluationControlModal.tsx
+++ b/services/frontend/src/components/evaluation/EvaluationControlModal.tsx
@@ -258,13 +258,6 @@ export function EvaluationControlModal({
                         </div>
                       )}
 
-                      {/* Info */}
-                      <div className="rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-900/20">
-                        <p className="text-sm text-blue-800 dark:text-blue-300">
-                          <strong>{t('evaluation.controlModal.note')}</strong> {t('evaluation.controlModal.backgroundInfo')}
-                        </p>
-                      </div>
-
                       {/* Inline cost preview — renders only when at least
                           one llm_judge_* metric is configured (deterministic
                           metrics like exact_match incur no API cost).

--- a/services/frontend/src/components/evaluation/__tests__/EvaluationControlModal.test.tsx
+++ b/services/frontend/src/components/evaluation/__tests__/EvaluationControlModal.test.tsx
@@ -123,10 +123,13 @@ describe('EvaluationControlModal', () => {
       expect(screen.getByText('5 configurations will be run')).toBeInTheDocument()
     })
 
-    it('shows info note', () => {
+    it('does not render the legacy "Note: runs in background" hint', () => {
+      // Removed in PR #65 as visual clutter — the background-run
+      // behavior is obvious from the page UX. Test kept as a regression
+      // guard so the box doesn't quietly come back.
       render(<EvaluationControlModal {...defaultProps} />)
-      expect(screen.getByText(/Note:/)).toBeInTheDocument()
-      expect(screen.getByText(/background/)).toBeInTheDocument()
+      expect(screen.queryByText(/Note:/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/background/)).not.toBeInTheDocument()
     })
 
     it('renders start and cancel buttons', () => {


### PR DESCRIPTION
## Summary
Two targeted fixes on top of PR #64 to make the evaluation cost panel reflect reality, plus a UI cleanup the user flagged.

### Why the panel showed \$0.09 for what's a \$2-3/call run

1. **Input was sampled from raw Sachverhalt (sample_task_texts)** — but the judge actually sees \`judge_prompt + reference + prediction\` where the prediction is the prior generation's full Gutachten. Avg prediction on the BenGER project: 4 372 output tokens. Raw task data: ~1 500-2 000. Input was undercounted 3-5×.
2. **Output was 60 % of max_tokens** — fine for generation, terrible for judges. With a gpt-5.4 judge whose max_tokens override is 16 K, that's 9 600 tokens of imagined output per call. Real judge output is ~500-2 000 tokens (a JSON score + brief rationale).

### Fixes
- New \`sample_prediction_inputs(db, project_id, …)\` in \`services/api/services/token_estimation.py\` — pulls recent successful \`generations.response_content\` for the project. Falls back to the existing \`sample_task_texts\` when no generation exists yet (cold start).
- Cost endpoint dispatches: \`mode='evaluation'\` → prediction sample; \`generation\` → task sample (unchanged).
- New constant \`_EVAL_OUTPUT_UTILIZATION = 0.15\` overrides the generation utilization for eval calls. On a 16 K-max-tokens judge that becomes ~2 400 output tokens — correct band.
- Note string updated to explain the new utilization.

### UX cleanup
- Removed the blue "Hinweis: Evaluation läuft im Hintergrund…" info box from the evaluation modal. Visual clutter, info is obvious from the page behavior. i18n keys (\`evaluation.controlModal.note\`/\`backgroundInfo\`) left intact in case anything else references them.

## Test plan
- [ ] CI green
- [ ] Post-deploy: open Start-Evaluation modal on the project. Cost should jump from ~\$0.09 to ~\$2-3 (15 cells × ~\$0.15-0.20/call) — within an order of magnitude of the real bill.
- [ ] Hinweis box gone.
- [ ] Cold-start project (no generations yet): falls back to task-text sampling without a 500.