### PR TITLE
fix(eval): latest-gen aggregation + modal coherence + judge schema validation

### DIFF
--- a/services/api/routers/evaluations/results.py
+++ b/services/api/routers/evaluations/results.py
@@ -827,24 +827,82 @@ async def get_results_by_task_model(
                 .all()
             )
 
-        # Query 2: Get annotation-based evaluation results
+        # Query 2: Get annotation-based evaluation results.
+        # Same latest-only / mean-of-all symmetry as the generation
+        # branch: when include_history is off, scope to the LATEST
+        # annotation per (task_id, completed_by) before joining evals.
+        # If a task has a fresh annotation that hasn't been evaluated
+        # yet, this leaves the cell empty (rendered as n/a) instead of
+        # silently surfacing an evaluation of an older annotation —
+        # which is what the user explicitly asked for.
         from models import User as DBUser
 
-        annotation_eval_results = (
-            db.query(
-                TaskEvaluation.task_id,
-                TaskEvaluation.annotation_id,
-                TaskEvaluation.field_name,
-                TaskEvaluation.metrics,
-                TaskEvaluation.created_at,
+        if aggregate_mean:
+            annotation_eval_results = (
+                db.query(
+                    TaskEvaluation.task_id,
+                    TaskEvaluation.annotation_id,
+                    TaskEvaluation.field_name,
+                    TaskEvaluation.metrics,
+                    TaskEvaluation.created_at,
+                )
+                .filter(
+                    TaskEvaluation.evaluation_id == evaluation_id,
+                    TaskEvaluation.generation_id == None,  # noqa: E711
+                    TaskEvaluation.annotation_id != None,  # noqa: E711
+                )
+                .all()
             )
-            .filter(
-                TaskEvaluation.evaluation_id == evaluation_id,
-                TaskEvaluation.generation_id == None,  # noqa: E711
-                TaskEvaluation.annotation_id != None,  # noqa: E711
+        else:
+            latest_ann = (
+                db.query(
+                    Annotation.id.label("ann_id"),
+                    func.row_number()
+                    .over(
+                        partition_by=[Annotation.task_id, Annotation.completed_by],
+                        order_by=Annotation.created_at.desc(),
+                    )
+                    .label("rn"),
+                )
+                .filter(Annotation.completed_by.isnot(None))
+                .subquery()
             )
-            .all()
-        )
+            latest_ann_ids = (
+                db.query(latest_ann.c.ann_id).filter(latest_ann.c.rn == 1).subquery()
+            )
+            ranked_ann_evals = (
+                db.query(
+                    TaskEvaluation.task_id,
+                    TaskEvaluation.annotation_id,
+                    TaskEvaluation.field_name,
+                    TaskEvaluation.metrics,
+                    TaskEvaluation.created_at,
+                    func.row_number()
+                    .over(
+                        partition_by=[TaskEvaluation.annotation_id, TaskEvaluation.field_name],
+                        order_by=TaskEvaluation.created_at.desc(),
+                    )
+                    .label("rn"),
+                )
+                .filter(
+                    TaskEvaluation.evaluation_id == evaluation_id,
+                    TaskEvaluation.generation_id == None,  # noqa: E711
+                    TaskEvaluation.annotation_id.isnot(None),
+                    TaskEvaluation.annotation_id.in_(db.query(latest_ann_ids.c.ann_id)),
+                )
+                .subquery()
+            )
+            annotation_eval_results = (
+                db.query(
+                    ranked_ann_evals.c.task_id,
+                    ranked_ann_evals.c.annotation_id,
+                    ranked_ann_evals.c.field_name,
+                    ranked_ann_evals.c.metrics,
+                    ranked_ann_evals.c.created_at,
+                )
+                .filter(ranked_ann_evals.c.rn == 1)
+                .all()
+            )
 
         if not sample_results and not annotation_eval_results:
             return {

--- a/services/api/routers/evaluations/results.py
+++ b/services/api/routers/evaluations/results.py
@@ -718,7 +718,6 @@ async def get_results_by_task_model(
         from models import TaskEvaluation
         from models import Generation as GenerationModel
         from models import LLMModel
-        from services.evaluation.human_eval_runs import HUMAN_GRADED_METRICS
 
         # Verify evaluation exists
         evaluation = db.query(DBEvaluationRun).filter(DBEvaluationRun.id == evaluation_id).first()
@@ -735,23 +734,20 @@ async def get_results_by_task_model(
                 detail="Access denied",
             )
 
-        # Detect a human-graded run (model_id='human' + the metric is in
-        # HUMAN_GRADED_METRICS). For these runs, multiple correctors append
-        # rows to the same singleton EvaluationRun — so the "include_history"
-        # toggle controls whether each cell shows the latest grade or the
-        # mean across all grading scores. LLM runs always use latest-only.
-        is_human_run = (
-            evaluation.model_id == "human"
-            and (evaluation.eval_metadata or {}).get("evaluation_type")
-            in HUMAN_GRADED_METRICS
-        )
-        aggregate_mean = is_human_run and include_history
+        # `include_history` controls cell aggregation:
+        #   off  → cell shows the score of the LATEST generation per (task,
+        #          model) only (the user's mental model: "what are the
+        #          current results"). For human-graded runs, "latest" means
+        #          the most recently appended grade row.
+        #   on   → cell shows the arithmetic mean across all historical
+        #          rows for that (task, model) — multiple generations for
+        #          LLM runs, or multiple correctors for human runs.
+        # Without this, three historical gpt-5.4 generations contributed
+        # 24 rows to a single cell average (8 metrics × 3 gens) silently.
+        aggregate_mean = include_history
 
-        # Get sample results: when aggregating, fetch all rows and average in
-        # Python (the score lives inside a JSON dict so SQL-side AVG would
-        # require JSON-path extraction); otherwise dedup latest-per-target
-        # via the existing window function.
         if aggregate_mean:
+            # Fetch all eval rows; cell_scores collector below averages them.
             sample_results = (
                 db.query(
                     TaskEvaluation.task_id,
@@ -768,6 +764,33 @@ async def get_results_by_task_model(
                 .all()
             )
         else:
+            # Two-step dedup:
+            # 1. latest_gen_id per (task_id, model_id) — picks the single
+            #    most recent generation that should drive the cell.
+            # 2. latest eval per (generation_id, field_name) within the set
+            #    of latest gens — picks the freshest eval if a gen was
+            #    re-evaluated.
+            #
+            # Without step 1, the previous implementation kept the latest
+            # eval of EVERY historical generation, then averaged them all
+            # into the cell (silently — the user expected "latest only").
+            latest_gen = (
+                db.query(
+                    GenerationModel.id.label("gen_id"),
+                    func.row_number()
+                    .over(
+                        partition_by=[GenerationModel.task_id, GenerationModel.model_id],
+                        order_by=GenerationModel.created_at.desc(),
+                    )
+                    .label("rn"),
+                )
+                .filter(GenerationModel.status == "completed")
+                .subquery()
+            )
+            latest_gen_ids = (
+                db.query(latest_gen.c.gen_id).filter(latest_gen.c.rn == 1).subquery()
+            )
+
             ranked_results = (
                 db.query(
                     TaskEvaluation.task_id,
@@ -786,7 +809,10 @@ async def get_results_by_task_model(
                     GenerationModel,
                     TaskEvaluation.generation_id == GenerationModel.id,
                 )
-                .filter(TaskEvaluation.evaluation_id == evaluation_id)
+                .filter(
+                    TaskEvaluation.evaluation_id == evaluation_id,
+                    TaskEvaluation.generation_id.in_(db.query(latest_gen_ids.c.gen_id)),
+                )
                 .subquery()
             )
             sample_results = (
@@ -1493,6 +1519,16 @@ async def get_sample_result_by_task_model(
     task_id: str = Query(..., description="Task ID"),
     model_id: str = Query(..., description="Model ID"),
     include_history: bool = Query(True, description="Include all historical results. When false, deduplicate to latest per field_name."),
+    generation_id: Optional[str] = Query(
+        None,
+        description=(
+            "Restrict results to evaluations of this exact generation. "
+            "Used by the result modal to keep its three tabs (Annotation, "
+            "Generation, Evaluation) locked to the same generation_id — "
+            "without it the modal could show today's generation in one tab "
+            "and yesterday's eval of a stale generation in another."
+        ),
+    ),
     current_user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
@@ -1563,7 +1599,7 @@ async def get_sample_result_by_task_model(
                 sample_results = []
         else:
             # Generation-based evaluation: join on Generation model
-            sample_results = (
+            q = (
                 db.query(TaskEvaluation)
                 .join(
                     GenerationModel,
@@ -1573,9 +1609,14 @@ async def get_sample_result_by_task_model(
                     TaskEvaluation.task_id == task_id,
                     GenerationModel.model_id == model_id,
                 )
-                .order_by(TaskEvaluation.created_at.desc())
-                .all()
             )
+            if generation_id:
+                # Modal tab-cohesion path: scope to the exact generation
+                # the user is viewing in the Generation tab. Without this
+                # the modal showed evals of any historical generation
+                # while the Generation tab showed only the latest.
+                q = q.filter(TaskEvaluation.generation_id == generation_id)
+            sample_results = q.order_by(TaskEvaluation.created_at.desc()).all()
 
         if not sample_results:
             return {

--- a/services/frontend/src/components/evaluation/EvaluationResults.tsx
+++ b/services/frontend/src/components/evaluation/EvaluationResults.tsx
@@ -822,7 +822,12 @@ export function EvaluationResults({
       setAnnotationLoading(false)
     }
 
-    // Fetch generation results only for model cells
+    // Fetch generation results only for model cells. Capture the
+    // single generation_id we'll lock the Evaluation tab to so all
+    // three tabs describe the same generation. Without this lock the
+    // Generation tab can show today's output while the Evaluation tab
+    // shows yesterday's eval of a stale generation.
+    let lockedGenerationId: string | undefined
     if (isAnnotatorCell) {
       setGenerationData([])
       setGenerationLoading(false)
@@ -833,7 +838,12 @@ export function EvaluationResults({
           params.append('include_history', 'true')
         }
         const result = await apiClient.get(`/generation-tasks/generation-result?${params}`)
-        setGenerationData(result.results || [])
+        const gens = result.results || []
+        setGenerationData(gens)
+        // The endpoint returns latest first when include_history=false; with
+        // include_history=true it still returns most-recent first. Either way
+        // the first row is the generation the user expects to see.
+        lockedGenerationId = gens[0]?.generation_id
       } catch (err) {
         console.error('Failed to fetch generation result:', err)
       } finally {
@@ -841,9 +851,17 @@ export function EvaluationResults({
       }
     }
 
-    // Fetch per-task evaluation results
+    // Fetch per-task evaluation results scoped to lockedGenerationId
+    // (annotator cells skip this scope — annotations are subjects, not
+    // generations). Without the scope the eval tab silently shows
+    // evaluations of any historical generation.
     try {
-      const result = await apiClient.getTaskEvaluation(taskId, modelId, showHistory)
+      const result = await apiClient.getTaskEvaluation(
+        taskId,
+        modelId,
+        showHistory,
+        isAnnotatorCell ? undefined : lockedGenerationId,
+      )
       setEvaluationData(result)
     } catch (err) {
       console.error('Failed to fetch evaluation sample result:', err)
@@ -1872,7 +1890,20 @@ function ResultDetailsModal({
               </DialogTitle>
               {modelId && (
                 <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
-                  {t('evaluation.multiFieldResults.model')}: {modelId} {taskId && `| ${t('evaluation.multiFieldResults.task')}: ${taskId.slice(0, 8)}...`}
+                  {t('evaluation.multiFieldResults.model')}: {modelId}
+                  {/* Surface the generation's timestamp + id so the user
+                   * can tell which generation the three tabs are
+                   * describing. Without this the modal looked identical
+                   * for two different generations of the same (task,
+                   * model) — the cell that was about to lie. */}
+                  {!isAnnotatorCell && generationData && generationData[0] && (
+                    <> · {t('evaluation.multiFieldResults.generation') ?? 'Generation'}: {
+                      generationData[0].generated_at
+                        ? new Date(generationData[0].generated_at).toLocaleString()
+                        : (generationData[0].generation_id || '').slice(0, 8) + '…'
+                    }</>
+                  )}
+                  {taskId && <> · {t('evaluation.multiFieldResults.task')}: {taskId.slice(0, 8)}…</>}
                 </p>
               )}
             </div>

--- a/services/frontend/src/lib/api/evaluations.ts
+++ b/services/frontend/src/lib/api/evaluations.ts
@@ -182,11 +182,15 @@ export class EvaluationsClient extends BaseApiClient {
     )
   }
 
-  // Get per-task evaluation results for a task-model combination
+  // Get per-task evaluation results for a task-model combination.
+  // `generationId` (optional) locks the response to evaluations of one
+  // exact generation — used by the result modal so its Generation and
+  // Evaluation tabs describe the same generation_id.
   async getTaskEvaluation(
     taskId: string,
     modelId: string,
     includeHistory: boolean = true,
+    generationId?: string,
   ): Promise<{
     task_id: string
     model_id: string
@@ -218,6 +222,9 @@ export class EvaluationsClient extends BaseApiClient {
     })
     if (!includeHistory) {
       params.append('include_history', 'false')
+    }
+    if (generationId) {
+      params.append('generation_id', generationId)
     }
     return await this.request(
       `/evaluations/sample-result?${params.toString()}`,

--- a/services/workers/ml_evaluation/llm_judge_evaluator.py
+++ b/services/workers/ml_evaluation/llm_judge_evaluator.py
@@ -640,6 +640,43 @@ class LLMJudgeEvaluator(BaseEvaluator):
                 content = response.get("content", "")
                 result = self._parse_evaluation_response(content)
 
+                # Metric-specific schema validation. For criteria whose
+                # prompt template asks for a multi-dimension grading
+                # (currently `llm_judge_falloesung`), a response carrying
+                # only `{score, justification}` is a format-break by the
+                # judge model — not a legitimate 1/100 grade. Treat it as
+                # a parse error so retries get a fresh attempt, and if all
+                # retries fail the row is marked failed (mode='missing'
+                # eval picks it up next time).
+                if result and "score" in result and criterion and criterion.startswith("llm_judge_falloesung"):
+                    dimensions = result.get("dimensions")
+                    if not isinstance(dimensions, dict) or not dimensions:
+                        logger.warning(
+                            f"Judge returned malformed schema for {criterion}: "
+                            f"missing 'dimensions' object — retrying"
+                        )
+                        last_failure = {
+                            "error": True,
+                            "error_message": (
+                                f"Judge returned malformed schema (no dimensions) for {criterion}"
+                            ),
+                            "_call_metadata": {
+                                **_extract_call_metadata(response),
+                                "error_type": "parse_error",
+                            },
+                            "_raw_output": content,
+                            "_judge_prompts_used": {
+                                "system_prompt": "You are an expert evaluator. Respond only with valid JSON.",
+                                "evaluation_prompt": prompt,
+                                "criterion": criterion,
+                                "judge_model": self.judge_model,
+                                "temperature": self.temperature,
+                            },
+                        }
+                        # Drop the malformed result so the retry path runs
+                        # (the conditional below would otherwise accept it).
+                        result = None
+
                 if result and "score" in result:
                     score = float(result["score"])
                     # Clamp score to valid range based on score_scale


### PR DESCRIPTION
## Summary

Four related fixes for the Benchathon evaluation page so the table numbers, the modal contents, and the stored judge grades all describe the same thing. Plan: \`~/.claude/plans/a-few-things-1-gleaming-mountain.md\`.

### F1 — Cell aggregation respects latest generation per (task, model)
\`services/api/routers/evaluations/results.py:694-893\`. The previous implementation deduplicated to the latest eval per \`(generation_id, field_name)\` but never filtered to a single generation per cell — three historical gpt-5.4 generations contributed 24 eval rows to one cell average. New: \`include_history=False\` (default) does a two-step dedup — latest generation per (task, model) → latest eval per (gen_id, field_name). \`include_history=True\` keeps the across-history mean (now also for LLM-graded runs, was previously a human-only no-op).

### F2 — Result modal locks all three tabs to one generation_id
\`EvaluationResults.tsx\` + \`lib/api/evaluations.ts\` + \`results.py:1516\`. Modal captures \`lockedGenerationId = generationData[0].generation_id\` and forwards it via a new optional \`generation_id\` query param on \`/evaluations/sample-result\`. Eliminates the failure mode where the Generation tab showed today's run while the Evaluation tab showed yesterday's eval of a stale generation.

### F3 — Judge schema validation rejects malformed responses
\`llm_judge_evaluator.py\` around line 641. For \`llm_judge_falloesung\` criteria, the parsed response must carry a non-empty \`dimensions\` object. A bare \`{score, justification}\` shape is the judge breaking format; treat it as a parse error so retries get a fresh attempt and (if all retries fail) the row is persisted with \`error_message='Judge returned malformed schema'\`. A mode='missing' eval-trigger then re-queues those cells.

### F4 — Modal title surfaces the generation's timestamp
Same modal header now reads \`Modell: X · Generation: <timestamp> · Aufgabe: <id>…\`. Without it, two different generations of the same (task, model) rendered an identical modal title.

## Operational follow-up (not in this patch)

After deploy, run this SQL once on prod to mark existing degraded rows as failed so mode='missing' picks them up for re-eval:

\`\`\`sql
UPDATE task_evaluations
SET error_message = COALESCE(error_message, 'Judge returned malformed schema (legacy backfill)'),
    metrics = NULL,
    passed = FALSE
WHERE field_name LIKE 'llm_judge_%'
  AND metrics IS NOT NULL
  AND (
    jsonb_typeof(metrics->'llm_judge_falloesung') = 'number'
    OR (metrics->'llm_judge_falloesung_response'->'dimensions') IS NULL
  );
\`\`\`

## Test plan
- [ ] CI green
- [ ] Post-deploy: open the eval page with "Verlauf einbeziehen" OFF — Zivilrecht / gpt-5.4 cell matches a SQL query that scores the latest generation per task only
- [ ] Toggle ON — number changes to mean across all historical generations
- [ ] Open modal for one cell — title now shows generation timestamp; Generation and Evaluation tabs reference the same generation_id
- [ ] Inject a fake judge response missing \`dimensions\` in a dev container — parser logs "malformed schema" and persists \`error_message\`, not a 0.01 grade