### PR TITLE
hotfix(eval-modal): fix generation_id table mismatch

### DIFF
--- a/services/api/routers/evaluations/results.py
+++ b/services/api/routers/evaluations/results.py
@@ -1669,11 +1669,18 @@ async def get_sample_result_by_task_model(
                 )
             )
             if generation_id:
-                # Modal tab-cohesion path: scope to the exact generation
-                # the user is viewing in the Generation tab. Without this
-                # the modal showed evals of any historical generation
-                # while the Generation tab showed only the latest.
-                q = q.filter(TaskEvaluation.generation_id == generation_id)
+                # Modal tab-cohesion path. The frontend obtains its
+                # `generation_id` from `/generation-tasks/generation-result`,
+                # which returns `response_generations.id` (the parent row
+                # per task/model/structure). `task_evaluations.generation_id`
+                # FKs to the inner `generations` table, so a direct equality
+                # on `TaskEvaluation.generation_id == generation_id` never
+                # matches and the modal renders empty even when the page
+                # shows a score for that cell. Filter on the joined
+                # `Generation.generation_id` (which is the FK back to
+                # ResponseGeneration) instead — that's the column whose
+                # value matches what the frontend sent.
+                q = q.filter(GenerationModel.generation_id == generation_id)
             sample_results = q.order_by(TaskEvaluation.created_at.desc()).all()
 
         if not sample_results:


### PR DESCRIPTION
## What broke
After PR #66 the modal called \`getTaskEvaluation(..., generationId)\` to lock its tabs to one generation. But the \`generationId\` came from \`/generation-tasks/generation-result\` (returns \`response_generations.id\`), while \`task_evaluations.generation_id\` FKs to the inner \`generations\` table — different ids, never matched. Cells with a real score on the page table opened a modal that said "No evaluation results found".

## Fix
\`services/api/routers/evaluations/results.py:1671\`. Filter on \`Generation.generation_id\` (the inner row's FK back to ResponseGeneration) instead of \`TaskEvaluation.generation_id\`. Frontend unchanged.

## Operational note (not in this patch)
Yesterday's one-time cleanup SQL also caught 227 annotation-side LLM-judge rows where the dimensioned data lived at \`metrics.llm_judge_falloesung.details.judge_response.dimensions\` instead of \`metrics.llm_judge_falloesung_response.dimensions\`. Those rows now show n/a; the next mode='missing' eval will regrade them. Future cleanups should use just \`jsonb_typeof(metrics->'llm_judge_falloesung') = 'number'\` as the degraded marker, without the dimensions-IS-NULL fallback.

## Test plan
- [ ] CI green
- [ ] Post-deploy: open a (task, model) cell on the eval page that shows a numeric score. Modal must surface evaluation rows in the Evaluation tab. Toggling Verlauf einbeziehen still locks to the latest generation.