### PR TITLE
feat(i18n): Korrektur Geheim / allowSkip strings

### DIFF
--- a/services/frontend/src/locales/de/common.json
+++ b/services/frontend/src/locales/de/common.json
@@ -7511,7 +7511,8 @@
     },
     "targetType": {
       "annotation": "Annotation",
-      "generation": "Generierung"
+      "generation": "Generierung",
+      "secret": "Geheim"
     },
     "totalItems": "{count} Elemente",
     "noItems": "Keine Elemente",
@@ -7636,6 +7637,7 @@
         "requeue_for_me": "Übersprungenes erneut anzeigen",
         "ignore_skipped": "Übersprungenes ausblenden"
       },
+      "allowSkip": "Überspringen erlauben",
       "requireCommentOnSkip": "Begründung beim Überspringen erforderlich",
       "allowSelfCorrection": "Eigene Annotationen korrigieren erlaubt",
       "visibilitySection": "Blinde Korrektur",

--- a/services/frontend/src/locales/en/common.json
+++ b/services/frontend/src/locales/en/common.json
@@ -7449,7 +7449,8 @@
     },
     "targetType": {
       "annotation": "Annotation",
-      "generation": "Generation"
+      "generation": "Generation",
+      "secret": "Hidden"
     },
     "totalItems": "{count} items",
     "noItems": "No items",
@@ -7579,6 +7580,7 @@
         "requeue_for_me": "Show skipped again to me",
         "ignore_skipped": "Hide skipped permanently"
       },
+      "allowSkip": "Allow skip",
       "requireCommentOnSkip": "Require comment on skip",
       "allowSelfCorrection": "Allow correcting one's own annotations",
       "visibilitySection": "Blind grading",


### PR DESCRIPTION
## Summary
- Adds three i18n keys consumed by benger-extended PR #17:
  - \`korrekturWorkflow.targetType.secret\` (\"Geheim\" / \"Hidden\")
  - \`korrektur.config.allowSkip\` (\"Überspringen erlauben\" / \"Allow skip\")
- Without these the new Korrektur Typ-column blinding and the per-metric skip toggle render raw i18n keys instead of localized strings.

## Test plan
- [x] Diff is locale-only; no code change.
- [ ] After merge + deploy: confirm the Benchathon project's Korrektur queue shows "Geheim" instead of "korrekturWorkflow.targetType.secret".