### PR TITLE
chore(landing): update dataset contributors and acknowledgements

### DIFF
--- a/services/frontend/src/locales/de/common.json
+++ b/services/frontend/src/locales/de/common.json
@@ -3049,14 +3049,23 @@
           "image": ""
         },
         {
-          "name": "Johannes Sigmund",
-          "role": "Wissenschaftlicher Mitarbeiter",
-          "institution": "TU Braunschweig",
+          "name": "Sofija Milijas",
+          "role": "Projektkoordination",
+          "institution": "Technische Universität München",
           "url": "",
           "image": ""
         }
       ],
       "teamDatasetSenior": [
+        {
+          "name": "Matthias Grabmair",
+          "role": "Projektleitung",
+          "institution": "Technische Universität München",
+          "url": "",
+          "image": ""
+        }
+      ],
+      "acknowledgements": [
         {
           "name": "Liane Wörner",
           "role": "Strafrecht",
@@ -3075,22 +3084,6 @@
           "name": "Dominik Brodowski",
           "role": "Strafrecht",
           "institution": "Universität des Saarlandes",
-          "url": "",
-          "image": ""
-        },
-        {
-          "name": "Matthias Grabmair",
-          "role": "Projektleitung",
-          "institution": "Technische Universität München",
-          "url": "",
-          "image": ""
-        }
-      ],
-      "acknowledgements": [
-        {
-          "name": "Sofija Milijas",
-          "role": "Projektkoordination",
-          "institution": "Technische Universität München",
           "url": "",
           "image": ""
         },

--- a/services/frontend/src/locales/en/common.json
+++ b/services/frontend/src/locales/en/common.json
@@ -3067,14 +3067,23 @@
           "image": ""
         },
         {
-          "name": "Johannes Sigmund",
-          "role": "Research Associate",
-          "institution": "TU Braunschweig",
+          "name": "Sofija Milijas",
+          "role": "Project Coordination",
+          "institution": "Technical University of Munich",
           "url": "",
           "image": ""
         }
       ],
       "teamDatasetSenior": [
+        {
+          "name": "Matthias Grabmair",
+          "role": "Project Supervisor",
+          "institution": "Technical University of Munich",
+          "url": "",
+          "image": ""
+        }
+      ],
+      "acknowledgements": [
         {
           "name": "Liane Wörner",
           "role": "Criminal Law",
@@ -3093,22 +3102,6 @@
           "name": "Dominik Brodowski",
           "role": "Criminal Law",
           "institution": "Saarland University",
-          "url": "",
-          "image": ""
-        },
-        {
-          "name": "Matthias Grabmair",
-          "role": "Project Supervisor",
-          "institution": "Technical University of Munich",
-          "url": "",
-          "image": ""
-        }
-      ],
-      "acknowledgements": [
-        {
-          "name": "Sofija Milijas",
-          "role": "Project Coordination",
-          "institution": "Technical University of Munich",
           "url": "",
           "image": ""
         },


### PR DESCRIPTION
## Summary
- Remove Johannes Sigmund from dataset contributors
- Promote Sofija Milijas into the dataset-contributors list (replacing Sigmund's slot)
- Move Liane Wörner, Sarah Rachut, Dominik Brodowski from Senior Authors to the first three Acknowledgements (they will not be on the paper)

Senior Authors now contains only Matthias Grabmair. EN + DE locale files updated symmetrically.

## Test plan
- [ ] `PeopleSection.test.tsx` still passes
- [ ] Landing page renders all four sections without name duplication