### PR TITLE
fix(seed): create EvaluationJudgeRun + set TaskEvaluation.judge_run_id

### DIFF
--- a/services/api/init_complete.py
+++ b/services/api/init_complete.py
@@ -558,7 +558,7 @@ def setup_e2e_evaluations(db):
     """
     from datetime import datetime
 
-    from models import EvaluationRun, TaskEvaluation, Generation, User
+    from models import EvaluationJudgeRun, EvaluationRun, TaskEvaluation, Generation, User
     from project_models import Project, Task
 
     admin = db.query(User).filter(User.email == "admin@example.com").first()
@@ -642,6 +642,22 @@ def setup_e2e_evaluations(db):
         )
         db.add(evaluation)
 
+        # Migration 042/043: every TaskEvaluation must hang off an
+        # EvaluationJudgeRun. The e2e config has no judge_model in
+        # metric_parameters, so use the catch-all shape (judge_model_id=NULL,
+        # run_index=0) — same pattern migration 043 uses for orphan backfill.
+        judge_run_id = str(uuid.uuid4())
+        judge_run = EvaluationJudgeRun(
+            id=judge_run_id,
+            evaluation_id=evaluation_id,
+            judge_model_id=None,
+            run_index=0,
+            status="completed",
+            completed_at=datetime.utcnow(),
+            samples_evaluated=len(tasks),
+        )
+        db.add(judge_run)
+
         # Create TaskEvaluation for each task
         for i, task in enumerate(tasks):
             if i >= len(scores):
@@ -655,6 +671,7 @@ def setup_e2e_evaluations(db):
             sample_result = TaskEvaluation(
                 id=str(uuid.uuid4()),
                 evaluation_id=evaluation_id,
+                judge_run_id=judge_run_id,
                 task_id=task.id,
                 generation_id=gen.id,
                 field_name="answer",


### PR DESCRIPTION
## Summary
Follow-up to PR #76. After unblocking the \`uq_generations_parent_run_index\` collision, the next seed step surfaces a sibling NOT-NULL violation that's been hidden behind it since 2026-05-06:

\`\`\`
null value in column "judge_run_id" of relation "task_evaluations" violates not-null constraint
\`\`\`

- Create one synthetic \`EvaluationJudgeRun\` per \`EvaluationRun\` (catch-all shape: \`judge_model_id=NULL\`, \`run_index=0\` — same pattern migration 043 uses for orphan backfill)
- Pass \`judge_run_id\` to every seeded \`TaskEvaluation\`

## Why
Migration 042 added \`task_evaluations.judge_run_id\` (nullable + FK to \`evaluation_judge_runs\`). Migration 043 tightened it to NOT NULL. The seed was never updated.

## Test plan
- [ ] PR CI green
- [ ] Re-run nightlies (\`Nightly Tests\` + \`Nightly Extended Tests\`); seed step must succeed on every shard