### PR TITLE
fix(seed): wire run_index + judge_run_id through test surfaces

### DIFF
--- a/services/api/routers/test_seeding.py
+++ b/services/api/routers/test_seeding.py
@@ -190,13 +190,20 @@ async def seed_mock_generations(
                 model_id=model_id,
                 status="completed",
                 responses_generated=len(model_gens),
+                runs_requested=0,
+                runs_completed=0,
+                runs_failed=0,
                 created_by=current_user.id,
                 created_at=datetime.utcnow(),
                 completed_at=datetime.utcnow(),
             )
             db.add(response_gen)
 
-            # Create individual Generation records
+            # Create individual Generation records. Migration 041 requires a
+            # unique (generation_id, run_index) per child — track our own
+            # contiguous index that increments only on actual inserts (so
+            # task-not-found skips don't leave gaps).
+            run_index = 0
             for gen_data in model_gens:
                 task_id = gen_data.get("task_id")
                 output = gen_data.get("output", "")
@@ -217,6 +224,7 @@ async def seed_mock_generations(
                     generation_id=response_gen_id,
                     task_id=task_id,
                     model_id=model_id,
+                    run_index=run_index,
                     case_data=str(task.data) if task.data else "",
                     response_content=output,
                     status="completed",
@@ -227,6 +235,10 @@ async def seed_mock_generations(
                 )
                 db.add(generation)
                 created_ids.append(generation_id)
+                run_index += 1
+
+            response_gen.runs_requested = run_index
+            response_gen.runs_completed = run_index
 
         db.commit()
 
@@ -357,7 +369,7 @@ async def seed_mock_evaluation(
     _check_test_environment()
 
     try:
-        from models import Evaluation, EvaluationSampleResult, Generation
+        from models import Evaluation, EvaluationJudgeRun, EvaluationSampleResult, Generation
         from project_models import Project
 
         # Verify project exists
@@ -409,6 +421,21 @@ async def seed_mock_evaluation(
             db.add(evaluation)
             evaluation_ids.append(evaluation_id)
 
+            # Migration 042/043: each TaskEvaluation must hang off an
+            # EvaluationJudgeRun. Use the catch-all shape (judge_model_id=NULL,
+            # run_index=0) — same pattern migration 043 uses for orphan backfill.
+            judge_run_id = str(uuid.uuid4())
+            judge_run = EvaluationJudgeRun(
+                id=judge_run_id,
+                evaluation_id=evaluation_id,
+                judge_model_id=None,
+                run_index=0,
+                status="completed",
+                completed_at=datetime.utcnow(),
+                samples_evaluated=len(model_results),
+            )
+            db.add(judge_run)
+
             # Create EvaluationSampleResult records
             for result_data in model_results:
                 generation = result_data["generation"]
@@ -418,6 +445,7 @@ async def seed_mock_evaluation(
                 sample_result = EvaluationSampleResult(
                     id=str(uuid.uuid4()),
                     evaluation_id=evaluation_id,
+                    judge_run_id=judge_run_id,
                     task_id=generation.task_id,
                     generation_id=generation.id,
                     field_name="answer",

--- a/services/api/tests/integration/test_comprehensive_round_trip.py
+++ b/services/api/tests/integration/test_comprehensive_round_trip.py
@@ -203,13 +203,17 @@ class TestComprehensiveRoundTrip:
                 config_id="config-1",
                 status="completed",
                 responses_generated=2,
+                runs_requested=2,
+                runs_completed=2,
+                runs_failed=0,
                 generation_metadata={"temperature": 0.7},
                 created_by=test_user.id,
             )
             response_generations.append(resp_gen)
             session.add(resp_gen)
 
-        # Create generations (LLM responses)
+        # Create generations (LLM responses). Migration 041 requires a unique
+        # (generation_id, run_index) per child — use the inner-loop index.
         generations = []
         for i, (task, resp_gen) in enumerate(zip(tasks, response_generations)):
             for j in range(2):
@@ -218,6 +222,7 @@ class TestComprehensiveRoundTrip:
                     generation_id=resp_gen.id,
                     task_id=task.id,
                     model_id="gpt-4",
+                    run_index=j,
                     case_data=json.dumps(
                         {"input": task.data['text']}
                     ),  # Must be string (Text field)


### PR DESCRIPTION
## Summary
Cleans up three remaining migration-041/042/043 fallout sites that PRs #76 and #77 didn't reach:

- \`routers/test_seeding.py::seed_mock_generations\` — \`run_index\` per child + parent counters
- \`routers/test_seeding.py::seed_mock_evaluation\` — synthetic \`EvaluationJudgeRun\` + \`judge_run_id\` on every result row
- \`tests/integration/test_comprehensive_round_trip.py\` fixture — same shape fix as the test seed

## Why
The post-#77 nightly run revealed:
- e2e shards (platform + extended) hit a 500 from \`POST /seed/generations\` with the exact \`uq_generations_parent_run_index\` collision
- The platform-api shard ERRORed in 10 tests, all at fixture setup, all from the same constraint via \`session.commit()\`

These are the same family of bug — multiple writer sites that pre-date the multi-run schema.

## Test plan
- [ ] PR CI green
- [ ] Re-trigger \`Nightly Tests\` + \`Nightly Extended Tests\`; round-trip tests + e2e seeding both clear