### PR TITLE
fix(tests): cost-estimate fixture assigned_by + e2e wizard expand-subsection

### DIFF
--- a/services/api/tests/integration/test_cost_estimate_subject_count.py
+++ b/services/api/tests/integration/test_cost_estimate_subject_count.py
@@ -89,6 +89,7 @@ def _seed_project_with_subjects(
         id=str(uuid.uuid4()),
         project_id=project.id,
         organization_id=test_org.id,
+        assigned_by=admin.id,
     ))
     test_db.flush()
 

--- a/services/frontend/e2e/helpers/evaluation-helpers.ts
+++ b/services/frontend/e2e/helpers/evaluation-helpers.ts
@@ -256,11 +256,51 @@ export class EvaluationHelpers {
   }
 
   /**
+   * Expand the inner "Evaluierungsmethoden" / "Evaluation Methods" SubSection
+   * inside the (already-opened) Evaluation ConfigCard. The EvaluationBuilder
+   * — and therefore the Add Evaluation button — only renders when this
+   * SubSection is open. SubSection defaults to collapsed.
+   *
+   * Idempotent: silent no-op if the section is already expanded (button
+   * already in DOM).
+   */
+  async expandEvaluationMethodsSection(): Promise<void> {
+    if (
+      await this.page
+        .locator('[data-testid="add-evaluation-button"]')
+        .isVisible({ timeout: 500 })
+        .catch(() => false)
+    ) {
+      return
+    }
+
+    const sectionTitles = [
+      'Evaluierungsmethoden',
+      'Evaluation Methods',
+      'Evaluation Methoden',
+    ]
+    for (const title of sectionTitles) {
+      const header = this.page.locator(`button:has(h2:text-is("${title}"))`).first()
+      if (await header.isVisible({ timeout: 1000 }).catch(() => false)) {
+        await header.click()
+        await this.page.waitForTimeout(500)
+        return
+      }
+    }
+    // Don't throw — fall through and let openAddEvaluationWizard surface the
+    // real failure ("Add Evaluation button not found"). A locale change or
+    // SubSection rename should still produce that diagnosable error.
+  }
+
+  /**
    * Click "Add Evaluation" button to open the wizard
    * Throws if button cannot be found
    */
   async openAddEvaluationWizard(): Promise<void> {
     console.log(`[openAddEvaluationWizard] starting at URL: ${this.page.url()}`)
+    // The button lives inside a SubSection that's collapsed by default —
+    // expand it first so the button is in the DOM.
+    await this.expandEvaluationMethodsSection()
     const testIdButton = this.page.locator('[data-testid="add-evaluation-button"]')
     if (await testIdButton.isVisible({ timeout: 3000 }).catch(() => false)) {
       await testIdButton.click()


### PR DESCRIPTION
## Summary
Two more nightly-only test surfaces cleaned up after the post-#78 run revealed them:

1. **\`test_cost_estimate_subject_count.py\`** — fixture creates \`ProjectOrganization\` rows without \`assigned_by\` (NOT NULL since baseline 001). Test was added 2026-05-09 and never saw green CI because of the seed crash. All 10 tests ERRORed at setup; one-line fix.

2. **\`e2e/helpers/evaluation-helpers.ts\`** — the Evaluation ConfigCard redesign moved the \`EvaluationBuilder\` (and therefore the Add Evaluation button) inside a \`SubSection\` titled "Evaluierungsmethoden" / "Evaluation Methods" that defaults to collapsed. The button isn't in the DOM until the sub-section is expanded. \`openAddEvaluationWizard\` now expands it first; idempotent if already open. Closes out canyon plan's 16 LLM-Judge spec failures.

## Why
Both were hidden behind the \`uq_generations_parent_run_index\` collision until PRs #76, #77, #78 unblocked seeding. Post-seed, they're now diagnosable and trivially fixable.

## Test plan
- [ ] PR CI green
- [ ] Re-trigger nightly; \`test_cost_estimate_subject_count.py\` 10 ERRORs → 10 PASS, LLM-Judge 16 FAIL → PASS