### PR TITLE
fix(tests): drop bogus project_id kwarg on Generation in cost-estimate fixture

### DIFF
--- a/services/api/tests/integration/test_cost_estimate_subject_count.py
+++ b/services/api/tests/integration/test_cost_estimate_subject_count.py
@@ -123,9 +123,10 @@ def _seed_project_with_subjects(
             )
             test_db.add(rg)
             test_db.flush()
+            # Generation has no project_id column — the cost-estimate
+            # filter joins via ResponseGeneration.project_id instead.
             test_db.add(Generation(
                 id=str(uuid.uuid4()),
-                project_id=project.id,  # used by cost_estimate filter
                 generation_id=rg.id,
                 task_id=task.id,
                 model_id=model_id,


### PR DESCRIPTION
## Summary
Drops the \`project_id=project.id\` kwarg from the \`Generation(...)\` constructor in \`test_cost_estimate_subject_count.py\`. Generation has no project_id column — the FK is through ResponseGeneration.

## Why
PR #79 cleared the first fixture bug (NOT NULL \`assigned_by\` on ProjectOrganization). The same fixture has a second latent bug at line 126: a TypeError on the bogus kwarg. The inline comment ("used by cost_estimate filter") was wishful thinking — the actual filter joins via ResponseGeneration.project_id.

Was hidden until PR #79 unblocked the assigned_by failure.

## Test plan
- [ ] PR CI green
- [ ] After merge + nightly: 10 ERRORs in test_cost_estimate_subject_count.py → 10 PASS