### PR TITLE
fix(tests): set case_data on Generation in cost-estimate fixture

### DIFF
--- a/services/api/tests/integration/test_cost_estimate_subject_count.py
+++ b/services/api/tests/integration/test_cost_estimate_subject_count.py
@@ -130,6 +130,7 @@ def _seed_project_with_subjects(
                 generation_id=rg.id,
                 task_id=task.id,
                 model_id=model_id,
+                case_data="{}",
                 response_content="...",
                 status="completed",
                 parse_status="success",


### PR DESCRIPTION
## Summary
Third latent bug in the same cost-estimate fixture (after #79 and #80). \`Generation.case_data\` is NOT NULL but the fixture never set it. Surfaced once PR #80 unblocked the previous bug.

## Why
Same hidden-behind-earlier-failure pattern. The fixture was authored 2026-05-09 with several missing-required-field bugs. Each layer was hidden by the next-earliest IntegrityError until the layer in front got fixed.

## Test plan
- [ ] CI green
- [ ] After merge + nightly: \`test_cost_estimate_subject_count.py\` 10 FAIL → 10 PASS

(If the next nightly surfaces yet another missing field in this fixture, we'll fix that too. Should be the last layer.)