### PR TITLE
i18n(korrektur): add highlights.selectTextNoLabel hint

### DIFF
--- a/services/frontend/src/locales/de/common.json
+++ b/services/frontend/src/locales/de/common.json
@@ -7581,7 +7581,8 @@
       "general": "Allgemeine Kommentare"
     },
     "highlights": {
-      "selectText": "Wählen Sie ein Label und markieren Sie Text, um einen Kommentar hinzuzufügen"
+      "selectText": "Wählen Sie ein Label und markieren Sie Text, um einen Kommentar hinzuzufügen",
+      "selectTextNoLabel": "Markiere Text in der Lösung, um einen Kommentar zu setzen."
     },
     "evaluations": {
       "title": "Evaluierungsergebnisse",

--- a/services/frontend/src/locales/en/common.json
+++ b/services/frontend/src/locales/en/common.json
@@ -7524,7 +7524,8 @@
       "general": "General Comments"
     },
     "highlights": {
-      "selectText": "Select a label, then highlight text to comment on it"
+      "selectText": "Select a label, then highlight text to comment on it",
+      "selectTextNoLabel": "Select text in the solution to leave an inline comment."
     },
     "evaluations": {
       "title": "Evaluation Results",


### PR DESCRIPTION
## Summary

Adds a single i18n string in `de` and `en` used by the extended-repo Korrektur Review tab to make the inline-comment-on-Lösung flow discoverable on projects that don't define a label taxonomy (`korrektur_config` null or empty).

- de: "Markiere Text in der Lösung, um einen Kommentar zu setzen."
- en: "Select text in the solution to leave an inline comment."

The consuming PR in `benger-extended` removes the label-first gate on text selection so a grader can drag-select directly on the Lösung and comment inline, mirroring the annotation-time span-comment flow on the Angabe field.

## Test plan

- [x] JSON syntax validates (`python3 -c "import json; json.load(open(...))"`)
- [x] Existing `highlights.selectText` key still in place (no rename / removal)