### PR TITLE
fix(projects): hide annotation buttons when annotation visibility off

### DIFF
--- a/services/frontend/src/app/projects/[id]/page.tsx
+++ b/services/frontend/src/app/projects/[id]/page.tsx
@@ -3794,23 +3794,27 @@ export default function ProjectDetailPage({ params }: ProjectDetailPageProps) {
               {t('project.quickActions.title')}
             </h2>
             <div className="space-y-3">
-              {userCompletedAllTasks && (
-                <div className="flex w-full items-center justify-center gap-2 rounded-md bg-emerald-50 px-4 py-2.5 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400">
-                  <CheckCircleIcon className="h-5 w-5" />
-                  <span className="font-medium">
-                    {t('project.quickActions.allTasksAnnotated')}
-                  </span>
-                </div>
+              {currentProject.enable_annotation !== false && (
+                <>
+                  {userCompletedAllTasks && (
+                    <div className="flex w-full items-center justify-center gap-2 rounded-md bg-emerald-50 px-4 py-2.5 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400">
+                      <CheckCircleIcon className="h-5 w-5" />
+                      <span className="font-medium">
+                        {t('project.quickActions.allTasksAnnotated')}
+                      </span>
+                    </div>
+                  )}
+                  <Button
+                    onClick={handleStartLabeling}
+                    variant="primary"
+                    className="w-full"
+                    disabled={currentProject.task_count === 0}
+                  >
+                    <PlayIcon className="mr-2 h-4 w-4" />
+                    {t('project.quickActions.startLabeling')}
+                  </Button>
+                </>
               )}
-              <Button
-                onClick={handleStartLabeling}
-                variant="primary"
-                className="w-full"
-                disabled={currentProject.task_count === 0}
-              >
-                <PlayIcon className="mr-2 h-4 w-4" />
-                {t('project.quickActions.startLabeling')}
-              </Button>
 
               {canSeeQuickAction('projectData') && (
                 <Button

--- a/services/frontend/src/components/projects/ProjectListTable.tsx
+++ b/services/frontend/src/components/projects/ProjectListTable.tsx
@@ -820,15 +820,17 @@ export function ProjectListTable({
                         })}
                       </td>
                       <td className="whitespace-nowrap px-6 py-4 text-right text-sm font-medium">
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            router.push(`/projects/${project.id}/label`)
-                          }}
-                          className="mr-4 text-emerald-600 hover:text-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
-                        >
-                          {t('projects.list.label')}
-                        </button>
+                        {project.enable_annotation !== false && (
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              router.push(`/projects/${project.id}/label`)
+                            }}
+                            className="mr-4 text-emerald-600 hover:text-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+                          >
+                            {t('projects.list.label')}
+                          </button>
+                        )}
                       </td>
                     </tr>
                   )


### PR DESCRIPTION
Follow-up to PR #86. Two UI surfaces still exposed annotation entry points even when a project had **Annotationskonfiguration** disabled in Settings → Section visibility:

- Project detail page → **Schnellaktionen**: the "Annotation starten" primary button (plus the "all tasks annotated" success badge).
- Project list page: the **Annotieren** action button at the end of each project row.

Both now gate on `enable_annotation !== false`, matching how the Statistiken tiles and the Annotation config card already behave.

## Test plan

- [x] Frontend: `npm test -- --testPathPatterns=ProjectListTable` → 100/100 pass.
- [x] Manual browser: in the dev stack on Benchaton 2 → toggle Annotationskonfiguration off → confirmed "Annotation starten" disappears from Schnellaktionen and "Annotieren" disappears from the row in the project list. Toggled back on, both reappear.
- [ ] After merge to prod: confirm same behavior on what-a-benger.net.

## Notes for merge button

Merging deploys directly to **production** (same path as PR #86). Diff is two files, six lines effective.