### PR TITLE
fix(stats): count scored (subject, metric) pairs for Evaluations tiles

### DIFF
--- a/services/api/routers/dashboard.py
+++ b/services/api/routers/dashboard.py
@@ -10,8 +10,13 @@ from sqlalchemy.orm import Session
 
 from auth_module import User, require_user
 from database import get_db
+from models import EvaluationRun
 from redis_cache import RedisCache
-from routers.projects.helpers import get_accessible_project_ids
+from routers.projects.helpers import (
+    _metric_key_is_real,
+    _scored_pairs_query,
+    get_accessible_project_ids,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -36,8 +41,10 @@ async def get_dashboard_stats(
     """
     org_context = request.headers.get("X-Organization-Context")
 
-    # Create cache key based on user ID and org context
-    cache_key = f"dashboard_stats:{current_user.id}:{org_context or 'private'}"
+    # Create cache key based on user ID and org context. The `v2` suffix
+    # invalidates the old "count of task_evaluations rows" answer when this
+    # deploy lands — see _scored_pairs_query for the new semantics.
+    cache_key = f"dashboard_stats:v2:{current_user.id}:{org_context or 'private'}"
 
     # Try to get from cache first
     cached_stats = cache.get(cache_key)
@@ -68,8 +75,7 @@ async def get_dashboard_stats(
                     (SELECT COUNT(*) FROM projects) as project_count,
                     (SELECT COUNT(*) FROM tasks) as task_count,
                     (SELECT COUNT(*) FROM annotations WHERE jsonb_array_length(result) > 0 AND was_cancelled = false) as annotation_count,
-                    (SELECT COUNT(*) FROM generations) as projects_with_generations,
-                    (SELECT COUNT(*) FROM task_evaluations) as projects_with_evaluations
+                    (SELECT COUNT(*) FROM generations) as projects_with_generations
             """
             )
             result = db.execute(stats_query).fetchone()
@@ -90,21 +96,30 @@ async def get_dashboard_stats(
                      WHERE jsonb_array_length(a.result) > 0 AND a.was_cancelled = false) as annotation_count,
                     (SELECT COUNT(*) FROM generations g
                      INNER JOIN tasks t ON g.task_id = t.id
-                     INNER JOIN accessible_projects ap ON t.project_id = ap.id) as projects_with_generations,
-                    (SELECT COUNT(*) FROM task_evaluations te
-                     INNER JOIN evaluation_runs er ON te.evaluation_id = er.id
-                     INNER JOIN accessible_projects ap ON er.project_id = ap.id) as projects_with_evaluations
+                     INNER JOIN accessible_projects ap ON t.project_id = ap.id) as projects_with_generations
             """
             bind_params = {f"pid_{i}": pid for i, pid in enumerate(accessible_ids)}
             stats_query = text(stats_query_str).bindparams(**bind_params)
             result = db.execute(stats_query).fetchone()
+
+        # Evaluations: distinct (subject, metric) pairs that have at least one
+        # scored row in a completed run. Same definition as the project page
+        # tile — see helpers._scored_pairs_query.
+        scored_pairs_q = _scored_pairs_query(db).distinct()
+        if accessible_ids is not None:
+            scored_pairs_q = scored_pairs_q.filter(
+                EvaluationRun.project_id.in_(accessible_ids)
+            )
+        evaluations_count = sum(
+            1 for _pid, sub_id, mk in scored_pairs_q.all() if _metric_key_is_real(mk)
+        )
 
         stats = {
             "project_count": result.project_count if result else 0,
             "task_count": result.task_count if result else 0,
             "annotation_count": result.annotation_count if result else 0,
             "projects_with_generations": result.projects_with_generations if result else 0,
-            "projects_with_evaluations": result.projects_with_evaluations if result else 0,
+            "projects_with_evaluations": evaluations_count,
         }
 
         # Cache the results for 5 minutes (dashboard stats don't change frequently)

--- a/services/api/routers/projects/helpers.py
+++ b/services/api/routers/projects/helpers.py
@@ -8,7 +8,8 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from fastapi import Depends, HTTPException, Request
-from sqlalchemy import case, func
+from sqlalchemy import case, cast, func
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Session, joinedload
 
 from auth_module import require_user
@@ -38,6 +39,44 @@ from project_models import (
     TaskAssignment,
 )
 from project_schemas import ProjectResponse
+
+
+# Metric-key noise stripped out of the "scored (subject, metric) pairs" tally.
+# Mirrors the dropdown filter in routers/evaluations/metadata.py so the tile and
+# the metric list agree on what counts as a "real" metric.
+_METRIC_NOISE_SUFFIXES = ("_details", "_raw", "_passed", "_grade_points", "_response")
+_METRIC_EXCLUDED_KEYS = {"raw_score", "error"}
+
+
+def _metric_key_is_real(key: Optional[str]) -> bool:
+    if not key or key in _METRIC_EXCLUDED_KEYS:
+        return False
+    return not key.endswith(_METRIC_NOISE_SUFFIXES)
+
+
+def _scored_pairs_query(db: Session):
+    """Base query that yields (project_id, subject_id, metric_key) for every
+    (annotation|generation, metric) pair that has at least one scored row in a
+    completed evaluation run. Caller adds project filters + DISTINCT."""
+    subject_expr = func.coalesce(
+        TaskEvaluation.annotation_id, TaskEvaluation.generation_id
+    )
+    metrics_jsonb = cast(TaskEvaluation.metrics, JSONB)
+    return (
+        db.query(
+            EvaluationRun.project_id,
+            subject_expr.label("subject_id"),
+            func.jsonb_object_keys(metrics_jsonb).label("metric_key"),
+        )
+        .select_from(TaskEvaluation)
+        .join(EvaluationRun, EvaluationRun.id == TaskEvaluation.evaluation_id)
+        .filter(
+            EvaluationRun.status == "completed",
+            subject_expr.isnot(None),
+            TaskEvaluation.metrics.isnot(None),
+            func.jsonb_typeof(metrics_jsonb) == "object",
+        )
+    )
 
 
 def _generation_models_count(project: Project) -> int:
@@ -176,18 +215,21 @@ def calculate_project_stats(
             .count()
         )
 
-    # Evaluation tallies — feed the Statistiken tile and the progress mix.
-    response.evaluation_count = (
-        db.query(EvaluationRun).filter(EvaluationRun.project_id == project_id).count()
+    # Evaluation tallies — count distinct (subject, metric) pairs that have at
+    # least one scored row in a completed run. Matches the user's intuition of
+    # "how many of my answers have been evaluated on how many metrics"; the old
+    # job-count masked partial coverage (a 1-job run scoring 314 of 500
+    # subjects looked identical to a fully-scored run).
+    pairs = (
+        _scored_pairs_query(db)
+        .filter(EvaluationRun.project_id == project_id)
+        .distinct()
+        .all()
     )
-    response.evaluations_completed_count = (
-        db.query(EvaluationRun)
-        .filter(
-            EvaluationRun.project_id == project_id,
-            EvaluationRun.status == "completed",
-        )
-        .count()
+    response.evaluation_count = sum(
+        1 for _pid, sub_id, mk in pairs if _metric_key_is_real(mk)
     )
+    response.evaluations_completed_count = response.evaluation_count
 
     # Mirror to the legacy aliases so frontends reading either name see the
     # same value (the labeling page reads num_tasks for the "Task X of Y"
@@ -245,24 +287,21 @@ def calculate_project_stats_batch(db: Session, project_ids: List[str]) -> Dict[s
         .group_by(Annotation.project_id)
     )
 
-    # Query 3: EvaluationRun stats — total runs + completed runs per project.
-    # Feeds both the Statistiken "Evaluations" tile and the progress mix.
-    evaluation_stats_query = (
-        db.query(
-            EvaluationRun.project_id,
-            func.count(EvaluationRun.id).label('evaluation_count'),
-            func.sum(
-                case((EvaluationRun.status == 'completed', 1), else_=0)
-            ).label('evaluations_completed_count'),
-        )
+    # Query 3: Scored (subject, metric) pairs per project. Same definition as
+    # the single-project path — see calculate_project_stats for the rationale.
+    # Pulls DISTINCT (project_id, subject_id, metric_key) tuples and counts in
+    # Python so we can strip noise keys (_raw, _details, etc.) consistently
+    # with routers/evaluations/metadata.py.
+    evaluation_pairs_query = (
+        _scored_pairs_query(db)
         .filter(EvaluationRun.project_id.in_(project_ids))
-        .group_by(EvaluationRun.project_id)
+        .distinct()
     )
 
     # Execute queries
     task_stats = task_stats_query.all()
     annotation_stats = annotation_stats_query.all()
-    evaluation_stats = evaluation_stats_query.all()
+    evaluation_pairs = evaluation_pairs_query.all()
 
     # Build stats lookup dictionary
     stats_map = {}
@@ -286,12 +325,17 @@ def calculate_project_stats_batch(db: Session, project_ids: List[str]) -> Dict[s
     for stat in annotation_stats:
         stats_map[stat.project_id]['annotation_count'] = stat.annotation_count or 0
 
-    # Populate evaluation stats
-    for stat in evaluation_stats:
-        stats_map[stat.project_id]['evaluation_count'] = stat.evaluation_count or 0
-        stats_map[stat.project_id]['evaluations_completed_count'] = (
-            stat.evaluations_completed_count or 0
-        )
+    # Populate evaluation stats — count scored (subject, metric) pairs per
+    # project after filtering noise keys.
+    for project_id, _sub_id, metric_key in evaluation_pairs:
+        if not _metric_key_is_real(metric_key):
+            continue
+        if project_id in stats_map:
+            stats_map[project_id]['evaluation_count'] += 1
+    for project_id in project_ids:
+        stats_map[project_id]['evaluations_completed_count'] = stats_map[project_id][
+            'evaluation_count'
+        ]
 
     return stats_map
 

--- a/services/api/tests/routers/projects/test_helpers.py
+++ b/services/api/tests/routers/projects/test_helpers.py
@@ -27,8 +27,13 @@ def test_calculate_project_stats_batch_with_projects():
         Mock(project_id='p2', annotation_count=18),
     ]
 
-    evaluation_stats = [
-        Mock(project_id='p1', evaluation_count=3, evaluations_completed_count=2),
+    # Scored (subject, metric) pairs. p1 has 3 distinct pairs (one is a
+    # noise key — `_raw` — that must be filtered out), p2 has none.
+    evaluation_pairs = [
+        ('p1', 'ann-1', 'bleu'),
+        ('p1', 'ann-1', 'rouge'),
+        ('p1', 'ann-2', 'bleu'),
+        ('p1', 'ann-2', 'bleu_raw'),  # noise suffix, should be dropped
     ]
 
     # Setup mock query chain for task stats
@@ -41,11 +46,13 @@ def test_calculate_project_stats_batch_with_projects():
         annotation_stats
     )
 
-    # Setup mock query chain for evaluation stats
+    # Setup mock query chain for scored-pairs query. Chain shape:
+    # db.query(...).select_from(...).join(...).filter(...)  ← from _scored_pairs_query
+    #   .filter(...).distinct().all()                       ← appended in batch path
     evaluation_query_mock = Mock()
-    evaluation_query_mock.filter.return_value.group_by.return_value.all.return_value = (
-        evaluation_stats
-    )
+    (
+        evaluation_query_mock.select_from.return_value.join.return_value.filter.return_value.filter.return_value.distinct.return_value.all.return_value
+    ) = evaluation_pairs
 
     # Setup db.query to return different mocks on consecutive calls
     db.query.side_effect = [task_query_mock, annotation_query_mock, evaluation_query_mock]
@@ -59,8 +66,9 @@ def test_calculate_project_stats_batch_with_projects():
     assert result['p1']['task_count'] == 10
     assert result['p1']['completed_tasks_count'] == 5
     assert result['p1']['annotation_count'] == 8
+    # 3 real pairs (bleu_raw filtered as noise)
     assert result['p1']['evaluation_count'] == 3
-    assert result['p1']['evaluations_completed_count'] == 2
+    assert result['p1']['evaluations_completed_count'] == 3
     assert result['p2']['task_count'] == 20
     assert result['p2']['completed_tasks_count'] == 15
     assert result['p2']['annotation_count'] == 18
@@ -94,7 +102,9 @@ def test_calculate_project_stats_batch_missing_annotations():
 
     # No evaluation rows for either project
     evaluation_query_mock = Mock()
-    evaluation_query_mock.filter.return_value.group_by.return_value.all.return_value = []
+    (
+        evaluation_query_mock.select_from.return_value.join.return_value.filter.return_value.filter.return_value.distinct.return_value.all.return_value
+    ) = []
 
     db.query.side_effect = [task_query_mock, annotation_query_mock, evaluation_query_mock]
 
@@ -117,8 +127,8 @@ def _annotation_only_project_mock():
     """Project mock with only the annotation stage enabled.
 
     Generation/evaluation are disabled so calculate_project_stats only fires
-    the task / annotation / completed-task / evaluation-count count queries
-    (5 total). Configs are None so the gen_models_count branch is also skipped.
+    the task / annotation / completed-task / scored-pairs queries (4 total).
+    Configs are None so the gen_models_count branch is also skipped.
     """
     project = Mock()
     project.enable_annotation = True
@@ -127,6 +137,15 @@ def _annotation_only_project_mock():
     project.generation_config = None
     project.evaluation_config = None
     return project
+
+
+def _empty_scored_pairs_query_mock():
+    """Mock chain matching _scored_pairs_query(...).filter(...).distinct().all() == []."""
+    q = Mock()
+    (
+        q.select_from.return_value.join.return_value.filter.return_value.filter.return_value.distinct.return_value.all.return_value
+    ) = []
+    return q
 
 
 def test_calculate_project_stats():
@@ -146,19 +165,15 @@ def test_calculate_project_stats():
     completed_tasks_query = Mock()
     completed_tasks_query.filter.return_value.count.return_value = 5
 
-    # Evaluation count + completed-evaluation count queries (always fire, used
-    # for the Statistiken tile even when enable_evaluation is False).
-    evaluation_count_query = Mock()
-    evaluation_count_query.filter.return_value.count.return_value = 0
-    evaluations_completed_query = Mock()
-    evaluations_completed_query.filter.return_value.count.return_value = 0
+    # Scored (subject, metric) pairs query — always fires, used for the
+    # Statistiken tile even when enable_evaluation is False.
+    scored_pairs_query = _empty_scored_pairs_query_mock()
 
     db.query.side_effect = [
         task_count_query,
         annotation_count_query,
         completed_tasks_query,
-        evaluation_count_query,
-        evaluations_completed_query,
+        scored_pairs_query,
     ]
 
     calculate_project_stats(
@@ -177,8 +192,16 @@ def test_calculate_project_stats_zero_tasks():
     db = Mock()
     response = Mock()
 
-    # All counts are zero
-    db.query.return_value.filter.return_value.count.return_value = 0
+    # task / annotation / completed_tasks all return 0; scored-pairs returns []
+    count_query = Mock()
+    count_query.filter.return_value.count.return_value = 0
+
+    db.query.side_effect = [
+        count_query,  # task_count
+        count_query,  # annotation_count
+        count_query,  # completed_tasks_count
+        _empty_scored_pairs_query_mock(),
+    ]
 
     calculate_project_stats(
         db, 'empty-project', response, project=_annotation_only_project_mock()

--- a/services/frontend/src/app/dashboard/page.tsx
+++ b/services/frontend/src/app/dashboard/page.tsx
@@ -11,6 +11,11 @@ import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
+// Compact a stat-tile count into a fixed-width form so 6+ digit values don't
+// overflow the card. 100000 -> "100k", 1234567 -> "1234k".
+const formatStatCount = (n: number): string =>
+  n >= 100000 ? `${Math.floor(n / 1000)}k` : String(n)
+
 export default function DashboardPage() {
   const { t } = useI18n()
   const { projects, fetchProjects, loading } = useProjectStore()
@@ -158,7 +163,7 @@ export default function DashboardPage() {
                     {t('dashboard.stats.projects')}
                   </dt>
                   <dd className="text-lg font-medium text-zinc-900 dark:text-white">
-                    {dashboardStats.project_count}
+                    {formatStatCount(dashboardStats.project_count)}
                   </dd>
                 </dl>
               </div>
@@ -193,7 +198,7 @@ export default function DashboardPage() {
                     {t('dashboard.stats.issues')}
                   </dt>
                   <dd className="text-lg font-medium text-zinc-900 dark:text-white">
-                    {dashboardStats.task_count}
+                    {formatStatCount(dashboardStats.task_count)}
                   </dd>
                 </dl>
               </div>
@@ -228,7 +233,7 @@ export default function DashboardPage() {
                     {t('dashboard.stats.annotations')}
                   </dt>
                   <dd className="text-lg font-medium text-zinc-900 dark:text-white">
-                    {dashboardStats.annotation_count}
+                    {formatStatCount(dashboardStats.annotation_count)}
                   </dd>
                 </dl>
               </div>
@@ -263,7 +268,7 @@ export default function DashboardPage() {
                     {t('dashboard.stats.generations')}
                   </dt>
                   <dd className="text-lg font-medium text-zinc-900 dark:text-white">
-                    {dashboardStats.projects_with_generations}
+                    {formatStatCount(dashboardStats.projects_with_generations)}
                   </dd>
                 </dl>
               </div>
@@ -298,7 +303,7 @@ export default function DashboardPage() {
                     {t('dashboard.stats.evaluations')}
                   </dt>
                   <dd className="text-lg font-medium text-zinc-900 dark:text-white">
-                    {dashboardStats.projects_with_evaluations}
+                    {formatStatCount(dashboardStats.projects_with_evaluations)}
                   </dd>
                 </dl>
               </div>


### PR DESCRIPTION
## Summary

- **Unifies the "Evaluations" count** on the project page and dashboard. Both now count distinct `(subject, metric)` pairs that have at least one scored row in a completed `EvaluationRun`. Previously the project page counted `evaluation_runs` rows (job count) and the dashboard counted `task_evaluations` rows (per-task × metric × judge_run × subject) — same label, different math. Benchathon showed `314` (jobs) instead of the thousands of scored pairs the user expected.
- **Includes korrektur human grades.** `human_eval_runs.get_or_create_human_eval_run` creates the singleton EvaluationRun with `status="completed"`, so the new filter picks up `korrektur_falloesung` pairs alongside LLM-judge metrics. Verified on dev DB: 13 korrektur task_evaluations → 9 distinct (subject, metric) pairs (multi-grader runs de-duplicate correctly).
- **Strips metric-key noise** (`_raw`, `_details`, `_passed`, `_grade_points`, `_response`, plus literal `raw_score`/`error`) so the tile matches the metric-name list in `routers/evaluations/metadata.py`.
- **Dashboard cache key bumped to `v2`** so the new value lands immediately at deploy time (no 5-minute stale window from the old answer).
- **Dashboard stat tiles k-format** values ≥100k as `Xk` (`100000 → 100k`, `1234567 → 1234k`) so 6+ digit counts don't overflow the cards.

## Knock-on (out of scope, follow-up)

`helpers._progress_parts` still uses the old `gen_models × eval_methods` denominator for the evaluation stage of the progress bar. With the new numerator (scored pairs) and old denominator (job count), the eval stage will read ~100% / be cap-clamped until the denominator is reworked to `(annotation_count + total_generation_count) × eval_methods_count`. Tracking separately.

## Test plan

- [x] `pytest tests/routers/projects/` — 92 passed (no regressions)
- [x] `pytest tests/routers/projects/test_helpers.py` — 10 passed (mocks updated for new query chain)
- [x] SQL probe on dev DB: `_scored_pairs_query` returns 7662 raw distinct tuples → 5705 after noise filter → matches per-project counts 3594 + 2111
- [x] End-to-end browser check on `http://benger.localhost/dashboard`: Evaluierungen tile shows `5705`
- [x] Korrektur verification: 13 task_evaluations with `korrektur_falloesung` → all under `status='completed'` runs → 9 distinct (subject, metric) pairs picked up by the new query
- [x] K-format spot check: `99999 → 99999`, `100000 → 100k`, `1234567 → 1234k`
- [ ] Post-merge: hit `/api/dashboard/stats` on prod and confirm cache-key `v2` returns fresh values