### PR TITLE
fix(auth): repair end-to-end password reset flow

### DIFF
--- a/services/api/app/auth_module/password_reset.py
+++ b/services/api/app/auth_module/password_reset.py
@@ -133,7 +133,7 @@ class PasswordResetService:
         Args:
             db: Database session
             user: User to send email to
-            base_url: Base URL for reset link
+            base_url: Base URL for reset link (used as fallback if FRONTEND_URL is unset)
             language: Language for email template
 
         Returns:
@@ -141,74 +141,20 @@ class PasswordResetService:
         """
         import os
 
-        from app.email_service import EmailService
+        from email_service import EmailService
 
-        # Generate reset token
         token = self.create_password_reset_token(db, user)
 
-        # Use FRONTEND_URL from environment
         frontend_url = os.getenv("FRONTEND_URL", base_url)
         reset_link = f"{frontend_url}/reset-password/{token}"
 
-        # Prepare email content
-        if language == "de":
-            subject = "Passwort zurücksetzen - BenGER"
-            html_body = f"""
-            <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-                <h2>Passwort zurücksetzen</h2>
-                <p>Hallo {user.name or user.username},</p>
-                <p>Sie haben eine Anfrage zum Zurücksetzen Ihres Passworts gestellt.</p>
-                <p>Klicken Sie auf den folgenden Link, um Ihr Passwort zurückzusetzen:</p>
-                <div style="margin: 30px 0;">
-                    <a href="{reset_link}" 
-                       style="background-color: #10b981; color: white; padding: 12px 24px; 
-                              text-decoration: none; border-radius: 6px; display: inline-block;">
-                        Passwort zurücksetzen
-                    </a>
-                </div>
-                <p>Oder kopieren Sie diesen Link in Ihren Browser:</p>
-                <p style="word-break: break-all; color: #6b7280;">{reset_link}</p>
-                <p>Dieser Link ist 24 Stunden gültig.</p>
-                <p>Falls Sie diese Anfrage nicht gestellt haben, können Sie diese E-Mail ignorieren.</p>
-                <hr style="margin: 30px 0; border: none; border-top: 1px solid #e5e7eb;">
-                <p style="color: #6b7280; font-size: 14px;">
-                    BenGER - Benchmark for German Legal Reasoning
-                </p>
-            </div>
-            """
-        else:
-            subject = "Reset Your Password - BenGER"
-            html_body = f"""
-            <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-                <h2>Reset Your Password</h2>
-                <p>Hello {user.name or user.username},</p>
-                <p>You have requested to reset your password.</p>
-                <p>Click the following link to reset your password:</p>
-                <div style="margin: 30px 0;">
-                    <a href="{reset_link}" 
-                       style="background-color: #10b981; color: white; padding: 12px 24px; 
-                              text-decoration: none; border-radius: 6px; display: inline-block;">
-                        Reset Password
-                    </a>
-                </div>
-                <p>Or copy this link to your browser:</p>
-                <p style="word-break: break-all; color: #6b7280;">{reset_link}</p>
-                <p>This link will expire in 24 hours.</p>
-                <p>If you didn't request this, you can safely ignore this email.</p>
-                <hr style="margin: 30px 0; border: none; border-top: 1px solid #e5e7eb;">
-                <p style="color: #6b7280; font-size: 14px;">
-                    BenGER - Benchmark for German Legal Reasoning
-                </p>
-            </div>
-            """
-
-        # Send email
         email_service = EmailService()
-        success = await email_service.send_email(
-            to_email=user.email, subject=subject, html_body=html_body
+        return await email_service.send_password_reset_email(
+            to_email=user.email,
+            user_name=user.name or user.username,
+            reset_link=reset_link,
+            language=language,
         )
-
-        return success
 
 
 # Create a singleton instance

--- a/services/api/services/email/email_service.py
+++ b/services/api/services/email/email_service.py
@@ -500,7 +500,7 @@ class EmailService:
                 <p>Oder kopieren Sie diesen Link in Ihren Browser:</p>
                 <p style="color: #007bff;">{reset_link}</p>
                 <p style="color: #666; font-size: 12px; margin-top: 30px;">
-                    Dieser Link ist 1 Stunde gültig. Falls Sie diese Anfrage nicht gestellt haben, können Sie diese E-Mail ignorieren.
+                    Dieser Link ist 24 Stunden gültig. Falls Sie diese Anfrage nicht gestellt haben, können Sie diese E-Mail ignorieren.
                 </p>
             </body>
             </html>
@@ -520,7 +520,7 @@ class EmailService:
                 <p>Or copy and paste this link into your browser:</p>
                 <p style="color: #007bff;">{reset_link}</p>
                 <p style="color: #666; font-size: 12px; margin-top: 30px;">
-                    This link will expire in 1 hour. If you didn't request this, you can safely ignore this email.
+                    This link will expire in 24 hours. If you didn't request this, you can safely ignore this email.
                 </p>
             </body>
             </html>

--- a/services/api/tests/unit/test_password_reset_service.py
+++ b/services/api/tests/unit/test_password_reset_service.py
@@ -1,0 +1,152 @@
+"""
+Integration-style tests for PasswordResetService.send_password_reset_email.
+
+These tests intentionally do NOT mock password_reset_service or EmailService —
+they exercise the real call chain all the way down to SendGridClient.send_message,
+which is the only thing stubbed. This is the test layer that catches:
+
+  * broken module imports inside the service (the bug that black-holed every
+    real password reset in prod until 2026-05-14)
+  * call-site/method-signature drift between PasswordResetService and EmailService
+
+Coverage that already exists under test_auth_router_coverage.py mocks
+`app.auth_module.password_reset.password_reset_service`, so it cannot see
+either class of bug.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_user():
+    user = MagicMock()
+    user.email = "user@example.com"
+    user.name = "Test User"
+    user.username = "test_user"
+    user.password_reset_token = None
+    user.password_reset_expires = None
+    return user
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    db.commit = MagicMock()
+    return db
+
+
+@pytest.mark.asyncio
+async def test_send_password_reset_email_end_to_end(mock_db, mock_user, monkeypatch):
+    """Full path: PasswordResetService -> EmailService -> SendGridClient.send_message.
+
+    Asserts the token is persisted on the user row, the link uses FRONTEND_URL,
+    and the SendGrid client receives a single message addressed to the user.
+    """
+    monkeypatch.setenv("FRONTEND_URL", "https://what-a-benger.net")
+
+    with patch("services.email.email_service.SendGridClient") as mock_sg_class, \
+         patch("database.SessionLocal"):
+        sg_instance = MagicMock()
+        sg_instance.send_message = MagicMock(return_value={"status": "success"})
+        mock_sg_class.return_value = sg_instance
+
+        from app.auth_module.password_reset import password_reset_service
+
+        ok = await password_reset_service.send_password_reset_email(
+            db=mock_db,
+            user=mock_user,
+            base_url="https://fallback.example",
+            language="de",
+        )
+
+    assert ok is True
+    assert mock_user.password_reset_token is not None
+    assert mock_user.password_reset_expires is not None
+    mock_db.commit.assert_called_once()
+
+    sg_instance.send_message.assert_called_once()
+    call_kwargs = sg_instance.send_message.call_args[1]
+    assert call_kwargs["to"] == ["user@example.com"]
+    assert "Passwort" in call_kwargs["subject"]
+    assert "https://what-a-benger.net/reset-password/" in call_kwargs["html_body"]
+    assert mock_user.password_reset_token in call_kwargs["html_body"]
+    # Template-declared duration must match PasswordResetService.TOKEN_EXPIRY_HOURS,
+    # otherwise users assume the link is dead before it actually expires.
+    assert "24 Stunden" in call_kwargs["html_body"]
+
+
+@pytest.mark.asyncio
+async def test_send_password_reset_email_propagates_sendgrid_failure(
+    mock_db, mock_user, monkeypatch
+):
+    """If SendGrid reports failure the service returns False, but the token
+    is still persisted (so admin diagnostics can find it and the email can
+    be re-issued without rotating the row)."""
+    monkeypatch.setenv("FRONTEND_URL", "https://what-a-benger.net")
+
+    with patch("services.email.email_service.SendGridClient") as mock_sg_class, \
+         patch("database.SessionLocal"):
+        sg_instance = MagicMock()
+        sg_instance.send_message = MagicMock(
+            return_value={"status": "error", "error": "boom"}
+        )
+        mock_sg_class.return_value = sg_instance
+
+        from app.auth_module.password_reset import password_reset_service
+
+        ok = await password_reset_service.send_password_reset_email(
+            db=mock_db, user=mock_user, base_url="https://fallback.example", language="en"
+        )
+
+    assert ok is False
+    assert mock_user.password_reset_token is not None
+
+
+@pytest.mark.asyncio
+async def test_send_password_reset_email_uses_username_when_name_missing(
+    mock_db, mock_user, monkeypatch
+):
+    monkeypatch.setenv("FRONTEND_URL", "https://what-a-benger.net")
+    mock_user.name = None
+
+    with patch("services.email.email_service.SendGridClient") as mock_sg_class, \
+         patch("database.SessionLocal"):
+        sg_instance = MagicMock()
+        sg_instance.send_message = MagicMock(return_value={"status": "success"})
+        mock_sg_class.return_value = sg_instance
+
+        from app.auth_module.password_reset import password_reset_service
+
+        ok = await password_reset_service.send_password_reset_email(
+            db=mock_db, user=mock_user, base_url="https://fallback.example", language="en"
+        )
+
+    assert ok is True
+    sent_html = sg_instance.send_message.call_args[1]["html_body"]
+    assert "test_user" in sent_html
+    assert "24 hours" in sent_html
+
+
+@pytest.mark.asyncio
+async def test_send_password_reset_email_falls_back_to_base_url(
+    mock_db, mock_user, monkeypatch
+):
+    """When FRONTEND_URL is unset the caller-supplied base_url is used."""
+    monkeypatch.delenv("FRONTEND_URL", raising=False)
+
+    with patch("services.email.email_service.SendGridClient") as mock_sg_class, \
+         patch("database.SessionLocal"):
+        sg_instance = MagicMock()
+        sg_instance.send_message = MagicMock(return_value={"status": "success"})
+        mock_sg_class.return_value = sg_instance
+
+        from app.auth_module.password_reset import password_reset_service
+
+        await password_reset_service.send_password_reset_email(
+            db=mock_db, user=mock_user, base_url="https://fallback.example", language="en"
+        )
+
+    sent_html = sg_instance.send_message.call_args[1]["html_body"]
+    assert "https://fallback.example/reset-password/" in sent_html

--- a/services/frontend/src/app/api/[...path]/__tests__/route.br3.test.ts
+++ b/services/frontend/src/app/api/[...path]/__tests__/route.br3.test.ts
@@ -43,7 +43,7 @@ describe('[...path] route branch coverage', () => {
     jest.restoreAllMocks()
   })
 
-  it('rejects auth endpoints (not verify-email)', async () => {
+  it('rejects auth endpoints not in the public allowlist', async () => {
     const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
       new Response('{}', { status: 200 })
     )
@@ -66,6 +66,34 @@ describe('[...path] route branch coverage', () => {
       { params: Promise.resolve({ path: ['auth', 'verify-email', 'token123'] }) }
     )
     expect(res.status).toBe(200)
+    fetchSpy.mockRestore()
+  })
+
+  it('allows auth/request-password-reset', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('{"message":"ok"}', { status: 200 })
+    )
+    const { POST } = require('../route')
+    const res = await POST(
+      makeRequest('benger.localhost', 'auth/request-password-reset', 'POST'),
+      { params: Promise.resolve({ path: ['auth', 'request-password-reset'] }) }
+    )
+    expect(res.status).toBe(200)
+    expect(fetchSpy).toHaveBeenCalled()
+    fetchSpy.mockRestore()
+  })
+
+  it('allows auth/reset-password', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('{"message":"ok"}', { status: 200 })
+    )
+    const { POST } = require('../route')
+    const res = await POST(
+      makeRequest('benger.localhost', 'auth/reset-password', 'POST'),
+      { params: Promise.resolve({ path: ['auth', 'reset-password'] }) }
+    )
+    expect(res.status).toBe(200)
+    expect(fetchSpy).toHaveBeenCalled()
     fetchSpy.mockRestore()
   })
 

--- a/services/frontend/src/app/api/[...path]/route.ts
+++ b/services/frontend/src/app/api/[...path]/route.ts
@@ -96,9 +96,20 @@ async function proxyRequest(
   try {
     const path = pathSegments.join('/')
 
-    // Allow verify-email endpoints through the catch-all
-    // Other auth endpoints have dedicated handlers for cookie management
-    if (path.startsWith('auth/') && !path.includes('verify-email')) {
+    // Auth endpoints that manage session cookies have dedicated handlers
+    // under src/app/api/auth/. Public auth endpoints (verify-email,
+    // request-password-reset, reset-password) don't touch cookies, so they
+    // are allowed through the catch-all here. Adding one to PUBLIC_AUTH_PATHS
+    // without a dedicated handler is intentional.
+    const PUBLIC_AUTH_PATHS = [
+      'verify-email',
+      'request-password-reset',
+      'reset-password',
+    ]
+    if (
+      path.startsWith('auth/') &&
+      !PUBLIC_AUTH_PATHS.some((p) => path.includes(p))
+    ) {
       logger.debug('Auth endpoint should use dedicated handler:', path)
       return NextResponse.json(
         { error: 'Use dedicated auth handler' },


### PR DESCRIPTION
Fixes #92.

## Summary

Production password reset has been 100% broken — the user-facing form's POST to `/api/auth/request-password-reset` was 400-rejected at the Next.js catch-all proxy before reaching the backend, and the same guard blocked `/api/auth/reset-password`, so even manually-issued tokens surfaced as "Dieser Zurücksetzungslink ist abgelaufen" on the reset page. Once the proxy block is lifted, three further latent bugs were waiting: a broken `from app.email_service` import in `password_reset.py`, a call to a non-existent `EmailService.send_email`, and a template that lied about a 1-hour TTL when the real one is 24 hours.

This PR fixes all four in one shot and adds the test coverage that should have caught the regression originally.

## Changes

- **`services/frontend/src/app/api/[...path]/route.ts`** — extend the public-auth allowlist to include `request-password-reset` and `reset-password` alongside `verify-email`. These endpoints don't manage session cookies, so the dedicated-handler rule doesn't apply.
- **`services/api/app/auth_module/password_reset.py`** — drop the broken `from app.email_service import EmailService` (wrong module path) and the non-existent `EmailService.send_email` call. Delegate to the existing typed `EmailService.send_password_reset_email`, deleting the duplicated bilingual HTML in the process. Net `-60 / +12` lines.
- **`services/api/services/email/email_service.py`** — bump the DE and EN password reset templates from "1 Stunde / 1 hour" to "24 Stunden / 24 hours" to match `PasswordResetService.TOKEN_EXPIRY_HOURS`.

## Tests

- **`services/frontend/src/app/api/[...path]/__tests__/route.br3.test.ts`** — new assertions that `auth/request-password-reset` and `auth/reset-password` are forwarded, plus the existing guard test for non-allowlisted auth paths still holds.
- **`services/api/tests/unit/test_password_reset_service.py`** — new integration-style suite that runs the full `PasswordResetService → EmailService → SendGridClient.send_message` chain with only the SendGrid HTTP boundary stubbed. The existing auth-router tests patched `password_reset_service` at the router boundary, which invisibly skipped both the broken import and the missing method — explicitly noted in the new file's docstring so this category of test isn't accidentally re-broken.

## Test plan

- [x] `make test-api FILE="tests/unit/test_password_reset_service.py"` — 4/4 pass
- [x] `make test-api FILE="tests/unit/test_email_service_coverage.py"` — 38/38 pass (template-text change doesn't regress existing assertions)
- [x] `make test-api FILE="tests/unit/test_auth_router_coverage.py" GREP="password"` — 8/8 pass
- [x] Frontend `npx jest src/app/api/[...path]/__tests__/route.{br3,test}.test.ts` — 124/124 pass
- [ ] Post-deploy: end-to-end through `https://what-a-benger.net/login` → "Passwort vergessen" → reset link → set new password → log in.

## Severity / deployment note

Critical user-facing bug. Merging this PR triggers the cross-repo dispatch to extended's `deploy-prod`. Until the deploy lands, the workaround is to set users' `hashed_password` directly in the DB via `kubectl exec` and hand them a temporary password.