### PR TITLE
feat(eval): per-cell Celery fan-out for run_evaluation (parallelize like generation)

### DIFF
--- a/infra/helm/benger/templates/deployment-workers.yaml
+++ b/infra/helm/benger/templates/deployment-workers.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Values.workers.name }}
           image: "{{ .Values.workers.image.repository }}:{{ .Values.workers.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.workers.image.pullPolicy }}
-          command: ["celery", "-A", "tasks", "worker", "--loglevel=info", "--concurrency={{ .Values.workers.concurrency | default 4 }}", "-Q", "celery,emails,default,generation"]
+          command: ["celery", "-A", "tasks", "worker", "--loglevel=info", "--concurrency={{ .Values.workers.concurrency | default 4 }}", "-Q", "celery,emails,default,generation,evaluation"]
           # Explicit empty args prevents server-side apply from preserving
           # an `args:` array set out-of-band via `kubectl patch`. Without
           # this, the container ran command + args (the same celery

--- a/infra/helm/benger/values.yaml
+++ b/infra/helm/benger/values.yaml
@@ -112,13 +112,20 @@ api:
 workers:
   name: workers
   replicaCount: 1
-  # Lowered from 8 to 4: each Celery fork loads its own copy of the
-  # embedding-based evaluators (BERTScore German BERT, MoverScore POT
-  # backend, sentence-transformers for semsim). With 8 forks all loading
-  # ~600MB models, peak memory ~5 GB just for models — easily blows past
-  # the worker limit on multi-metric runs. 4 still parallelizes nicely
-  # while halving peak resident model memory.
-  concurrency: 4
+  # Bumped 4 → 16 with the per-cell eval fan-out (PR #94). The legacy
+  # bundled `tasks.run_evaluation` ran serially in one fork so 4 was
+  # plenty; under chord fan-out each sub-task is one (task, generation)
+  # cell, and the worker needs 16+ concurrent forks to saturate the
+  # ZJS Fälle scale (6940 cells × 7 metrics) in 1–2 h instead of days.
+  #
+  # Memory budget rechecked: each fork still loads its own ~600 MB of
+  # embedding evaluators when those metrics are configured. With the
+  # 12 Gi worker limit (see `resources.limits.memory` below), 16 forks
+  # × 600 MB ≈ 9.6 Gi peak when all three embedding metrics fire — fits
+  # with headroom. Most evals (including ZJS Fälle, which is
+  # llm_judge_falloesung only) load no embeddings at all and stay well
+  # under the limit.
+  concurrency: 16
   deploymentStrategy:
     type: RollingUpdate
     rollingUpdate:

--- a/infra/helm/benger/values.yaml
+++ b/infra/helm/benger/values.yaml
@@ -112,20 +112,30 @@ api:
 workers:
   name: workers
   replicaCount: 1
-  # Bumped 4 → 16 with the per-cell eval fan-out (PR #94). The legacy
-  # bundled `tasks.run_evaluation` ran serially in one fork so 4 was
-  # plenty; under chord fan-out each sub-task is one (task, generation)
-  # cell, and the worker needs 16+ concurrent forks to saturate the
-  # ZJS Fälle scale (6940 cells × 7 metrics) in 1–2 h instead of days.
+  # Default kept at 4 to fit the 12 Gi worker memory limit for evals
+  # that load all three embedding-based evaluators (BERTScore +
+  # MoverScore + sentence-transformers) — each fork's full RSS reaches
+  # ~1.5–2 GB under those workloads (see the resources comment below;
+  # the bare ~600 MB figure is just weights, not tokenizer caches +
+  # SQLAlchemy buffers + Python overhead).
   #
-  # Memory budget rechecked: each fork still loads its own ~600 MB of
-  # embedding evaluators when those metrics are configured. With the
-  # 12 Gi worker limit (see `resources.limits.memory` below), 16 forks
-  # × 600 MB ≈ 9.6 Gi peak when all three embedding metrics fire — fits
-  # with headroom. Most evals (including ZJS Fälle, which is
-  # llm_judge_falloesung only) load no embeddings at all and stay well
-  # under the limit.
-  concurrency: 16
+  # The per-cell fan-out (PR #94) parallelizes evaluation across cells
+  # rather than relying on multi-fork concurrency, but for workloads
+  # that *don't* load embedding metrics (e.g. ZJS Fälle: llm_judge_
+  # falloesung only), operators can safely bump this to 16 to saturate
+  # the chord faster:
+  #
+  #   kubectl patch deployment/benger-workers -n benger --type=json \
+  #     -p '[{"op": "replace", "path": "/spec/template/spec/containers/0/command",
+  #          "value": ["celery","-A","tasks","worker","--loglevel=info",
+  #                    "--concurrency=16","-Q",
+  #                    "celery,emails,default,generation,evaluation"]}]'
+  #
+  # A future change can either (a) auto-tune concurrency by inspecting
+  # the config's metric set at orchestrator dispatch, or (b) raise the
+  # memory limit to ~24 Gi if the host has headroom (currently 22 Gi
+  # total / ~17 Gi free, so a 24 Gi pod wouldn't fit).
+  concurrency: 4
   deploymentStrategy:
     type: RollingUpdate
     rollingUpdate:

--- a/services/api/alembic/versions/048_unique_task_evaluation_cell.py
+++ b/services/api/alembic/versions/048_unique_task_evaluation_cell.py
@@ -1,0 +1,93 @@
+"""Add partial unique index on task_evaluations cell-tuple for dedup safety.
+
+The cell-level fan-out refactor (`tasks.evaluate_generation_cell`,
+`tasks.evaluate_annotation_cell`) needs an upsert target so concurrent
+sub-tasks for the same (evaluation, judge_run, gen-or-ann, field_name)
+land exactly one row instead of two. Today the eval pipeline runs in
+one Celery task with no concurrency, so duplicates have been avoided
+implicitly; under per-cell dispatch we need a DB-level guarantee.
+
+The index covers (evaluation_id, judge_run_id, COALESCE(generation_id,
+sentinel), COALESCE(annotation_id, sentinel), field_name). Exactly one
+of generation_id/annotation_id is non-null per row, so the sentinel
+trick gives a deterministic tuple either way. judge_run_id was tightened
+to NOT NULL in migration 043 so no COALESCE there.
+
+`WHERE evaluation_id IS NOT NULL` skips legacy orphan rows defensively
+(none observed in prod 2026-05-14, but cheap).
+
+Idempotent: pre-existing duplicates are deduped first, keeping the most
+recent row per tuple. The dedup window targets only rows that share the
+exact (evaluation_id, judge_run_id, gen, ann, field_name) — historical
+multi-attempt evaluations on the same cell (e.g., two separate eval_runs)
+have different evaluation_id and are left alone.
+
+Revision ID: 048_unique_task_evaluation_cell
+Revises: 047_drop_projects_organization_id
+Create Date: 2026-05-14
+"""
+
+from sqlalchemy import inspect
+
+from alembic import op
+
+
+revision = "048_unique_task_evaluation_cell"
+down_revision = "047_drop_projects_organization_id"
+branch_labels = None
+depends_on = None
+
+
+INDEX_NAME = "uq_task_evaluations_cell"
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    return index_name in {ix["name"] for ix in insp.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    if _index_exists("task_evaluations", INDEX_NAME):
+        return
+
+    # Dedup any pre-existing rows that would violate the unique constraint.
+    # Keep the latest by created_at; delete older duplicates.
+    op.execute(
+        """
+        DELETE FROM task_evaluations a
+        USING task_evaluations b
+        WHERE a.id <> b.id
+          AND a.evaluation_id IS NOT NULL
+          AND b.evaluation_id IS NOT NULL
+          AND a.evaluation_id = b.evaluation_id
+          AND a.judge_run_id = b.judge_run_id
+          AND COALESCE(a.generation_id, '00000000-0000-0000-0000-000000000000'::uuid)
+              = COALESCE(b.generation_id, '00000000-0000-0000-0000-000000000000'::uuid)
+          AND COALESCE(a.annotation_id, '00000000-0000-0000-0000-000000000000'::uuid)
+              = COALESCE(b.annotation_id, '00000000-0000-0000-0000-000000000000'::uuid)
+          AND a.field_name = b.field_name
+          AND (a.created_at < b.created_at
+               OR (a.created_at = b.created_at AND a.id < b.id))
+        """
+    )
+
+    op.execute(
+        f"""
+        CREATE UNIQUE INDEX {INDEX_NAME}
+        ON task_evaluations (
+            evaluation_id,
+            judge_run_id,
+            COALESCE(generation_id, '00000000-0000-0000-0000-000000000000'::uuid),
+            COALESCE(annotation_id, '00000000-0000-0000-0000-000000000000'::uuid),
+            field_name
+        )
+        WHERE evaluation_id IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    if not _index_exists("task_evaluations", INDEX_NAME):
+        return
+    op.execute(f"DROP INDEX {INDEX_NAME}")

--- a/services/api/alembic/versions/048_unique_task_evaluation_cell.py
+++ b/services/api/alembic/versions/048_unique_task_evaluation_cell.py
@@ -62,10 +62,10 @@ def upgrade() -> None:
           AND b.evaluation_id IS NOT NULL
           AND a.evaluation_id = b.evaluation_id
           AND a.judge_run_id = b.judge_run_id
-          AND COALESCE(a.generation_id, '00000000-0000-0000-0000-000000000000'::uuid)
-              = COALESCE(b.generation_id, '00000000-0000-0000-0000-000000000000'::uuid)
-          AND COALESCE(a.annotation_id, '00000000-0000-0000-0000-000000000000'::uuid)
-              = COALESCE(b.annotation_id, '00000000-0000-0000-0000-000000000000'::uuid)
+          AND COALESCE(a.generation_id, '00000000-0000-0000-0000-000000000000')
+              = COALESCE(b.generation_id, '00000000-0000-0000-0000-000000000000')
+          AND COALESCE(a.annotation_id, '00000000-0000-0000-0000-000000000000')
+              = COALESCE(b.annotation_id, '00000000-0000-0000-0000-000000000000')
           AND a.field_name = b.field_name
           AND (a.created_at < b.created_at
                OR (a.created_at = b.created_at AND a.id < b.id))
@@ -78,8 +78,8 @@ def upgrade() -> None:
         ON task_evaluations (
             evaluation_id,
             judge_run_id,
-            COALESCE(generation_id, '00000000-0000-0000-0000-000000000000'::uuid),
-            COALESCE(annotation_id, '00000000-0000-0000-0000-000000000000'::uuid),
+            COALESCE(generation_id, '00000000-0000-0000-0000-000000000000'),
+            COALESCE(annotation_id, '00000000-0000-0000-0000-000000000000'),
             field_name
         )
         WHERE evaluation_id IS NOT NULL

--- a/services/api/routers/evaluations/multi_field.py
+++ b/services/api/routers/evaluations/multi_field.py
@@ -2,9 +2,11 @@
 Evaluation run endpoints (N:M field mapping).
 """
 
+import hashlib
+import json as _stdjson
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
@@ -314,24 +316,57 @@ async def run_evaluation(
         dispatched_configs = [_with_run_seed(c.dict()) for c in llm_configs]
 
         # Idempotency guard: if the same user just dispatched an
-        # evaluation against this project that's still in-flight, return
-        # that run's id instead of spawning a duplicate. Without this,
-        # a double-click on the "Run" button dispatched two chord-fan-outs
-        # that processed every cell twice — at ZJS Fälle scale that
-        # silently doubled the LLM bill. 30s window covers the
-        # accidental-double-click case without blocking legitimate
-        # sequential re-triggers.
+        # evaluation against this project with the SAME config payload
+        # that's still in-flight, return that run's id instead of
+        # spawning a duplicate. Without this, a double-click on the
+        # "Run" button dispatched two chord-fan-outs that processed
+        # every cell twice — at ZJS Fälle scale that silently doubled
+        # the LLM bill. 30s window covers the accidental-double-click
+        # case without blocking legitimate sequential re-triggers.
+        #
+        # Hash includes the config payload + scope filters so two
+        # legitimate distinct evals on the same project (e.g. BLEU on
+        # tasks 1-10 then ROUGE on tasks 11-20) don't collapse into
+        # one. Uses sha1 over a stable JSON serialization; hash lands
+        # in `eval_metadata.dispatch_hash` for lookup.
         from datetime import timedelta as _td
-        recent_inflight = (
+        dispatch_payload = {
+            "configs": dispatched_configs,
+            "task_ids": request.task_ids or [],
+            "model_ids": request.model_ids or [],
+            "annotator_user_ids": request.annotator_user_ids or [],
+            "force_rerun": request.force_rerun,
+        }
+        dispatch_hash = hashlib.sha1(
+            _stdjson.dumps(dispatch_payload, sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest()
+        # `datetime.now(timezone.utc)` matches the timezone-aware
+        # `created_at` column (`DateTime(timezone=True)`); a naive
+        # `datetime.now()` would compare local-clock-as-if-UTC and
+        # silently break the 30s window on any non-UTC host.
+        # Filter the hash match in Python rather than SQL: the column
+        # is mapped as the generic `JSON` type (not `JSONB`), so the
+        # SQLAlchemy `.astext` accessor isn't available. The 30s window
+        # bounds the candidate set to a handful of rows per user/project,
+        # so a Python-side scan is cheaper than adding a JSON index +
+        # custom dialect SQL just for this lookup.
+        recent_candidates = (
             db.query(DBEvaluationRun)
             .filter(
                 DBEvaluationRun.project_id == request.project_id,
                 DBEvaluationRun.created_by == current_user.id,
                 DBEvaluationRun.status.in_(("pending", "running")),
-                DBEvaluationRun.created_at >= datetime.now() - _td(seconds=30),
+                DBEvaluationRun.created_at >= datetime.now(timezone.utc) - _td(seconds=30),
             )
             .order_by(DBEvaluationRun.created_at.desc())
-            .first()
+            .all()
+        )
+        recent_inflight = next(
+            (
+                r for r in recent_candidates
+                if (r.eval_metadata or {}).get("dispatch_hash") == dispatch_hash
+            ),
+            None,
         )
         if recent_inflight is not None:
             return EvaluationRunResponse(
@@ -357,12 +392,17 @@ async def run_evaluation(
             evaluation_type_ids=evaluation_type_ids,
             metrics={},
             status="pending",
-            created_at=datetime.now(),
+            created_at=datetime.now(timezone.utc),
             created_by=current_user.id,
             samples_evaluated=0,
             eval_metadata={
                 "evaluation_type": "evaluation",
                 "triggered_by": current_user.id,
+                # Stable hash of the dispatch payload — used by the
+                # idempotency lookup to distinguish two legitimately
+                # different in-flight evals from a double-click on the
+                # same one.
+                "dispatch_hash": dispatch_hash,
                 "evaluation_configs": dispatched_configs,
                 "batch_size": request.batch_size,
                 "label_config_version": request.label_config_version,
@@ -589,12 +629,24 @@ async def cancel_evaluation_run(
         )
 
     org_context = get_org_context_from_request(http_request)
-    if not auth_service.check_project_access(
-        current_user, project, Permission.PROJECT_VIEW, db, org_context=org_context
-    ):
+    # Single-run cancel: allow the user who triggered the run to cancel
+    # it, OR anyone with project EDIT permission. PROJECT_VIEW is too
+    # permissive here (an annotator could cancel an admin's 6940-cell
+    # eval); PROJECT_EDIT-only would block the user-cancels-own-run
+    # case. The disjunction matches the symmetry users expect: "I can
+    # cancel what I started."
+    is_owner = evaluation.created_by == current_user.id
+    has_edit = auth_service.check_project_access(
+        current_user, project, Permission.PROJECT_EDIT, db, org_context=org_context
+    )
+    if not (is_owner or has_edit):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="You don't have permission to cancel evaluations on this project",
+            detail=(
+                "You don't have permission to cancel this evaluation. "
+                "Only the user who triggered the run or a user with project "
+                "edit permission can cancel."
+            ),
         )
 
     if evaluation.status in ("completed", "failed", "cancelled"):
@@ -633,12 +685,18 @@ async def cancel_all_project_evaluations(
         )
 
     org_context = get_org_context_from_request(http_request)
+    # Bulk cancel is strictly PROJECT_EDIT — it nukes every in-flight
+    # run on the project regardless of who triggered them, so a
+    # read-only viewer must not be able to fire it.
     if not auth_service.check_project_access(
-        current_user, project, Permission.PROJECT_VIEW, db, org_context=org_context
+        current_user, project, Permission.PROJECT_EDIT, db, org_context=org_context
     ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="You don't have permission to cancel evaluations on this project",
+            detail=(
+                "You don't have permission to bulk-cancel evaluations on "
+                "this project (requires project edit permission)."
+            ),
         )
 
     in_flight = (

--- a/services/api/routers/evaluations/multi_field.py
+++ b/services/api/routers/evaluations/multi_field.py
@@ -313,6 +313,43 @@ async def run_evaluation(
 
         dispatched_configs = [_with_run_seed(c.dict()) for c in llm_configs]
 
+        # Idempotency guard: if the same user just dispatched an
+        # evaluation against this project that's still in-flight, return
+        # that run's id instead of spawning a duplicate. Without this,
+        # a double-click on the "Run" button dispatched two chord-fan-outs
+        # that processed every cell twice — at ZJS Fälle scale that
+        # silently doubled the LLM bill. 30s window covers the
+        # accidental-double-click case without blocking legitimate
+        # sequential re-triggers.
+        from datetime import timedelta as _td
+        recent_inflight = (
+            db.query(DBEvaluationRun)
+            .filter(
+                DBEvaluationRun.project_id == request.project_id,
+                DBEvaluationRun.created_by == current_user.id,
+                DBEvaluationRun.status.in_(("pending", "running")),
+                DBEvaluationRun.created_at >= datetime.now() - _td(seconds=30),
+            )
+            .order_by(DBEvaluationRun.created_at.desc())
+            .first()
+        )
+        if recent_inflight is not None:
+            return EvaluationRunResponse(
+                evaluation_id=recent_inflight.id,
+                project_id=request.project_id,
+                status="already_running",
+                message=(
+                    "An evaluation by this user is already in flight on "
+                    f"this project (id {recent_inflight.id}, status "
+                    f"{recent_inflight.status}); returning that run instead "
+                    "of dispatching a duplicate."
+                ),
+                evaluation_configs_count=len(enabled_configs),
+                task_id=None,
+                started_at=recent_inflight.created_at,
+                human_eval_run_ids=human_run_ids,
+            )
+
         evaluation = DBEvaluationRun(
             id=str(uuid.uuid4()),
             project_id=request.project_id,
@@ -408,6 +445,216 @@ async def run_evaluation(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to start evaluation: {str(e)}",
         )
+
+
+# ============= Cancellation =============
+#
+# Cancel sets `EvaluationRun.status='cancelled'` and `completed_at=now()`,
+# and fails any child `EvaluationJudgeRun` still in `running`. It
+# DELIBERATELY does NOT delete `task_evaluations` rows — partial results
+# are preserved so a subsequent `force_rerun=False` (missing-only) trigger
+# can reuse them. The new orchestrator's preload status filter includes
+# `'cancelled'` so this works without extra wiring (see PR #94).
+#
+# The worker side is already plumbed for cancel: each cell sub-task does
+# a parent-status check at entry and short-circuits if terminal; the
+# `_bump_evaluation_counters` UPDATE filters out terminal parents so any
+# late counter bump no-ops. So flipping status is enough — in-flight
+# cells will drain within the duration of the LLM call they're holding.
+
+
+class CancelEvaluationResponse(BaseModel):
+    """Result of cancelling one or many evaluation runs."""
+
+    cancelled_run_ids: List[str]
+    failed_child_judge_run_count: int
+    preserved_task_evaluation_count: int
+    message: str
+
+
+def _cancel_runs(
+    db: Session,
+    *,
+    run_ids: List[str],
+    reason: str,
+) -> CancelEvaluationResponse:
+    """Cancel-runs helper used by both single and bulk endpoints. SQL
+    mirrors the Phase-0 prod cleanup we did pre-deploy (see PR #94
+    deploy plan). Uses raw text() so the `json::jsonb` cast survives
+    under Postgres 18's FIPS-strict type coercion (eval_metadata is
+    typed `json`, not `jsonb`)."""
+    from sqlalchemy import text as _text
+
+    if not run_ids:
+        return CancelEvaluationResponse(
+            cancelled_run_ids=[],
+            failed_child_judge_run_count=0,
+            preserved_task_evaluation_count=0,
+            message="No runs to cancel.",
+        )
+
+    cancelled = db.execute(
+        _text(
+            """
+            UPDATE evaluation_runs
+               SET status = 'cancelled',
+                   completed_at = NOW(),
+                   error_message = COALESCE(error_message, :reason),
+                   eval_metadata = (
+                     jsonb_set(
+                       jsonb_set(COALESCE(eval_metadata::jsonb, '{}'::jsonb),
+                                 '{cancelled_via_api}', 'true'::jsonb),
+                       '{cancel_reason}', to_jsonb(CAST(:reason AS text))
+                     )
+                   )::json
+             WHERE id = ANY(:ids)
+               AND status IN ('pending', 'running')
+            RETURNING id
+            """
+        ),
+        {"ids": run_ids, "reason": reason},
+    )
+    actually_cancelled = [row[0] for row in cancelled.fetchall()]
+
+    if not actually_cancelled:
+        return CancelEvaluationResponse(
+            cancelled_run_ids=[],
+            failed_child_judge_run_count=0,
+            preserved_task_evaluation_count=0,
+            message="No runs in pending/running state to cancel.",
+        )
+
+    failed_judge_runs = db.execute(
+        _text(
+            """
+            UPDATE evaluation_judge_runs
+               SET status = 'failed',
+                   completed_at = NOW(),
+                   error_message = COALESCE(error_message, :reason)
+             WHERE evaluation_id = ANY(:ids) AND status = 'running'
+            """
+        ),
+        {"ids": actually_cancelled, "reason": "Parent EvaluationRun cancelled"},
+    ).rowcount
+
+    preserved = db.execute(
+        _text(
+            "SELECT count(*) FROM task_evaluations WHERE evaluation_id = ANY(:ids)"
+        ),
+        {"ids": actually_cancelled},
+    ).scalar()
+
+    db.commit()
+
+    return CancelEvaluationResponse(
+        cancelled_run_ids=actually_cancelled,
+        failed_child_judge_run_count=failed_judge_runs or 0,
+        preserved_task_evaluation_count=preserved or 0,
+        message=(
+            f"Cancelled {len(actually_cancelled)} run(s); "
+            f"{failed_judge_runs or 0} in-flight judge_run(s) marked failed; "
+            f"{preserved or 0} task_evaluation row(s) preserved for "
+            f"missing-only re-trigger."
+        ),
+    )
+
+
+@router.post(
+    "/run/{evaluation_id}/cancel",
+    response_model=CancelEvaluationResponse,
+)
+async def cancel_evaluation_run(
+    http_request: Request,
+    evaluation_id: str,
+    current_user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Cancel a single in-flight evaluation run. Partial scores survive."""
+    evaluation = (
+        db.query(DBEvaluationRun)
+        .filter(DBEvaluationRun.id == evaluation_id)
+        .first()
+    )
+    if not evaluation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Evaluation '{evaluation_id}' not found",
+        )
+
+    project = db.query(Project).filter(Project.id == evaluation.project_id).first()
+    if not project:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Parent project '{evaluation.project_id}' not found",
+        )
+
+    org_context = get_org_context_from_request(http_request)
+    if not auth_service.check_project_access(
+        current_user, project, Permission.PROJECT_VIEW, db, org_context=org_context
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You don't have permission to cancel evaluations on this project",
+        )
+
+    if evaluation.status in ("completed", "failed", "cancelled"):
+        return CancelEvaluationResponse(
+            cancelled_run_ids=[],
+            failed_child_judge_run_count=0,
+            preserved_task_evaluation_count=0,
+            message=f"Evaluation is already terminal (status='{evaluation.status}'); nothing to cancel.",
+        )
+
+    reason = f"Cancelled via API by user {current_user.id}"
+    return _cancel_runs(db, run_ids=[evaluation_id], reason=reason)
+
+
+@router.post(
+    "/projects/{project_id}/runs/cancel-all",
+    response_model=CancelEvaluationResponse,
+)
+async def cancel_all_project_evaluations(
+    http_request: Request,
+    project_id: str,
+    current_user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Cancel every in-flight (pending or running) evaluation on a project.
+
+    Useful when an operator wants to stop a runaway re-trigger or
+    multiple stuck runs at once. Per-run rows are preserved for
+    missing-only re-trigger downstream.
+    """
+    project = db.query(Project).filter(Project.id == project_id).first()
+    if not project:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Project '{project_id}' not found",
+        )
+
+    org_context = get_org_context_from_request(http_request)
+    if not auth_service.check_project_access(
+        current_user, project, Permission.PROJECT_VIEW, db, org_context=org_context
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You don't have permission to cancel evaluations on this project",
+        )
+
+    in_flight = (
+        db.query(DBEvaluationRun.id)
+        .filter(
+            DBEvaluationRun.project_id == project_id,
+            DBEvaluationRun.status.in_(("pending", "running")),
+        )
+        .all()
+    )
+    run_ids = [row[0] for row in in_flight]
+    reason = (
+        f"Bulk-cancelled via API by user {current_user.id} "
+        f"(project {project_id})"
+    )
+    return _cancel_runs(db, run_ids=run_ids, reason=reason)
 
 
 @router.get("/projects/{project_id}/available-fields", response_model=AvailableFieldsResponse)

--- a/services/api/routers/evaluations/multi_field.py
+++ b/services/api/routers/evaluations/multi_field.py
@@ -368,7 +368,7 @@ async def run_evaluation(
                     "model_ids": request.model_ids,
                     "annotator_user_ids": request.annotator_user_ids,
                 },
-                queue="celery",
+                queue="evaluation",
             )
 
             # Update evaluation with task ID

--- a/services/api/tests/integration/test_evaluation_cancel_idempotency.py
+++ b/services/api/tests/integration/test_evaluation_cancel_idempotency.py
@@ -1,0 +1,406 @@
+"""
+Integration tests for the cancel endpoints + idempotency guard added
+in PR #94 (per-cell eval fan-out).
+
+Source-grep tests in `tests/unit/test_evaluation_multi_field_endpoints.py`
+already pin the presence of the auth/datetime/dispatch_hash logic in
+the handler source; these go further: real HTTP round-trip through
+the FastAPI test client, real Postgres state mutations via the test
+DB, real auth via the existing `auth_headers` fixture.
+
+What this covers that the unit greps don't:
+  - The SQL actually runs (catches the json/jsonb cast errors that
+    blew up three times during dev).
+  - The cancel preserves `task_evaluations` rows (the core promise).
+  - Annotators (`PROJECT_VIEW` only) are rejected on cancel-all.
+  - Same-payload double-POST resolves to one EvaluationRun.
+  - Different-payload double-POST resolves to two EvaluationRuns
+    (the dispatch_hash discriminator).
+"""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from models import (
+    EvaluationJudgeRun,
+    EvaluationRun,
+    TaskEvaluation,
+    User,
+)
+from project_models import (
+    Annotation,
+    Project,
+    ProjectOrganization,
+    Task,
+)
+
+BASE = "/api/evaluations"
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+def _make_project_with_inflight_eval(db, admin: User, org, *, with_task_evals: int = 0):
+    """Seed a project + a single in-flight EvaluationRun + N task_evaluations."""
+    project = Project(
+        id=_uid(),
+        title=f"CancelTest {uuid.uuid4().hex[:6]}",
+        created_by=admin.id,
+        label_config='<View><Text name="text" value="$text"/></View>',
+    )
+    db.add(project)
+    db.flush()
+
+    db.add(
+        ProjectOrganization(
+            id=_uid(),
+            project_id=project.id,
+            organization_id=org.id,
+            assigned_by=admin.id,
+        )
+    )
+    db.flush()
+
+    task = Task(
+        id=_uid(),
+        project_id=project.id,
+        data={"text": "t"},
+        inner_id=1,
+        created_by=admin.id,
+    )
+    db.add(task)
+    db.flush()
+
+    ann = Annotation(
+        id=_uid(),
+        task_id=task.id,
+        project_id=project.id,
+        completed_by=admin.id,
+        result=[],
+        was_cancelled=False,
+    )
+    db.add(ann)
+    db.flush()
+
+    eval_run = EvaluationRun(
+        id=_uid(),
+        project_id=project.id,
+        model_id="gpt-4o",
+        evaluation_type_ids=["bleu"],
+        metrics={},
+        status="running",
+        samples_evaluated=0,
+        created_by=admin.id,
+        created_at=datetime.now(timezone.utc),
+        eval_metadata={"evaluation_type": "evaluation"},
+    )
+    db.add(eval_run)
+    db.flush()
+
+    judge_run = EvaluationJudgeRun(
+        id=_uid(),
+        evaluation_id=eval_run.id,
+        judge_model_id="gpt-4o",
+        run_index=0,
+        status="running",
+        started_at=datetime.now(timezone.utc),
+    )
+    db.add(judge_run)
+    db.flush()
+
+    for i in range(with_task_evals):
+        db.add(
+            TaskEvaluation(
+                id=_uid(),
+                evaluation_id=eval_run.id,
+                judge_run_id=judge_run.id,
+                task_id=task.id,
+                generation_id=None,
+                annotation_id=ann.id,
+                field_name=f"smoke|__response__|musterloesung|{i}",
+                answer_type="text",
+                ground_truth="gt",
+                prediction="pred",
+                metrics={"bleu": 0.5},
+                passed=True,
+            )
+        )
+    db.flush()
+
+    return {
+        "project": project,
+        "task": task,
+        "annotation": ann,
+        "eval_run": eval_run,
+        "judge_run": judge_run,
+    }
+
+
+@pytest.mark.integration
+class TestCancelSingle:
+    """POST /api/evaluations/run/{evaluation_id}/cancel"""
+
+    def test_cancel_flips_status_and_preserves_rows(
+        self, client, test_db, test_users, auth_headers, test_org
+    ):
+        data = _make_project_with_inflight_eval(
+            test_db, test_users[0], test_org, with_task_evals=5
+        )
+        eval_id = data["eval_run"].id
+
+        resp = client.post(
+            f"{BASE}/run/{eval_id}/cancel",
+            headers={**auth_headers["admin"], "X-Organization-Context": test_org.id},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["cancelled_run_ids"] == [eval_id]
+        assert body["preserved_task_evaluation_count"] == 5
+
+        # DB state: parent flipped, judge_run failed, task_evaluations untouched.
+        test_db.expire_all()
+        assert test_db.query(EvaluationRun).filter_by(id=eval_id).one().status == "cancelled"
+        assert test_db.query(EvaluationJudgeRun).filter_by(
+            id=data["judge_run"].id
+        ).one().status == "failed"
+        assert (
+            test_db.query(TaskEvaluation)
+            .filter_by(evaluation_id=eval_id)
+            .count()
+            == 5
+        )
+
+    def test_cancel_already_terminal_is_noop(
+        self, client, test_db, test_users, auth_headers, test_org
+    ):
+        data = _make_project_with_inflight_eval(test_db, test_users[0], test_org)
+        data["eval_run"].status = "completed"
+        test_db.flush()
+
+        resp = client.post(
+            f"{BASE}/run/{data['eval_run'].id}/cancel",
+            headers={**auth_headers["admin"], "X-Organization-Context": test_org.id},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["cancelled_run_ids"] == []
+        assert "already terminal" in resp.json()["message"]
+
+    def test_cancel_nonexistent_run_404(self, client, test_db, auth_headers):
+        resp = client.post(
+            f"{BASE}/run/{_uid()}/cancel",
+            headers=auth_headers["admin"],
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.integration
+class TestCancelAll:
+    """POST /api/evaluations/projects/{project_id}/runs/cancel-all"""
+
+    def test_cancel_all_flips_multiple_runs(
+        self, client, test_db, test_users, auth_headers, test_org
+    ):
+        admin = test_users[0]
+        # Two in-flight runs on the same project.
+        data1 = _make_project_with_inflight_eval(test_db, admin, test_org, with_task_evals=3)
+        project_id = data1["project"].id
+        # Add a second eval_run to the same project.
+        second = EvaluationRun(
+            id=_uid(),
+            project_id=project_id,
+            model_id="gpt-4o",
+            evaluation_type_ids=["bleu"],
+            metrics={},
+            status="pending",
+            samples_evaluated=0,
+            created_by=admin.id,
+            created_at=datetime.now(timezone.utc),
+            eval_metadata={"evaluation_type": "evaluation"},
+        )
+        test_db.add(second)
+        test_db.flush()
+
+        resp = client.post(
+            f"{BASE}/projects/{project_id}/runs/cancel-all",
+            headers={**auth_headers["admin"], "X-Organization-Context": test_org.id},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert set(body["cancelled_run_ids"]) == {data1["eval_run"].id, second.id}
+        assert body["preserved_task_evaluation_count"] == 3
+
+    def test_cancel_all_no_inflight_runs(
+        self, client, test_db, test_users, auth_headers, test_org
+    ):
+        data = _make_project_with_inflight_eval(test_db, test_users[0], test_org)
+        # Flip the seeded run to terminal so nothing is in flight.
+        data["eval_run"].status = "completed"
+        test_db.flush()
+
+        resp = client.post(
+            f"{BASE}/projects/{data['project'].id}/runs/cancel-all",
+            headers={**auth_headers["admin"], "X-Organization-Context": test_org.id},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["cancelled_run_ids"] == []
+
+
+@pytest.mark.integration
+class TestCancelAuth:
+    """The cancel endpoints' permission gate. Annotators have only
+    PROJECT_VIEW; without the PR #94 tightening they could nuke an
+    admin's 6940-cell ZJS run from the runs UI."""
+
+    def test_annotator_cannot_bulk_cancel(
+        self, client, test_db, test_users, auth_headers, test_org
+    ):
+        admin = next(u for u in test_users if u.is_superadmin)
+        data = _make_project_with_inflight_eval(test_db, admin, test_org)
+        # Annotator has PROJECT_VIEW (via project membership / org role) but
+        # not PROJECT_EDIT. cancel-all requires PROJECT_EDIT strictly.
+        resp = client.post(
+            f"{BASE}/projects/{data['project'].id}/runs/cancel-all",
+            headers={
+                **auth_headers["annotator"],
+                "X-Organization-Context": test_org.id,
+            },
+        )
+        # 403 (forbidden) or 404 (no access path) — both forbid the
+        # bulk-nuke. The unacceptable result would be a 200 with
+        # cancelled_run_ids populated.
+        assert resp.status_code in (403, 404), (
+            f"annotator unexpectedly able to bulk-cancel: {resp.status_code} {resp.text}"
+        )
+
+
+@pytest.mark.integration
+class TestDispatchIdempotency:
+    """`POST /run` idempotency guard: same user, same project, same
+    config payload within 30s returns the existing run id with
+    `status='already_running'` instead of duplicate-dispatching."""
+
+    def _make_project_with_generations(self, test_db, admin, org):
+        """Eval dispatch needs at least one task on the project to
+        avoid the empty-config short-circuit."""
+        project = Project(
+            id=_uid(),
+            title=f"IdempTest {uuid.uuid4().hex[:6]}",
+            created_by=admin.id,
+            label_config='<View><Text name="text" value="$text"/></View>',
+        )
+        test_db.add(project)
+        test_db.flush()
+        test_db.add(
+            ProjectOrganization(
+                id=_uid(),
+                project_id=project.id,
+                organization_id=org.id,
+                assigned_by=admin.id,
+            )
+        )
+        for i in range(2):
+            test_db.add(
+                Task(
+                    id=_uid(),
+                    project_id=project.id,
+                    data={"text": f"t{i}"},
+                    inner_id=i + 1,
+                    created_by=admin.id,
+                )
+            )
+        test_db.flush()
+        return project
+
+    def _post_run(self, client, headers, payload):
+        # Patch celery dispatch to a no-op so the test doesn't hit the
+        # broker. The idempotency guard runs BEFORE dispatch so we
+        # only need the EvaluationRun row to land.
+        with patch(
+            "routers.evaluations.helpers.celery_app.send_task",
+            return_value=type("T", (), {"id": "task-stub"})(),
+        ):
+            return client.post(f"{BASE}/run", headers=headers, json=payload)
+
+    def test_same_payload_double_post_returns_one_run(
+        self, client, test_db, test_users, auth_headers, test_org
+    ):
+        admin = next(u for u in test_users if u.is_superadmin)
+        project = self._make_project_with_generations(test_db, admin, test_org)
+
+        payload = {
+            "project_id": project.id,
+            "evaluation_configs": [
+                {
+                    "id": "c1",
+                    "metric": "bleu",
+                    "prediction_fields": ["__response__"],
+                    "reference_fields": ["ref"],
+                    "enabled": True,
+                }
+            ],
+            "force_rerun": True,
+        }
+        headers = {**auth_headers["admin"], "X-Organization-Context": test_org.id}
+        r1 = self._post_run(client, headers, payload)
+        r2 = self._post_run(client, headers, payload)
+        assert r1.status_code == 200, r1.text
+        assert r2.status_code == 200, r2.text
+        id1 = r1.json()["evaluation_id"]
+        id2 = r2.json()["evaluation_id"]
+        assert id1 == id2, "same payload should dedupe to one run"
+        assert r2.json()["status"] == "already_running"
+
+        # Exactly one EvaluationRun in DB.
+        test_db.expire_all()
+        rows = (
+            test_db.query(EvaluationRun)
+            .filter(EvaluationRun.project_id == project.id)
+            .all()
+        )
+        assert len(rows) == 1
+
+    def test_different_payload_double_post_returns_two_runs(
+        self, client, test_db, test_users, auth_headers, test_org
+    ):
+        admin = next(u for u in test_users if u.is_superadmin)
+        project = self._make_project_with_generations(test_db, admin, test_org)
+        headers = {**auth_headers["admin"], "X-Organization-Context": test_org.id}
+
+        payload_a = {
+            "project_id": project.id,
+            "evaluation_configs": [
+                {
+                    "id": "bleu-cfg",
+                    "metric": "bleu",
+                    "prediction_fields": ["__response__"],
+                    "reference_fields": ["ref"],
+                    "enabled": True,
+                }
+            ],
+            "force_rerun": True,
+        }
+        payload_b = {
+            **payload_a,
+            "evaluation_configs": [
+                {**payload_a["evaluation_configs"][0], "id": "rouge-cfg", "metric": "rouge_l"}
+            ],
+        }
+        r1 = self._post_run(client, headers, payload_a)
+        r2 = self._post_run(client, headers, payload_b)
+        assert r1.status_code == 200 and r2.status_code == 200
+        assert r1.json()["evaluation_id"] != r2.json()["evaluation_id"], (
+            "different configs MUST NOT collapse to one run "
+            "(dispatch_hash discriminator failed)"
+        )
+        # Both rows landed.
+        test_db.expire_all()
+        rows = (
+            test_db.query(EvaluationRun)
+            .filter(EvaluationRun.project_id == project.id)
+            .all()
+        )
+        assert len(rows) == 2

--- a/services/api/tests/unit/test_evaluation_multi_field_endpoints.py
+++ b/services/api/tests/unit/test_evaluation_multi_field_endpoints.py
@@ -432,3 +432,66 @@ class TestCancellationEndpoints:
         # pending/running.
         assert "DBEvaluationRun.created_by" in src
         assert 'status.in_(("pending", "running"))' in src
+
+    def test_run_endpoint_idempotency_uses_tz_aware_datetime(self):
+        """The `created_at` column is `DateTime(timezone=True)`. A naive
+        `datetime.now()` compared against it is order-of-hours wrong on
+        any non-UTC host (CET in summer = UTC+2 makes the 30s window
+        either always-hit or never-hit). Pin the tz-aware call."""
+        import inspect
+        from routers.evaluations.multi_field import run_evaluation
+
+        src = inspect.getsource(run_evaluation)
+        assert "datetime.now(timezone.utc)" in src, (
+            "idempotency window must use tz-aware `datetime.now(timezone.utc)` "
+            "to match `EvaluationRun.created_at` (DateTime timezone=True)"
+        )
+
+    def test_run_endpoint_idempotency_includes_dispatch_hash(self):
+        """Without a config-payload hash in the lookup, firing BLEU on
+        tasks 1-10 then ROUGE on tasks 11-20 within 30s would return
+        the BLEU run id wrongly (two distinct evals collapse to one)."""
+        import inspect
+        from routers.evaluations.multi_field import run_evaluation
+
+        src = inspect.getsource(run_evaluation)
+        assert "dispatch_hash" in src, (
+            "idempotency lookup must include a stable hash of the dispatch "
+            "payload so two legitimately-different evals on the same project "
+            "by the same user within 30s aren't collapsed into one"
+        )
+        assert "sha1" in src or "blake2" in src or "sha256" in src, (
+            "dispatch_hash must be derived from a real hash function over the "
+            "config payload + scope filters"
+        )
+
+    def test_cancel_endpoints_require_appropriate_permission(self):
+        """A read-only viewer (`PROJECT_VIEW` only) MUST NOT be able to
+        cancel evaluations — that would let an annotator nuke an
+        admin's 6940-cell ZJS run. Per-run cancel allows owner-OR-edit;
+        bulk cancel requires strictly `PROJECT_EDIT`."""
+        import inspect
+        from routers.evaluations.multi_field import (
+            cancel_all_project_evaluations,
+            cancel_evaluation_run,
+        )
+
+        single = inspect.getsource(cancel_evaluation_run)
+        bulk = inspect.getsource(cancel_all_project_evaluations)
+
+        # Bulk: strictly PROJECT_EDIT.
+        assert "Permission.PROJECT_EDIT" in bulk, (
+            "cancel-all must require PROJECT_EDIT"
+        )
+        assert "Permission.PROJECT_VIEW" not in bulk, (
+            "cancel-all must NOT accept PROJECT_VIEW (too permissive)"
+        )
+
+        # Single: owner-OR-edit (the disjunction lets a user cancel
+        # their own runs without needing edit on the project).
+        assert "Permission.PROJECT_EDIT" in single, (
+            "cancel-single must check PROJECT_EDIT as one branch of the auth"
+        )
+        assert "created_by == current_user.id" in single, (
+            "cancel-single must allow the run's creator to cancel their own run"
+        )

--- a/services/api/tests/unit/test_evaluation_multi_field_endpoints.py
+++ b/services/api/tests/unit/test_evaluation_multi_field_endpoints.py
@@ -360,3 +360,75 @@ class TestResolveUserOrgForProject:
 
         result = resolve_user_org_for_project(user, project, db)
         assert result == "org-2"
+
+
+class TestCancellationEndpoints:
+    """Source-contract tests for the cancel endpoints + idempotency.
+
+    Full HTTP integration would require the test app + DB harness; the
+    contracts asserted here are enough to catch the most likely
+    regression (someone removes / renames the endpoints or the helper)."""
+
+    def test_cancel_endpoints_exist(self):
+        from routers.evaluations import multi_field
+        from inspect import getmembers, iscoroutinefunction
+
+        fn_names = {n for n, f in getmembers(multi_field, iscoroutinefunction)}
+        assert "cancel_evaluation_run" in fn_names, (
+            "POST /api/evaluations/run/{id}/cancel handler missing"
+        )
+        assert "cancel_all_project_evaluations" in fn_names, (
+            "POST /api/evaluations/projects/{pid}/runs/cancel-all handler missing"
+        )
+
+    def test_cancel_helper_preserves_task_evaluations(self):
+        """`_cancel_runs` must NOT delete `task_evaluations`. Partial
+        scores survive cancel so a `force_rerun=False` re-trigger
+        picks up from where the cancelled run left off."""
+        from routers.evaluations.multi_field import _cancel_runs  # noqa: F401
+        import inspect
+
+        src = inspect.getsource(_cancel_runs)
+        # Hostile: the helper must not contain a DELETE against task_evaluations.
+        assert "DELETE FROM task_evaluations" not in src.upper().replace(
+            "DELETE FROM TASK_EVALUATIONS", "DELETE FROM TASK_EVALUATIONS"
+        ), "cancel must NEVER delete task_evaluations rows"
+        # It must do exactly the three SQL operations: UPDATE evaluation_runs,
+        # UPDATE evaluation_judge_runs, SELECT count(*).
+        assert "UPDATE evaluation_runs" in src
+        assert "UPDATE evaluation_judge_runs" in src
+        assert "task_evaluations" in src  # for the preserved-count SELECT
+
+    def test_cancel_helper_only_terminates_inflight(self):
+        """The UPDATE filter `AND status IN ('pending','running')`
+        prevents flipping an already-terminal run (`completed`/`failed`/
+        `cancelled`) into `cancelled`, which would lose its
+        `completed_at`/`error_message` provenance."""
+        import inspect
+        from routers.evaluations.multi_field import _cancel_runs
+
+        src = inspect.getsource(_cancel_runs)
+        assert "AND status IN ('pending', 'running')" in src, (
+            "cancel must only touch pending/running runs, not flip terminal ones"
+        )
+
+    def test_run_endpoint_has_idempotency_guard(self):
+        """Double-clicking the Run button (or any race between two POSTs
+        within 30s by the same user on the same project) must return
+        the in-flight run's id with `status='already_running'`, not
+        spawn a duplicate dispatch that doubles the LLM bill."""
+        import inspect
+        from routers.evaluations.multi_field import run_evaluation
+
+        src = inspect.getsource(run_evaluation)
+        assert "already_running" in src, (
+            "run_evaluation must short-circuit on a recent in-flight dispatch "
+            "and return `status='already_running'`"
+        )
+        assert "timedelta" in src and "seconds=30" in src, (
+            "idempotency window of 30s must be present"
+        )
+        # The check looks at the same project + same user + status
+        # pending/running.
+        assert "DBEvaluationRun.created_by" in src
+        assert 'status.in_(("pending", "running"))' in src

--- a/services/frontend/src/components/evaluation/EvaluationResults.tsx
+++ b/services/frontend/src/components/evaluation/EvaluationResults.tsx
@@ -14,6 +14,7 @@ import { Button } from '@/components/shared/Button'
 import { Card } from '@/components/shared/Card'
 import { LoadingSpinner } from '@/components/shared/LoadingSpinner'
 import { useToast } from '@/components/shared/Toast'
+import { InflightRunsBanner } from '@/components/evaluation/InflightRunsBanner'
 import { useAuth } from '@/contexts/AuthContext'
 import { useI18n } from '@/contexts/I18nContext'
 import { TaskDataViewModal } from '@/components/tasks/TaskDataViewModal'
@@ -1133,6 +1134,17 @@ export function EvaluationResults({
 
   return (
     <div className="space-y-4">
+      {/* In-flight runs banner — surfaces every `pending`/`running` run
+          with per-run cancel and a bulk "cancel all" so an operator can
+          stop a runaway or duplicate dispatch without resorting to
+          kubectl exec / direct SQL. Partial scores survive cancel; a
+          subsequent `force_rerun=false` re-trigger picks up where the
+          cancelled run left off. */}
+      <InflightRunsBanner
+        projectId={String(projectId)}
+        evaluations={results.evaluations}
+        onChanged={fetchResults}
+      />
       {/* Header with metric selector, controls, and action buttons */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">

--- a/services/frontend/src/components/evaluation/InflightRunsBanner.tsx
+++ b/services/frontend/src/components/evaluation/InflightRunsBanner.tsx
@@ -1,0 +1,235 @@
+/**
+ * In-flight evaluation runs banner.
+ *
+ * Shows every EvaluationRun in `pending` or `running` state with a
+ * per-run cancel and a bulk "cancel all" button. Lets operators stop
+ * runaway or duplicate dispatches from the UI instead of needing
+ * direct DB / kubectl exec access. Partial TaskEvaluation rows survive
+ * cancel — the next `force_rerun=false` re-trigger picks them up via
+ * the orchestrator's missing-only preload (PR #94).
+ *
+ * Hidden when there's nothing in flight.
+ */
+
+'use client'
+
+import { Button } from '@/components/shared/Button'
+import { useToast } from '@/components/shared/Toast'
+import { useI18n } from '@/contexts/I18nContext'
+import { apiClient } from '@/lib/api/client'
+import { ExclamationTriangleIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { useState } from 'react'
+
+type EvaluationLike = {
+  evaluation_id: string
+  status: string
+  samples_evaluated?: number
+  eval_metadata?: {
+    cells_dispatched?: number
+    failures_by_reason?: Record<string, number>
+  } | null
+}
+
+export interface InflightRunsBannerProps {
+  projectId: string
+  evaluations: EvaluationLike[]
+  /** Called after a successful cancel so the parent refetches. */
+  onChanged: () => void
+}
+
+export function InflightRunsBanner({
+  projectId,
+  evaluations,
+  onChanged,
+}: InflightRunsBannerProps) {
+  const { t } = useI18n()
+  const { addToast } = useToast()
+  const [cancelling, setCancelling] = useState<Set<string>>(new Set())
+  const [bulkCancelling, setBulkCancelling] = useState(false)
+
+  const inflight = evaluations.filter(
+    (e) => e.status === 'pending' || e.status === 'running'
+  )
+
+  if (inflight.length === 0) return null
+
+  const markCancelling = (id: string, active: boolean) => {
+    setCancelling((prev) => {
+      const next = new Set(prev)
+      if (active) next.add(id)
+      else next.delete(id)
+      return next
+    })
+  }
+
+  const cancelOne = async (id: string) => {
+    if (
+      !window.confirm(
+        t(
+          'evaluation.cancel.confirmSingle',
+          'Diesen Lauf abbrechen? Bereits berechnete Bewertungen bleiben erhalten.'
+        )
+      )
+    ) {
+      return
+    }
+    markCancelling(id, true)
+    try {
+      const result = await apiClient.evaluations.cancelEvaluationRun(id)
+      addToast(
+        result.cancelled_run_ids.length > 0
+          ? t('evaluation.cancel.success', 'Lauf abgebrochen.') +
+              ` (${result.preserved_task_evaluation_count} Bewertungen erhalten)`
+          : result.message,
+        'success'
+      )
+      onChanged()
+    } catch (err) {
+      addToast(
+        t('evaluation.cancel.error', 'Abbruch fehlgeschlagen.') +
+          ' ' +
+          (err instanceof Error ? err.message : String(err)),
+        'error'
+      )
+    } finally {
+      markCancelling(id, false)
+    }
+  }
+
+  const cancelAll = async () => {
+    if (
+      !window.confirm(
+        t(
+          'evaluation.cancel.confirmAll',
+          `Alle ${inflight.length} laufenden/anstehenden Läufe abbrechen? Bereits berechnete Bewertungen bleiben erhalten.`
+        )
+      )
+    ) {
+      return
+    }
+    setBulkCancelling(true)
+    try {
+      const result = await apiClient.evaluations.cancelAllProjectEvaluations(
+        projectId
+      )
+      addToast(
+        result.cancelled_run_ids.length > 0
+          ? t('evaluation.cancel.bulkSuccess', 'Läufe abgebrochen.') +
+              ` (${result.cancelled_run_ids.length} Läufe, ${result.preserved_task_evaluation_count} Bewertungen erhalten)`
+          : result.message,
+        'success'
+      )
+      onChanged()
+    } catch (err) {
+      addToast(
+        t('evaluation.cancel.error', 'Abbruch fehlgeschlagen.') +
+          ' ' +
+          (err instanceof Error ? err.message : String(err)),
+        'error'
+      )
+    } finally {
+      setBulkCancelling(false)
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 dark:border-amber-700 dark:bg-amber-900/20">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-sm text-amber-900 dark:text-amber-100">
+          <ExclamationTriangleIcon className="h-5 w-5 flex-shrink-0" />
+          <span className="font-medium">
+            {t(
+              'evaluation.inflight.heading',
+              `${inflight.length} Auswertung(en) laufen gerade`
+            )}
+          </span>
+        </div>
+        {inflight.length > 1 && (
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={cancelAll}
+            disabled={bulkCancelling || cancelling.size > 0}
+            className="text-amber-900 dark:text-amber-100"
+          >
+            {bulkCancelling
+              ? t('evaluation.cancel.cancellingAll', 'Breche ab …')
+              : t('evaluation.cancel.cancelAll', 'Alle abbrechen')}
+          </Button>
+        )}
+      </div>
+      <ul className="mt-2 space-y-1.5">
+        {inflight.map((e) => {
+          const cells = e.eval_metadata?.cells_dispatched ?? null
+          const evald = e.samples_evaluated ?? 0
+          const progress =
+            cells && cells > 0
+              ? ` — ${evald}/${cells}`
+              : evald > 0
+                ? ` — ${evald} ${t('evaluation.inflight.samples', 'Samples')}`
+                : ''
+          const isCancelling = cancelling.has(e.evaluation_id)
+          return (
+            <li
+              key={e.evaluation_id}
+              className="flex items-center justify-between gap-2 rounded bg-white/60 px-2 py-1 text-xs text-gray-700 dark:bg-zinc-900/40 dark:text-gray-300"
+            >
+              <span className="font-mono">
+                {e.evaluation_id.slice(0, 8)}
+                <span className="ml-2 text-gray-500 dark:text-gray-400">
+                  ({e.status}
+                  {progress})
+                </span>
+              </span>
+              <button
+                type="button"
+                onClick={() => cancelOne(e.evaluation_id)}
+                disabled={isCancelling || bulkCancelling}
+                className="inline-flex items-center gap-1 rounded border border-amber-400 px-2 py-0.5 text-amber-800 hover:bg-amber-100 disabled:opacity-50 dark:border-amber-600 dark:text-amber-100 dark:hover:bg-amber-800/30"
+                aria-label={t('evaluation.cancel.singleAria', 'Diesen Lauf abbrechen')}
+              >
+                <XMarkIcon className="h-3.5 w-3.5" />
+                {isCancelling
+                  ? t('evaluation.cancel.cancelling', 'Breche ab …')
+                  : t('evaluation.cancel.cancel', 'Abbrechen')}
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+      {/* Aggregate failure-reason breakdown across in-flight runs.
+          Sub-tasks bump `samples_failed` for transient errors that
+          *produce no TaskEvaluation row* (rate-limit, content policy,
+          judge timeout, poison cell) — without this surface the user
+          sees a pass_rate drop but no signal as to why. */}
+      {(() => {
+        const totals: Record<string, number> = {}
+        for (const e of inflight) {
+          const reasons = e.eval_metadata?.failures_by_reason
+          if (!reasons) continue
+          for (const [reason, n] of Object.entries(reasons)) {
+            totals[reason] = (totals[reason] ?? 0) + n
+          }
+        }
+        const entries = Object.entries(totals).sort((a, b) => b[1] - a[1])
+        if (entries.length === 0) return null
+        return (
+          <div className="mt-2 flex flex-wrap items-center gap-1.5 text-xs text-amber-900 dark:text-amber-100">
+            <span className="opacity-70">
+              {t('evaluation.inflight.failuresLabel', 'Fehlschläge nach Grund:')}
+            </span>
+            {entries.map(([reason, n]) => (
+              <span
+                key={reason}
+                className="rounded bg-amber-200/70 px-1.5 py-0.5 font-mono dark:bg-amber-800/40"
+                title={reason}
+              >
+                {reason}: {n}
+              </span>
+            ))}
+          </div>
+        )
+      })()}
+    </div>
+  )
+}

--- a/services/frontend/src/components/evaluation/InflightRunsBanner.tsx
+++ b/services/frontend/src/components/evaluation/InflightRunsBanner.tsx
@@ -16,6 +16,7 @@
 import { Button } from '@/components/shared/Button'
 import { useToast } from '@/components/shared/Toast'
 import { useI18n } from '@/contexts/I18nContext'
+import { useConfirm } from '@/hooks/useDialogs'
 import { apiClient } from '@/lib/api/client'
 import { ExclamationTriangleIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import { useState } from 'react'
@@ -37,6 +38,12 @@ export interface InflightRunsBannerProps {
   onChanged: () => void
 }
 
+// Cap the number of distinct failure-reason badges rendered.
+// `_classify_cell_failure` whitelists 5 buckets server-side so this
+// will normally show ≤5; the cap is defense-in-depth in case anyone
+// ever bypasses the classifier.
+const MAX_FAILURE_BADGES = 8
+
 export function InflightRunsBanner({
   projectId,
   evaluations,
@@ -44,6 +51,7 @@ export function InflightRunsBanner({
 }: InflightRunsBannerProps) {
   const { t } = useI18n()
   const { addToast } = useToast()
+  const confirm = useConfirm()
   const [cancelling, setCancelling] = useState<Set<string>>(new Set())
   const [bulkCancelling, setBulkCancelling] = useState(false)
 
@@ -63,32 +71,36 @@ export function InflightRunsBanner({
   }
 
   const cancelOne = async (id: string) => {
-    if (
-      !window.confirm(
-        t(
-          'evaluation.cancel.confirmSingle',
-          'Diesen Lauf abbrechen? Bereits berechnete Bewertungen bleiben erhalten.'
-        )
-      )
-    ) {
-      return
-    }
+    const ok = await confirm({
+      title: t('evaluation.cancel.confirmSingleTitle', 'Lauf abbrechen?'),
+      message: t(
+        'evaluation.cancel.confirmSingleMessage',
+        'Bereits berechnete Bewertungen bleiben erhalten und werden beim nächsten Lauf wiederverwendet.'
+      ),
+      confirmText: t('evaluation.cancel.cancel', 'Abbrechen'),
+      cancelText: t('evaluation.cancel.keepRunning', 'Weiterlaufen lassen'),
+      variant: 'warning',
+    })
+    if (!ok) return
     markCancelling(id, true)
     try {
       const result = await apiClient.evaluations.cancelEvaluationRun(id)
       addToast(
         result.cancelled_run_ids.length > 0
-          ? t('evaluation.cancel.success', 'Lauf abgebrochen.') +
-              ` (${result.preserved_task_evaluation_count} Bewertungen erhalten)`
+          ? t('evaluation.cancel.successWithCount', {
+              preserved: result.preserved_task_evaluation_count,
+              defaultValue: `Lauf abgebrochen. ${result.preserved_task_evaluation_count} Bewertungen erhalten.`,
+            } as any)
           : result.message,
         'success'
       )
       onChanged()
     } catch (err) {
       addToast(
-        t('evaluation.cancel.error', 'Abbruch fehlgeschlagen.') +
-          ' ' +
-          (err instanceof Error ? err.message : String(err)),
+        t('evaluation.cancel.errorWithDetail', {
+          detail: err instanceof Error ? err.message : String(err),
+          defaultValue: `Abbruch fehlgeschlagen: ${err instanceof Error ? err.message : String(err)}`,
+        } as any),
         'error'
       )
     } finally {
@@ -97,16 +109,17 @@ export function InflightRunsBanner({
   }
 
   const cancelAll = async () => {
-    if (
-      !window.confirm(
-        t(
-          'evaluation.cancel.confirmAll',
-          `Alle ${inflight.length} laufenden/anstehenden Läufe abbrechen? Bereits berechnete Bewertungen bleiben erhalten.`
-        )
-      )
-    ) {
-      return
-    }
+    const ok = await confirm({
+      title: t('evaluation.cancel.confirmAllTitle', 'Alle Läufe abbrechen?'),
+      message: t('evaluation.cancel.confirmAllMessage', {
+        count: inflight.length,
+        defaultValue: `Alle ${inflight.length} laufenden bzw. anstehenden Läufe abbrechen? Bereits berechnete Bewertungen bleiben erhalten und werden beim nächsten Lauf wiederverwendet.`,
+      } as any),
+      confirmText: t('evaluation.cancel.cancelAllConfirm', 'Alle abbrechen'),
+      cancelText: t('evaluation.cancel.keepRunning', 'Weiterlaufen lassen'),
+      variant: 'danger',
+    })
+    if (!ok) return
     setBulkCancelling(true)
     try {
       const result = await apiClient.evaluations.cancelAllProjectEvaluations(
@@ -114,17 +127,21 @@ export function InflightRunsBanner({
       )
       addToast(
         result.cancelled_run_ids.length > 0
-          ? t('evaluation.cancel.bulkSuccess', 'Läufe abgebrochen.') +
-              ` (${result.cancelled_run_ids.length} Läufe, ${result.preserved_task_evaluation_count} Bewertungen erhalten)`
+          ? t('evaluation.cancel.bulkSuccessWithCount', {
+              runs: result.cancelled_run_ids.length,
+              preserved: result.preserved_task_evaluation_count,
+              defaultValue: `${result.cancelled_run_ids.length} Läufe abgebrochen, ${result.preserved_task_evaluation_count} Bewertungen erhalten.`,
+            } as any)
           : result.message,
         'success'
       )
       onChanged()
     } catch (err) {
       addToast(
-        t('evaluation.cancel.error', 'Abbruch fehlgeschlagen.') +
-          ' ' +
-          (err instanceof Error ? err.message : String(err)),
+        t('evaluation.cancel.errorWithDetail', {
+          detail: err instanceof Error ? err.message : String(err),
+          defaultValue: `Abbruch fehlgeschlagen: ${err instanceof Error ? err.message : String(err)}`,
+        } as any),
         'error'
       )
     } finally {
@@ -132,16 +149,40 @@ export function InflightRunsBanner({
     }
   }
 
+  // Aggregate failure-reason breakdown across in-flight runs.
+  // Sub-tasks bump `samples_failed` for transient errors that *produce
+  // no TaskEvaluation row* (rate-limit, content policy, judge timeout,
+  // poison cell) — without this surface the user sees a pass_rate
+  // drop with no signal as to why. Capped at MAX_FAILURE_BADGES to
+  // bound the layout.
+  const failureBuckets = (() => {
+    const totals: Record<string, number> = {}
+    for (const e of inflight) {
+      const reasons = e.eval_metadata?.failures_by_reason
+      if (!reasons) continue
+      for (const [reason, n] of Object.entries(reasons)) {
+        totals[reason] = (totals[reason] ?? 0) + n
+      }
+    }
+    return Object.entries(totals).sort((a, b) => b[1] - a[1])
+  })()
+  const shownFailures = failureBuckets.slice(0, MAX_FAILURE_BADGES)
+  const hiddenFailureCount = failureBuckets.length - shownFailures.length
+
   return (
-    <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 dark:border-amber-700 dark:bg-amber-900/20">
+    <div
+      role="status"
+      aria-live="polite"
+      className="rounded-lg border border-amber-300 bg-amber-50 p-3 dark:border-amber-700 dark:bg-amber-900/20"
+    >
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-2 text-sm text-amber-900 dark:text-amber-100">
           <ExclamationTriangleIcon className="h-5 w-5 flex-shrink-0" />
           <span className="font-medium">
-            {t(
-              'evaluation.inflight.heading',
-              `${inflight.length} Auswertung(en) laufen gerade`
-            )}
+            {t('evaluation.inflight.heading', {
+              count: inflight.length,
+              defaultValue: `${inflight.length} Auswertung(en) laufen gerade`,
+            } as any)}
           </span>
         </div>
         {inflight.length > 1 && (
@@ -197,39 +238,30 @@ export function InflightRunsBanner({
           )
         })}
       </ul>
-      {/* Aggregate failure-reason breakdown across in-flight runs.
-          Sub-tasks bump `samples_failed` for transient errors that
-          *produce no TaskEvaluation row* (rate-limit, content policy,
-          judge timeout, poison cell) — without this surface the user
-          sees a pass_rate drop but no signal as to why. */}
-      {(() => {
-        const totals: Record<string, number> = {}
-        for (const e of inflight) {
-          const reasons = e.eval_metadata?.failures_by_reason
-          if (!reasons) continue
-          for (const [reason, n] of Object.entries(reasons)) {
-            totals[reason] = (totals[reason] ?? 0) + n
-          }
-        }
-        const entries = Object.entries(totals).sort((a, b) => b[1] - a[1])
-        if (entries.length === 0) return null
-        return (
-          <div className="mt-2 flex flex-wrap items-center gap-1.5 text-xs text-amber-900 dark:text-amber-100">
-            <span className="opacity-70">
-              {t('evaluation.inflight.failuresLabel', 'Fehlschläge nach Grund:')}
+      {shownFailures.length > 0 && (
+        <div className="mt-2 flex flex-wrap items-center gap-1.5 text-xs text-amber-900 dark:text-amber-100">
+          <span className="opacity-70">
+            {t('evaluation.inflight.failuresLabel', 'Fehlschläge nach Grund:')}
+          </span>
+          {shownFailures.map(([reason, n]) => (
+            <span
+              key={reason}
+              className="rounded bg-amber-200/70 px-1.5 py-0.5 font-mono dark:bg-amber-800/40"
+              title={reason}
+            >
+              {reason}: {n}
             </span>
-            {entries.map(([reason, n]) => (
-              <span
-                key={reason}
-                className="rounded bg-amber-200/70 px-1.5 py-0.5 font-mono dark:bg-amber-800/40"
-                title={reason}
-              >
-                {reason}: {n}
-              </span>
-            ))}
-          </div>
-        )
-      })()}
+          ))}
+          {hiddenFailureCount > 0 && (
+            <span className="rounded bg-amber-300/70 px-1.5 py-0.5 dark:bg-amber-700/40">
+              {t('evaluation.inflight.failuresMore', {
+                count: hiddenFailureCount,
+                defaultValue: `+${hiddenFailureCount} weitere`,
+              } as any)}
+            </span>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/services/frontend/src/components/evaluation/__tests__/EvaluationResults.test.tsx
+++ b/services/frontend/src/components/evaluation/__tests__/EvaluationResults.test.tsx
@@ -168,6 +168,15 @@ jest.mock('@/components/tasks/TaskDataViewModal', () => ({
     ) : null,
 }))
 
+// The InflightRunsBanner uses `useConfirm` from `@/hooks/useDialogs`,
+// which requires a `DialogProvider` wrapper. These tests render
+// EvaluationResults directly without that provider — the banner
+// itself is tested separately in `InflightRunsBanner.test.tsx`, so
+// stubbing it out here is the right scope boundary.
+jest.mock('@/components/evaluation/InflightRunsBanner', () => ({
+  InflightRunsBanner: () => null,
+}))
+
 jest.mock('@heroicons/react/24/outline', () => ({
   ArrowDownTrayIcon: (props: any) => <span data-testid="arrow-down-tray-icon" {...props} />,
   ArrowPathIcon: (props: any) => <span data-testid="arrow-path-icon" {...props} />,

--- a/services/frontend/src/components/evaluation/__tests__/InflightRunsBanner.test.tsx
+++ b/services/frontend/src/components/evaluation/__tests__/InflightRunsBanner.test.tsx
@@ -1,0 +1,250 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Behavior tests for the in-flight runs banner: render gating, per-run
+ * cancel, bulk cancel, confirm dialog flow, failure-reason aggregation,
+ * and the +N overflow cap.
+ */
+import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { InflightRunsBanner } from '../InflightRunsBanner'
+
+// Stable mocks for the I18nContext — the banner uses `t(key, default)`
+// and `t(key, { defaultValue, count })`; preserve both shapes.
+jest.mock('@/contexts/I18nContext', () => ({
+  useI18n: () => ({
+    t: (_key: string, fallback: any) => {
+      if (typeof fallback === 'string') return fallback
+      if (fallback && typeof fallback === 'object' && 'defaultValue' in fallback) {
+        return fallback.defaultValue
+      }
+      return _key
+    },
+  }),
+}))
+
+const mockAddToast = jest.fn()
+jest.mock('@/components/shared/Toast', () => ({
+  useToast: () => ({ addToast: mockAddToast }),
+}))
+
+const mockCancelEvaluationRun = jest.fn()
+const mockCancelAll = jest.fn()
+jest.mock('@/lib/api/client', () => ({
+  apiClient: {
+    evaluations: {
+      cancelEvaluationRun: (...args: any[]) => mockCancelEvaluationRun(...args),
+      cancelAllProjectEvaluations: (...args: any[]) => mockCancelAll(...args),
+    },
+  },
+}))
+
+// `useConfirm` returns an async function that resolves to a boolean.
+// Default to "user clicked confirm" so we exercise the cancel path.
+const mockConfirm = jest.fn().mockResolvedValue(true)
+jest.mock('@/hooks/useDialogs', () => ({
+  useConfirm: () => mockConfirm,
+}))
+
+const baseRun = (id: string, overrides: any = {}) => ({
+  evaluation_id: id,
+  status: 'running',
+  samples_evaluated: 0,
+  eval_metadata: { cells_dispatched: 100, failures_by_reason: {} },
+  ...overrides,
+})
+
+const PROJECT_ID = 'proj-xyz'
+
+describe('InflightRunsBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockConfirm.mockResolvedValue(true)
+  })
+
+  test('renders nothing when no in-flight runs', () => {
+    const { container } = render(
+      <InflightRunsBanner
+        projectId={PROJECT_ID}
+        evaluations={[
+          { evaluation_id: 'r1', status: 'completed' },
+          { evaluation_id: 'r2', status: 'failed' },
+          { evaluation_id: 'r3', status: 'cancelled' },
+        ]}
+        onChanged={jest.fn()}
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  test('renders per-run row with progress and a Cancel button', () => {
+    render(
+      <InflightRunsBanner
+        projectId={PROJECT_ID}
+        evaluations={[
+          baseRun('aabbccddee112233', {
+            samples_evaluated: 42,
+            eval_metadata: { cells_dispatched: 100 },
+          }),
+        ]}
+        onChanged={jest.fn()}
+      />
+    )
+    // Shows the truncated id + progress.
+    expect(screen.getByText(/aabbccdd/)).toBeInTheDocument()
+    expect(screen.getByText(/42\/100/)).toBeInTheDocument()
+    // The role="status" + aria-live announce live changes for SRs.
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite')
+  })
+
+  test('bulk-cancel button hidden when only one in-flight, shown when >=2', () => {
+    const { rerender } = render(
+      <InflightRunsBanner
+        projectId={PROJECT_ID}
+        evaluations={[baseRun('r1')]}
+        onChanged={jest.fn()}
+      />
+    )
+    expect(screen.queryByText('Alle abbrechen')).not.toBeInTheDocument()
+
+    rerender(
+      <InflightRunsBanner
+        projectId={PROJECT_ID}
+        evaluations={[baseRun('r1'), baseRun('r2')]}
+        onChanged={jest.fn()}
+      />
+    )
+    expect(screen.getByText('Alle abbrechen')).toBeInTheDocument()
+  })
+
+  test('per-run cancel: confirm → API → toast → onChanged', async () => {
+    mockCancelEvaluationRun.mockResolvedValue({
+      cancelled_run_ids: ['r1'],
+      failed_child_judge_run_count: 0,
+      preserved_task_evaluation_count: 5,
+      message: 'ok',
+    })
+    const onChanged = jest.fn()
+    render(
+      <InflightRunsBanner
+        projectId={PROJECT_ID}
+        evaluations={[baseRun('r1aaaaaa')]}
+        onChanged={onChanged}
+      />
+    )
+    await userEvent.click(screen.getByLabelText('Diesen Lauf abbrechen'))
+    await waitFor(() => expect(mockConfirm).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(mockCancelEvaluationRun).toHaveBeenCalledWith('r1aaaaaa'))
+    await waitFor(() => expect(mockAddToast).toHaveBeenCalledTimes(1))
+    expect(mockAddToast.mock.calls[0][1]).toBe('success')
+    expect(onChanged).toHaveBeenCalledTimes(1)
+  })
+
+  test('per-run cancel: user clicks "keep running" in dialog → no API call', async () => {
+    mockConfirm.mockResolvedValueOnce(false)
+    render(
+      <InflightRunsBanner
+        projectId={PROJECT_ID}
+        evaluations={[baseRun('r1')]}
+        onChanged={jest.fn()}
+      />
+    )
+    await userEvent.click(screen.getByLabelText('Diesen Lauf abbrechen'))
+    await waitFor(() => expect(mockConfirm).toHaveBeenCalled())
+    expect(mockCancelEvaluationRun).not.toHaveBeenCalled()
+    expect(mockAddToast).not.toHaveBeenCalled()
+  })
+
+  test('per-run cancel: API failure shows error toast and re-enables button', async () => {
+    mockCancelEvaluationRun.mockRejectedValue(new Error('boom'))
+    render(
+      <InflightRunsBanner
+        projectId={PROJECT_ID}
+        evaluations={[baseRun('r1')]}
+        onChanged={jest.fn()}
+      />
+    )
+    const btn = screen.getByLabelText('Diesen Lauf abbrechen')
+    await userEvent.click(btn)
+    await waitFor(() => expect(mockAddToast).toHaveBeenCalledTimes(1))
+    expect(mockAddToast.mock.calls[0][1]).toBe('error')
+    // Button is not stuck in disabled state after error.
+    expect(btn).not.toBeDisabled()
+  })
+
+  test('cancel-all: API → toast', async () => {
+    mockCancelAll.mockResolvedValue({
+      cancelled_run_ids: ['r1', 'r2'],
+      failed_child_judge_run_count: 2,
+      preserved_task_evaluation_count: 99,
+      message: 'ok',
+    })
+    const onChanged = jest.fn()
+    render(
+      <InflightRunsBanner
+        projectId={PROJECT_ID}
+        evaluations={[baseRun('r1'), baseRun('r2')]}
+        onChanged={onChanged}
+      />
+    )
+    await userEvent.click(screen.getByText('Alle abbrechen'))
+    await waitFor(() => expect(mockCancelAll).toHaveBeenCalledWith(PROJECT_ID))
+    await waitFor(() => expect(mockAddToast).toHaveBeenCalledTimes(1))
+    expect(onChanged).toHaveBeenCalledTimes(1)
+  })
+
+  test('failure-reason breakdown aggregates across runs', () => {
+    render(
+      <InflightRunsBanner
+        projectId={PROJECT_ID}
+        evaluations={[
+          baseRun('r1', {
+            eval_metadata: {
+              cells_dispatched: 100,
+              failures_by_reason: { rate_limit: 5, timeout: 1 },
+            },
+          }),
+          baseRun('r2', {
+            eval_metadata: {
+              cells_dispatched: 100,
+              failures_by_reason: { rate_limit: 3, content_policy: 2 },
+            },
+          }),
+        ]}
+        onChanged={jest.fn()}
+      />
+    )
+    // rate_limit sums across both runs (5 + 3 = 8).
+    expect(screen.getByText('rate_limit: 8')).toBeInTheDocument()
+    expect(screen.getByText('timeout: 1')).toBeInTheDocument()
+    expect(screen.getByText('content_policy: 2')).toBeInTheDocument()
+  })
+
+  test('failure-reason badges cap at 8 with overflow chip', () => {
+    const reasons: Record<string, number> = {}
+    for (let i = 0; i < 12; i++) reasons[`reason_${i}`] = 12 - i
+    render(
+      <InflightRunsBanner
+        projectId={PROJECT_ID}
+        evaluations={[
+          baseRun('r1', {
+            eval_metadata: {
+              cells_dispatched: 100,
+              failures_by_reason: reasons,
+            },
+          }),
+        ]}
+        onChanged={jest.fn()}
+      />
+    )
+    // Top 8 by count are shown; the rest collapse into "+4 weitere".
+    // (Order is desc by count: reason_0=12, ..., reason_7=5 visible;
+    // reason_8=4, ..., reason_11=1 hidden.)
+    expect(screen.getByText('reason_0: 12')).toBeInTheDocument()
+    expect(screen.getByText('reason_7: 5')).toBeInTheDocument()
+    expect(screen.queryByText('reason_8: 4')).not.toBeInTheDocument()
+    expect(screen.getByText('+4 weitere')).toBeInTheDocument()
+  })
+})

--- a/services/frontend/src/lib/api/evaluations.ts
+++ b/services/frontend/src/lib/api/evaluations.ts
@@ -966,6 +966,38 @@ export class EvaluationsClient extends BaseApiClient {
   }
 
   /**
+   * Cancel a single in-flight evaluation run. Partial TaskEvaluation
+   * rows are preserved on the server so a `force_rerun=false` re-trigger
+   * picks up from where the cancelled run left off.
+   */
+  async cancelEvaluationRun(evaluationId: string): Promise<{
+    cancelled_run_ids: string[]
+    failed_child_judge_run_count: number
+    preserved_task_evaluation_count: number
+    message: string
+  }> {
+    return this.request(`/evaluations/run/${evaluationId}/cancel`, {
+      method: 'POST',
+    })
+  }
+
+  /**
+   * Cancel every in-flight (pending or running) evaluation on a project.
+   * Useful when an operator wants to stop a runaway re-trigger or
+   * multiple stuck runs at once.
+   */
+  async cancelAllProjectEvaluations(projectId: string): Promise<{
+    cancelled_run_ids: string[]
+    failed_child_judge_run_count: number
+    preserved_task_evaluation_count: number
+    message: string
+  }> {
+    return this.request(`/evaluations/projects/${projectId}/runs/cancel-all`, {
+      method: 'POST',
+    })
+  }
+
+  /**
    * Get detailed evaluation results.
    * Returns per-field-combination scores grouped by evaluation config.
    */

--- a/services/workers/Dockerfile
+++ b/services/workers/Dockerfile
@@ -17,4 +17,4 @@ RUN if [ -d "./shared" ]; then \
     fi
 
 # Start Celery Worker
-CMD ["celery", "-A", "tasks", "worker", "--loglevel=info", "-Q", "celery,emails,default,generation"]
+CMD ["celery", "-A", "tasks", "worker", "--loglevel=info", "-Q", "celery,emails,default,generation,evaluation"]

--- a/services/workers/tasks.py
+++ b/services/workers/tasks.py
@@ -3041,6 +3041,28 @@ def run_evaluation(
                     )
                 )
 
+            # Final cancel check just before chord dispatch. The
+            # orchestrator's setup phase (judge_run creation, work-unit
+            # enumeration, missing-only preload) can run for ~25 s on a
+            # ZJS-scale eval; an admin or operator hitting Cancel during
+            # that window should stop us BEFORE we fan out 6940 sub-tasks
+            # that each immediately short-circuit on their own
+            # parent-status check. Saves Celery message churn + worker
+            # CPU for no useful work.
+            db.refresh(evaluation)
+            if evaluation.status in ("cancelled", "failed", "completed"):
+                logger.info(
+                    f"Eval {evaluation_id} reached terminal status "
+                    f"'{evaluation.status}' during orchestrator setup; "
+                    f"skipping chord dispatch."
+                )
+                return {
+                    "status": "cancelled_before_dispatch",
+                    "evaluation_id": evaluation_id,
+                    "current_status": evaluation.status,
+                    "cells_would_have_dispatched": cells_dispatched,
+                }
+
             callback_sig = finalize_evaluation_run.signature(
                 kwargs={"evaluation_id": evaluation_id},
                 queue="evaluation",
@@ -3947,6 +3969,91 @@ def _build_sample_evaluator_for_cell(
     return SampleEvaluator(evaluation_id, field_configs, metric_parameters)
 
 
+_CELL_ATTEMPT_TTL_SECS = 86400
+_CELL_ATTEMPT_LIMIT = 3
+
+
+def _record_cell_attempt(evaluation_id: str, cell_key: str) -> int:
+    """Per-cell attempt counter in Redis, used as a poison-cell guard.
+
+    With `acks_late=True` + `reject_on_worker_lost=True` on the cell
+    sub-tasks, a cell that deterministically crashes the worker (e.g.
+    deterministic OOM on a 50KB generation with all embedding metrics)
+    would be redelivered indefinitely — `max_retries` only counts
+    explicit `self.retry()` calls, not broker-level redeliveries. This
+    counter caps that loop: after `_CELL_ATTEMPT_LIMIT` redeliveries
+    the sub-task records the failure reason and short-circuits, the
+    chord still completes, and the parent run finalizes without
+    burning unbounded LLM/judge quota.
+
+    Falls back to "first attempt" on Redis error rather than blocking
+    the eval; a Redis outage shouldn't fail-open into burning quota
+    long-term, but during the outage we'd rather process normally.
+    """
+    try:
+        client = redis.from_url(app.conf.broker_url)
+        key = f"benger:cell_attempts:{evaluation_id}:{cell_key}"
+        n = client.incr(key)
+        client.expire(key, _CELL_ATTEMPT_TTL_SECS)
+        return int(n)
+    except Exception as ex:
+        logger.warning(f"_record_cell_attempt redis error: {ex}; treating as first attempt")
+        return 1
+
+
+def _record_cell_failure_reason(db, evaluation_id: str, reason: str) -> None:
+    """Increment `eval_metadata.failures_by_reason[reason]` so the UI
+    can surface *why* cells silently failed (rate-limit, judge timeout,
+    poison cell, etc.) instead of just `samples_failed=N` with no
+    breakdown. Uses `jsonb_set(... , create_missing=true)` so the
+    nested object is created on first failure of any kind.
+
+    Skips entirely when the parent is already terminal, mirroring the
+    `_bump_evaluation_counters` guard."""
+    from sqlalchemy import text as _text
+
+    db.execute(
+        _text(
+            """
+            UPDATE evaluation_runs
+               SET eval_metadata = (
+                 jsonb_set(
+                   COALESCE(eval_metadata::jsonb, '{}'::jsonb),
+                   ARRAY['failures_by_reason', :reason],
+                   to_jsonb(
+                     COALESCE(
+                       (eval_metadata::jsonb->'failures_by_reason'->>:reason)::int,
+                       0
+                     ) + 1
+                   ),
+                   true
+                 )
+               )::json
+             WHERE id = :evaluation_id
+               AND status NOT IN ('completed', 'failed', 'cancelled')
+            """
+        ),
+        {"evaluation_id": evaluation_id, "reason": reason},
+    )
+
+
+def _classify_cell_failure(exc: BaseException) -> str:
+    """Bucket a cell exception into a stable string the UI can group
+    on. Conservative: just use the exception class name if we don't
+    recognise a known LLM-provider error pattern."""
+    name = type(exc).__name__.lower()
+    msg = str(exc).lower()
+    if "rate" in name or "rate_limit" in msg or "rate limit" in msg or "429" in msg:
+        return "rate_limit"
+    if "timeout" in name or "timeout" in msg:
+        return "timeout"
+    if "content" in msg and ("policy" in msg or "filter" in msg):
+        return "content_policy"
+    if "quota" in msg or "exceeded" in msg:
+        return "quota_exceeded"
+    return type(exc).__name__
+
+
 def _bulk_upsert_task_evaluations(
     db, rows: List[Dict[str, Any]]
 ) -> Tuple[int, int, int]:
@@ -4104,6 +4211,23 @@ def evaluate_generation_cell(
         if parent_status in ("cancelled", "failed", "completed"):
             return {"status": "skipped", "reason": f"parent_{parent_status}",
                     "evaluation_id": evaluation_id, "generation_id": generation_id}
+
+        # Poison-cell guard: cap broker-level redeliveries via Redis
+        # counter so a deterministic-OOM cell doesn't loop forever.
+        attempts = _record_cell_attempt(evaluation_id, f"gen:{generation_id}")
+        if attempts > _CELL_ATTEMPT_LIMIT:
+            logger.error(
+                f"evaluate_generation_cell: poison cell — gen {generation_id} "
+                f"hit attempt #{attempts} for eval {evaluation_id}; bailing"
+            )
+            _record_cell_failure_reason(db, evaluation_id, "poison_cell_max_attempts")
+            _bump_evaluation_counters(
+                db, evaluation_id=evaluation_id,
+                samples_evaluated=0, samples_passed=0, samples_failed=1,
+            )
+            db.commit()
+            return {"status": "poisoned", "evaluation_id": evaluation_id,
+                    "generation_id": generation_id, "attempts": attempts}
 
         gen = db.query(Generation).filter(Generation.id == generation_id).first()
         if not gen:
@@ -4517,9 +4641,10 @@ def evaluate_generation_cell(
         )
         db.rollback()
         # Don't propagate — the chord finalizer must still fire. Best-effort
-        # increment of `samples_failed` so the finalizer's parent-status
-        # logic accounts for this cell.
+        # increment of `samples_failed` and record the failure reason so
+        # the UI can surface *why* the cell silently produced no row.
         try:
+            _record_cell_failure_reason(db, evaluation_id, _classify_cell_failure(e))
             _bump_evaluation_counters(
                 db,
                 evaluation_id=evaluation_id,
@@ -4585,6 +4710,22 @@ def evaluate_annotation_cell(
         if parent_status in ("cancelled", "failed", "completed"):
             return {"status": "skipped", "reason": f"parent_{parent_status}",
                     "evaluation_id": evaluation_id, "annotation_id": annotation_id}
+
+        # Poison-cell guard — mirror of evaluate_generation_cell.
+        attempts = _record_cell_attempt(evaluation_id, f"ann:{annotation_id}")
+        if attempts > _CELL_ATTEMPT_LIMIT:
+            logger.error(
+                f"evaluate_annotation_cell: poison cell — ann {annotation_id} "
+                f"hit attempt #{attempts} for eval {evaluation_id}; bailing"
+            )
+            _record_cell_failure_reason(db, evaluation_id, "poison_cell_max_attempts")
+            _bump_evaluation_counters(
+                db, evaluation_id=evaluation_id,
+                samples_evaluated=0, samples_passed=0, samples_failed=1,
+            )
+            db.commit()
+            return {"status": "poisoned", "evaluation_id": evaluation_id,
+                    "annotation_id": annotation_id, "attempts": attempts}
 
         annotation = db.query(Annotation).filter(Annotation.id == annotation_id).first()
         if not annotation:
@@ -4957,6 +5098,7 @@ def evaluate_annotation_cell(
         )
         db.rollback()
         try:
+            _record_cell_failure_reason(db, evaluation_id, _classify_cell_failure(e))
             _bump_evaluation_counters(
                 db,
                 evaluation_id=evaluation_id,

--- a/services/workers/tasks.py
+++ b/services/workers/tasks.py
@@ -3947,37 +3947,46 @@ def _build_sample_evaluator_for_cell(
     return SampleEvaluator(evaluation_id, field_configs, metric_parameters)
 
 
-def _bulk_upsert_task_evaluations(db, rows: List[Dict[str, Any]]) -> int:
+def _bulk_upsert_task_evaluations(
+    db, rows: List[Dict[str, Any]]
+) -> Tuple[int, int, int]:
     """Insert TaskEvaluation rows with `ON CONFLICT DO NOTHING` against
     the partial unique index `uq_task_evaluations_cell` from migration 048.
 
-    Returns the rowcount actually inserted (may be < len(rows) if some
-    were silently deduped against an existing row — that's the idempotency
-    guarantee under concurrent retries / redelivered Celery tasks).
+    Returns `(rows_actually_inserted, passed_count, failed_count)` —
+    counts derived from `RETURNING passed` so the caller can bump parent
+    counters by the *real* number of rows that landed, not by the number
+    requested. On a Celery message redelivery, all rows hit conflict and
+    `(0, 0, 0)` is returned: the redelivered task contributes nothing to
+    `samples_evaluated` / `samples_passed` / `samples_failed`, eliminating
+    the double-bump race that an unconditional `samples_evaluated += N`
+    would have on retry.
+
+    SQLAlchemy's bare `ON CONFLICT DO NOTHING` (no `index_elements`)
+    catches any unique-constraint violation. The only partial unique
+    index on this table is `uq_task_evaluations_cell` (migration 048);
+    UUID PKs are generated fresh per insert so PK collisions are
+    statistically impossible. If a future migration adds another unique
+    index here, tighten this to `index_where=` to pin the conflict
+    target.
     """
     if not rows:
-        return 0
+        return (0, 0, 0)
     from sqlalchemy.dialects.postgresql import insert as pg_insert
     from models import TaskEvaluation
 
-    # The unique index uses COALESCE() expressions and a WHERE predicate,
-    # so SQLAlchemy's `index_elements` shortcut can't infer it. Reference
-    # the index by name via `constraint=`.
-    stmt = pg_insert(TaskEvaluation.__table__).values(rows)
-    stmt = stmt.on_conflict_do_nothing(index_elements=None)
-    # Force the conflict target to our partial expression index. psycopg2
-    # accepts `ON CONFLICT ON CONSTRAINT` syntax via `constraint=` for
-    # named constraints, but for expression indexes we must use the
-    # `index_where` clause. The simplest reliable form is to emit the
-    # raw conflict target.
-    from sqlalchemy import text as _text
-
-    # SQLAlchemy's on_conflict_do_nothing with index_elements=None emits
-    # bare `ON CONFLICT DO NOTHING` which Postgres treats as "any unique
-    # constraint" — that's what we want here (only one unique index that
-    # could fire is the one from migration 048).
+    stmt = (
+        pg_insert(TaskEvaluation.__table__)
+        .values(rows)
+        .on_conflict_do_nothing()
+        .returning(TaskEvaluation.__table__.c.passed)
+    )
     result = db.execute(stmt)
-    return result.rowcount or 0
+    returned = result.fetchall()
+    n_inserted = len(returned)
+    n_passed = sum(1 for r in returned if r.passed)
+    n_failed = n_inserted - n_passed
+    return (n_inserted, n_passed, n_failed)
 
 
 def _bump_evaluation_counters(
@@ -4003,6 +4012,14 @@ def _bump_evaluation_counters(
 
     if samples_evaluated == 0 and samples_passed == 0 and samples_failed == 0:
         return
+    # The `status NOT IN ('completed','failed','cancelled')` filter is
+    # the TOCTOU guard for finalize: once the chord callback marks the
+    # parent terminal, any late sub-task bump (e.g. from a Celery
+    # message redelivery after the chord backend's barrier released)
+    # becomes a no-op (rowcount=0) instead of clobbering the finalized
+    # counters or resurrecting `eval_metadata`. Also covers the
+    # admin-cancels-mid-run case — once status='cancelled' lands, no
+    # further per-cell work mutates the parent row.
     db.execute(
         _text(
             """
@@ -4021,6 +4038,7 @@ def _bump_evaluation_counters(
                    )::json,
                    has_sample_results = true
              WHERE id = :evaluation_id
+               AND status NOT IN ('completed', 'failed', 'cancelled')
             """
         ),
         {
@@ -4032,7 +4050,13 @@ def _bump_evaluation_counters(
     )
 
 
-@app.task(name="tasks.evaluate_generation_cell", bind=True, max_retries=2)
+@app.task(
+    name="tasks.evaluate_generation_cell",
+    bind=True,
+    max_retries=2,
+    acks_late=True,
+    reject_on_worker_lost=True,
+)
 def evaluate_generation_cell(
     self,
     evaluation_id: str,
@@ -4066,6 +4090,20 @@ def evaluate_generation_cell(
     try:
         from models import EvaluationRun, Generation, TaskEvaluation
         from project_models import Annotation, Task
+
+        # Parent-status short-circuit. The legacy bundled task checked
+        # `EvaluationRun.status` at the top of each iteration and bailed
+        # if the user/admin cancelled mid-run; with chord fan-out, the
+        # ~6940 cells are already in-flight when cancel happens, so each
+        # sub-task must re-check itself or the cancellation does nothing
+        # but mark the parent terminal. Avoid burning LLM quota on
+        # cancelled work.
+        parent_status = db.query(EvaluationRun.status).filter(
+            EvaluationRun.id == evaluation_id
+        ).scalar()
+        if parent_status in ("cancelled", "failed", "completed"):
+            return {"status": "skipped", "reason": f"parent_{parent_status}",
+                    "evaluation_id": evaluation_id, "generation_id": generation_id}
 
         gen = db.query(Generation).filter(Generation.id == generation_id).first()
         if not gen:
@@ -4449,13 +4487,18 @@ def evaluate_generation_cell(
                         local_samples_failed += 1
 
         # Bulk upsert + atomic counter bump. One commit per sub-task.
-        _bulk_upsert_task_evaluations(db, sample_results)
+        # Bump by the *actually inserted* row count (from RETURNING),
+        # not by the locally-tallied counts. On Celery message
+        # redelivery, all rows conflict and `n_inserted == 0`, so the
+        # redelivered task contributes nothing to the parent counters
+        # — defense against the `acks_late=True` double-bump path.
+        n_inserted, n_passed, n_failed = _bulk_upsert_task_evaluations(db, sample_results)
         _bump_evaluation_counters(
             db,
             evaluation_id=evaluation_id,
-            samples_evaluated=local_samples_evaluated,
-            samples_passed=local_samples_passed,
-            samples_failed=local_samples_failed,
+            samples_evaluated=n_inserted,
+            samples_passed=n_passed,
+            samples_failed=n_failed,
         )
         db.commit()
         return {
@@ -4463,9 +4506,9 @@ def evaluate_generation_cell(
             "evaluation_id": evaluation_id,
             "task_id": task_id,
             "generation_id": generation_id,
-            "samples_added": local_samples_evaluated,
-            "samples_passed": local_samples_passed,
-            "samples_failed": local_samples_failed,
+            "samples_added": n_inserted,
+            "samples_passed": n_passed,
+            "samples_failed": n_failed,
         }
     except Exception as e:
         logger.error(
@@ -4498,7 +4541,13 @@ def evaluate_generation_cell(
         db.close()
 
 
-@app.task(name="tasks.evaluate_annotation_cell", bind=True, max_retries=2)
+@app.task(
+    name="tasks.evaluate_annotation_cell",
+    bind=True,
+    max_retries=2,
+    acks_late=True,
+    reject_on_worker_lost=True,
+)
 def evaluate_annotation_cell(
     self,
     evaluation_id: str,
@@ -4528,6 +4577,14 @@ def evaluate_annotation_cell(
         from project_models import Annotation, Task
         from annotation_utils import extract_all_field_values as _extract_all_fields
         from eval_field_classification import classify_pred_fields
+
+        # Parent-status short-circuit — mirror of evaluate_generation_cell.
+        parent_status = db.query(EvaluationRun.status).filter(
+            EvaluationRun.id == evaluation_id
+        ).scalar()
+        if parent_status in ("cancelled", "failed", "completed"):
+            return {"status": "skipped", "reason": f"parent_{parent_status}",
+                    "evaluation_id": evaluation_id, "annotation_id": annotation_id}
 
         annotation = db.query(Annotation).filter(Annotation.id == annotation_id).first()
         if not annotation:
@@ -4874,13 +4931,14 @@ def evaluate_annotation_cell(
                             local_samples_evaluated += 1
                             local_samples_failed += 1
 
-        _bulk_upsert_task_evaluations(db, sample_results)
+        # Bump by RETURNING-derived counts — see gen sub-task for rationale.
+        n_inserted, n_passed, n_failed = _bulk_upsert_task_evaluations(db, sample_results)
         _bump_evaluation_counters(
             db,
             evaluation_id=evaluation_id,
-            samples_evaluated=local_samples_evaluated,
-            samples_passed=local_samples_passed,
-            samples_failed=local_samples_failed,
+            samples_evaluated=n_inserted,
+            samples_passed=n_passed,
+            samples_failed=n_failed,
         )
         db.commit()
         return {
@@ -4888,9 +4946,9 @@ def evaluate_annotation_cell(
             "evaluation_id": evaluation_id,
             "task_id": task_id,
             "annotation_id": annotation_id,
-            "samples_added": local_samples_evaluated,
-            "samples_passed": local_samples_passed,
-            "samples_failed": local_samples_failed,
+            "samples_added": n_inserted,
+            "samples_passed": n_passed,
+            "samples_failed": n_failed,
         }
     except Exception as e:
         logger.error(
@@ -4920,7 +4978,12 @@ def evaluate_annotation_cell(
         db.close()
 
 
-@app.task(name="tasks.finalize_evaluation_run", bind=True)
+@app.task(
+    name="tasks.finalize_evaluation_run",
+    bind=True,
+    acks_late=True,
+    reject_on_worker_lost=True,
+)
 def finalize_evaluation_run(
     self,
     _sub_task_results: Any,

--- a/services/workers/tasks.py
+++ b/services/workers/tasks.py
@@ -3992,8 +3992,12 @@ def _bump_evaluation_counters(
 
     Postgres serializes row-level UPDATEs on `id = :evaluation_id`, so
     concurrent sub-task bumps don't lose updates. `samples_passed` and
-    `samples_failed` live inside the `eval_metadata` JSONB blob; bump
-    them with `jsonb_set` + `coalesce` so a missing key starts from 0.
+    `samples_failed` live inside the `eval_metadata` blob; bump them
+    with `jsonb_set` + `coalesce` so a missing key starts from 0. The
+    column is typed `json` (legacy), and Postgres 18 with FIPS-enforced
+    OpenSSL refuses implicit `json`↔`jsonb` coercion — so cast
+    explicitly: `eval_metadata::jsonb` for the read side, then
+    `(... )::json` to write back.
     """
     from sqlalchemy import text as _text
 
@@ -4004,15 +4008,17 @@ def _bump_evaluation_counters(
             """
             UPDATE evaluation_runs
                SET samples_evaluated = COALESCE(samples_evaluated, 0) + :n,
-                   eval_metadata = jsonb_set(
+                   eval_metadata = (
                        jsonb_set(
-                           COALESCE(eval_metadata, '{}'::jsonb),
-                           '{samples_passed}',
-                           to_jsonb(COALESCE((eval_metadata->>'samples_passed')::int, 0) + :p)
-                       ),
-                       '{samples_failed}',
-                       to_jsonb(COALESCE((eval_metadata->>'samples_failed')::int, 0) + :f)
-                   ),
+                           jsonb_set(
+                               COALESCE(eval_metadata::jsonb, '{}'::jsonb),
+                               '{samples_passed}',
+                               to_jsonb(COALESCE((eval_metadata->>'samples_passed')::int, 0) + :p)
+                           ),
+                           '{samples_failed}',
+                           to_jsonb(COALESCE((eval_metadata->>'samples_failed')::int, 0) + :f)
+                       )
+                   )::json,
                    has_sample_results = true
              WHERE id = :evaluation_id
             """

--- a/services/workers/tasks.py
+++ b/services/workers/tasks.py
@@ -2726,7 +2726,19 @@ def run_evaluation(
                             params_snapshot=None,
                         )
 
-            # Load tasks with annotations
+            # ── Work-unit enumeration ───────────────────────────────────────────
+            #
+            # Replaces the prior in-process loop that did the actual evaluation
+            # work. The orchestrator now ONLY enumerates what's left to do
+            # (tasks × generations and tasks × annotations after applying
+            # scope filters + `evaluate_missing_only` skip set), then
+            # dispatches one Celery sub-task per cell via a chord. Cell
+            # sub-tasks run in parallel across the worker pool; the chord
+            # callback (`finalize_evaluation_run`) aggregates child statuses
+            # and computes the final metrics dict exactly once when every
+            # header sub-task has finished.
+
+            # Load tasks (same filters as the legacy body)
             tasks_query = db.query(Task).filter(Task.project_id == project_id)
             if task_ids:
                 tasks_query = tasks_query.filter(Task.id.in_(task_ids))
@@ -2742,9 +2754,9 @@ def run_evaluation(
                     "evaluation_id": evaluation_id,
                 }
 
-            logger.info(f"Loaded {len(tasks)} tasks for evaluation")
+            logger.info(f"Loaded {len(tasks)} tasks for evaluation enumeration")
 
-            # Pre-compute expected field keys from enabled configs
+            # Pre-compute expected field keys (same as legacy 2747-2753).
             all_expected_field_keys = {
                 f"{c.get('id', 'unknown')}|{pf}|{rf}"
                 for c in enabled_configs
@@ -2752,19 +2764,12 @@ def run_evaluation(
                 for rf in c.get("reference_fields", [])
             }
 
-            # Bulk-load successfully evaluated (generation_id, field_name) pairs
-            # Checks ALL evaluation runs (not just current) so interrupted runs can be resumed
-            # field_name includes config_id so different configs won't collide
-            evaluated_by_gen: dict[str, set[str]] = {}
+            # Pre-load the gen-side missing-only skip set (same query as
+            # legacy 2755-2794 — terminal-error rows count as "tried" to
+            # avoid hopeless retries).
+            evaluated_by_gen: Dict[str, set] = {}
             if evaluate_missing_only:
                 task_id_list = [t.id for t in tasks]
-                # Mirror the read path in
-                # `services/api/routers/evaluations/results.py` (status
-                # filter on EvaluationRun): rows from cancelled/failed runs
-                # are hidden as `n/a` in the UI, so the missing-detector
-                # must also ignore them — otherwise a phantom row from a
-                # killed run masks the cell as "already evaluated" and it
-                # never gets retried.
                 existing = (
                     db.query(
                         TaskEvaluation.generation_id,
@@ -2780,1229 +2785,245 @@ def run_evaluation(
                     .all()
                 )
                 for r in existing:
-                    # Terminal-error rows are NOT scored, but missing-only must
-                    # still treat them as "tried" so a known-failed evaluation
-                    # doesn't get retried indefinitely (causing stub pile-up
-                    # and burning API quota on a hopeless target).
                     if _row_has_score(r.metrics) or _row_is_terminal_error(r.metrics):
                         evaluated_by_gen.setdefault(r.generation_id, set()).add(
                             _normalize_field_key(r.field_name, is_annotation=False)
                         )
                 logger.info(
-                    f"Loaded existing evaluations: {sum(len(v) for v in evaluated_by_gen.values())} "
+                    f"Loaded existing gen evaluations: {sum(len(v) for v in evaluated_by_gen.values())} "
                     f"results across {len(evaluated_by_gen)} generations"
                 )
 
-            # Build field configs for SampleEvaluator
-            field_configs = {}
-            metric_parameters = {}
-            for config in enabled_configs:
-                config_id = config.get("id", "unknown")
-                metric = config.get("metric", "")
-                params = config.get("metric_parameters", {})
-
-                # For each prediction-reference field pair
-                for pred_field in config.get("prediction_fields", []):
-                    for ref_field in config.get("reference_fields", []):
-                        field_key = f"{config_id}|{pred_field}|{ref_field}"
-                        field_configs[field_key] = {"type": "text"}
-                        if params:
-                            metric_parameters[field_key] = {metric: params}
-
-            sample_evaluator = SampleEvaluator(evaluation_id, field_configs, metric_parameters)
-
-            # Process tasks
-            sample_results = []
-            aggregate_metrics = {}
-            samples_evaluated = 0
-            samples_passed = 0
-            samples_failed = 0
-
-            # Check if any config uses annotation fields (not task.* fields)
-            uses_annotation_fields = any(
-                any(not ref.startswith("task.") for ref in config.get("reference_fields", []))
-                for config in enabled_configs
+            # Enumerate generation cells.
+            uses_all_model = any(
+                "__all_model__" in c.get("prediction_fields", []) for c in enabled_configs
             )
-
+            gen_cells: List[tuple] = []  # (task_id, generation_id)
             for task in tasks:
-                # Get annotations (ground truth) - only needed if using annotation reference fields
-                ground_truth_annotation = None
-                if uses_annotation_fields:
-                    annotations = db.query(Annotation).filter(Annotation.task_id == task.id).all()
-                    if annotations:
-                        ground_truth_annotation = annotations[0]
-
-                # Get generations for this task
-                # Check if any config uses __all_model__ - if so, include failed parses too
-                # (we can use raw response_content as prediction)
-                uses_all_model = any(
-                    "__all_model__" in config.get("prediction_fields", [])
-                    for config in enabled_configs
-                )
-
                 generations_query = db.query(Generation).filter(Generation.task_id == task.id)
-
-                # Only filter by parse_status if not using __all_model__
                 if not uses_all_model:
                     generations_query = generations_query.filter(
                         Generation.parse_status == "success"
                     )
-
-                # Filter by label_config_version if specified
                 if label_config_version:
                     generations_query = generations_query.filter(
                         Generation.label_config_version == label_config_version
                     )
-
-                # Filter by model_ids if specified (for single-cell re-evaluation
-                # or for scoped runs from the eval modal — issue #69).
                 if model_ids:
                     generations_query = generations_query.filter(
                         Generation.model_id.in_(model_ids)
                     )
-
                 generations = generations_query.all()
-
-                if not generations:
-                    logger.debug(f"Task {task.id} has no generations, skipping")
-                    continue
-
-                # Evaluate each generation against each config
-                for generation in generations:
-                    # Skip fully-evaluated generations (all configs done)
+                for gen in generations:
                     if evaluate_missing_only:
-                        gen_done = evaluated_by_gen.get(generation.id, set())
+                        gen_done = evaluated_by_gen.get(gen.id, set())
                         if all_expected_field_keys and all_expected_field_keys.issubset(gen_done):
-                            logger.info(
-                                f"Skipping fully-evaluated generation {generation.id} "
-                                f"(model: {generation.model_id})"
-                            )
+                            # Fully evaluated already; nothing to dispatch for this cell.
                             continue
+                    gen_cells.append((task.id, gen.id))
 
-                    for config in enabled_configs:
-                        config_id = config.get("id", "unknown")
-                        metric = config.get("metric", "")
-                        prediction_fields = config.get("prediction_fields", [])
-                        reference_fields = config.get("reference_fields", [])
+            # Annotation-side enumeration. The legacy body at ~3357-3412
+            # pre-loaded all annotations once (with the annotator_user_ids
+            # scope filter applied) and the existing-annotation-eval set
+            # for dedup. We keep that pattern, just used for enumeration
+            # instead of in-place iteration.
+            ann_cells: List[tuple] = []  # (task_id, annotation_id)
+            has_human_config = False
+            try:
+                from eval_field_classification import classify_pred_fields as _classify_pf
 
-                        # Korrektur is human-graded only; never persisted by the
-                        # worker. Skip the entire config for the model-gen path
-                        # (the human-eval path below also skips it).
-                        if metric.startswith("korrektur_"):
-                            continue
+                for c in enabled_configs:
+                    metric = c.get("metric", "")
+                    if metric.startswith("korrektur_"):
+                        continue
+                    human_pfs, _ = _classify_pf(metric, c.get("prediction_fields", []))
+                    if human_pfs:
+                        has_human_config = True
+                        break
+            except Exception:
+                has_human_config = False
 
-                        # Evaluate each field pair
-                        for pred_field in prediction_fields:
-                            # Skip human annotation fields — handled in annotation section below
-                            if pred_field.startswith("human:") or pred_field == "__all_human__":
-                                continue
-
-                            for ref_field in reference_fields:
-                                field_key = f"{config_id}|{pred_field}|{ref_field}"
-
-                                # Skip already-evaluated config+field pairs.
-                                # Normalize on lookup so legacy colon/no-prefix
-                                # rows match the canonical format.
-                                if evaluate_missing_only and _normalize_field_key(
-                                    field_key, is_annotation=False
-                                ) in evaluated_by_gen.get(generation.id, set()):
-                                    continue
-
-                                # Extract ground truth - from task.data if prefixed with "task."
-                                if ref_field.startswith("task."):
-                                    # Extract from task.data (e.g., "task.binary_solution" -> task.data['binary_solution'])
-                                    data_field = ref_field[5:]  # Remove "task." prefix
-                                    ground_truth = task.data.get(data_field) if task.data else None
-                                elif ground_truth_annotation:
-                                    # Extract from annotation
-                                    ground_truth = _extract_field_value_from_annotation(
-                                        ground_truth_annotation.result or [], ref_field
-                                    )
-                                    # Fallback: check task.data if not found in annotation
-                                    # (matches immediate evaluation behavior at line ~2955)
-                                    if ground_truth is None and task.data and ref_field in task.data:
-                                        ground_truth = task.data.get(ref_field)
-                                else:
-                                    # No annotation — try task.data directly
-                                    ground_truth = task.data.get(ref_field) if task.data else None
-                                if ground_truth is None:
-                                    logger.warning(
-                                        f"Evaluation skip: reference field '{ref_field}' not found "
-                                        f"for task {task.id} (config {config_id})"
-                                    )
-                                    continue
-
-                                # Strip model: prefix for extraction from parsed_annotation
-                                base_field = pred_field
-                                if pred_field.startswith("model:"):
-                                    base_field = pred_field[6:]
-
-                                # Extract prediction from generation
-                                # Handle special __all_model__ field - use raw response_content
-                                if pred_field == "__all_model__":
-                                    prediction = generation.response_content
-                                else:
-                                    prediction = _extract_field_value_from_parsed_annotation(
-                                        generation.parsed_annotation, base_field
-                                    )
-                                    # Fallback to response_content if parsed_annotation is empty/null
-                                    if prediction is None and generation.response_content:
-                                        prediction = generation.response_content
-                                if prediction is None:
-                                    logger.warning(
-                                        f"Evaluation skip: prediction field '{pred_field}' not found "
-                                        f"for task {task.id}, model {generation.model_id} (config {config_id})"
-                                    )
-                                    continue
-
-                                # Evaluate this sample
-                                # Allow unparsed generations when using __all_model__ (raw response_content)
-                                allow_unparsed = pred_field == "__all_model__"
-                                try:
-                                    # Guard: an llm_judge_* metric whose
-                                    # evaluator wasn't initialized at startup
-                                    # (typically because the API key lookup
-                                    # failed for the triggering user/org) must
-                                    # NOT silently fall through to
-                                    # sample_evaluator. The standard sample
-                                    # evaluator can't compute LLM-judge metrics
-                                    # and would write a row with a literal null
-                                    # value and no error — silently corrupting
-                                    # the user's data. Persist a terminal-error
-                                    # row instead so missing-only stops
-                                    # retrying.
-                                    if (
-                                        metric.startswith("llm_judge_")
-                                        and config_id not in llm_judge_evaluators
-                                    ):
-                                        import uuid as _guard_uuid
-                                        sample_results.append({
-                                            "id": str(_guard_uuid.uuid4()),
-                                            "evaluation_id": evaluation_id,
-                                            # Migration 043 made judge_run_id NOT NULL.
-                                            # When the judge can't initialize there's no
-                                            # per-judge child run to point at, so we
-                                            # attach the per-evaluation default fallback
-                                            # so the row persists as a terminal-error
-                                            # marker instead of crashing with a
-                                            # NotNullViolation.
-                                            "judge_run_id": default_judge_run_id,
-                                            "task_id": task.id,
-                                            "generation_id": generation.id,
-                                            "field_name": field_key,
-                                            "answer_type": "text",
-                                            "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
-                                            "prediction": str(prediction)[:1000] if prediction else "",
-                                            "metrics": {
-                                                metric: {
-                                                    "value": None,
-                                                    "method": metric,
-                                                    "error": (
-                                                        f"LLM judge evaluator not initialized for config "
-                                                        f"{config_id} — likely missing API key for the "
-                                                        f"triggering user/org. Run skipped this metric."
-                                                    ),
-                                                    "details": {},
-                                                },
-                                            },
-                                            "passed": False,
-                                            "error_message": (
-                                                f"LLM judge evaluator not initialized for config "
-                                                f"{config_id}"
-                                            ),
-                                        })
-                                        samples_evaluated += 1
-                                        samples_failed += 1
-                                        continue
-                                    if (
-                                        metric.startswith("llm_judge_")
-                                        and config_id in llm_judge_evaluators
-                                    ):
-                                        # ── Multi-judge / multi-run fan-out ──
-                                        # One LLM call per (judge_model, run_index)
-                                        # entry; one TaskEvaluation row per call.
-                                        # The order of judge_runs_by_config[cid]
-                                        # is the user-configured order so the
-                                        # judge ensemble UI can label them
-                                        # consistently across re-renders.
-                                        per_judge_results: List[Dict[str, Any]] = []
-
-                                        # Get context from task data (shared across judges)
-                                        context = (
-                                            _get_insensitive(task.data, "text")
-                                            or _get_insensitive(task.data, "input")
-                                            or _get_insensitive(task.data, "sachverhalt")
-                                            or ""
-                                        )
-
-                                        # Falloesung: override ground_truth from task data
-                                        eval_ground_truth = str(ground_truth) if ground_truth else ""
-                                        if metric == "llm_judge_falloesung" and task.data:
-                                            muster = _get_insensitive(task.data, "musterloesung") or _get_insensitive(task.data, "musterlösung")
-                                            if muster:
-                                                eval_ground_truth = str(muster)
-
-                                        # Determine criterion from metric name (shared)
-                                        criterion = metric.replace("llm_judge_", "")
-                                        if criterion == "custom":
-                                            criterion = "correctness"
-                                        elif criterion == "overall":
-                                            criterion = "correctness"
-
-                                        for jr_entry in judge_runs_by_config.get(config_id, []):
-                                            jr_evaluator = jr_entry["evaluator"]
-                                            jr_id = jr_entry["judge_run_id"]
-                                            jr_judge_model = jr_entry["judge_model_id"]
-                                            jr_run_index = jr_entry["run_index"]
-
-                                            if jr_evaluator is None:
-                                                # This judge_run failed init — record a terminal-error
-                                                # TaskEvaluation row so the per-judge stats see the failure.
-                                                import uuid as _err_uuid
-
-                                                per_judge_results.append({
-                                                    "id": str(_err_uuid.uuid4()),
-                                                    "evaluation_id": evaluation_id,
-                                                    "judge_run_id": jr_id,
-                                                    "task_id": task.id,
-                                                    "generation_id": generation.id,
-                                                    "field_name": field_key,
-                                                    "answer_type": "text",
-                                                    "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
-                                                    "prediction": str(prediction)[:1000] if prediction else "",
-                                                    "metrics": {
-                                                        metric: {
-                                                            "value": None,
-                                                            "method": metric,
-                                                            "error": f"judge {jr_judge_model} run {jr_run_index} not initialized",
-                                                            "details": {},
-                                                        },
-                                                    },
-                                                    "passed": False,
-                                                    "error_message": f"judge {jr_judge_model} run {jr_run_index} not initialized",
-                                                })
-                                                continue
-
-                                            # One LLM call per judge_run.
-                                            # Falloesung is dispatched through the extended
-                                            # package: the prompt, JSON schema, parser and
-                                            # dimensions semantics are extended-only logic.
-                                            # Platform owns persistence (the loop below);
-                                            # extended owns compute. Mirror of the
-                                            # immediate-eval hook at the
-                                            # ``run_single_sample_evaluation`` site below.
-                                            if metric == "llm_judge_falloesung":
-                                                try:
-                                                    from benger_extended.workers import (
-                                                        get_falloesung_bulk_compute_fn,
-                                                    )
-                                                except ImportError as exc:
-                                                    raise RuntimeError(
-                                                        "Metric 'llm_judge_falloesung' requires the "
-                                                        "benger_extended package; it is not installed "
-                                                        "in this worker."
-                                                    ) from exc
-                                                falloesung_bulk_fn = get_falloesung_bulk_compute_fn()
-                                                sachverhalt = (
-                                                    _get_insensitive(task.data, "sachverhalt")
-                                                    if task.data
-                                                    else ""
-                                                )
-                                                result = falloesung_bulk_fn(
-                                                    ai_service=jr_evaluator.ai_service,
-                                                    judge_model=jr_evaluator.judge_model,
-                                                    temperature=jr_evaluator.temperature,
-                                                    max_tokens=jr_evaluator.max_tokens,
-                                                    sachverhalt=str(sachverhalt) if sachverhalt else "",
-                                                    musterloesung=eval_ground_truth,
-                                                    prediction=str(prediction) if prediction else "",
-                                                    thinking_budget=getattr(jr_evaluator, "thinking_budget", None),
-                                                    reasoning_effort=getattr(jr_evaluator, "reasoning_effort", None),
-                                                )
-                                            else:
-                                                result = jr_evaluator._evaluate_single_criterion(
-                                                    context=context,
-                                                    ground_truth=eval_ground_truth,
-                                                    prediction=str(prediction) if prediction else "",
-                                                    criterion=criterion,
-                                                    task_data=task.data,
-                                                )
-
-                                            judge_prompts = (
-                                                result.pop("_judge_prompts_used", None)
-                                                if result
-                                                else None
-                                            )
-
-                                            raw_score = (
-                                                result.get("score") if result is not None else None
-                                            )
-
-                                            error_msg = None
-                                            if raw_score is not None:
-                                                if jr_evaluator.score_scale == "0-1":
-                                                    score = raw_score
-                                                elif jr_evaluator.score_scale == "0-100":
-                                                    score = raw_score / 100.0
-                                                else:
-                                                    score = (raw_score - 1) / 4
-                                            else:
-                                                score = None
-                                                error_msg = (
-                                                    (result.get("error_message") if result else None)
-                                                    or "LLM judge evaluation failed"
-                                                )
-                                                logger.warning(
-                                                    f"LLM judge {jr_judge_model} run {jr_run_index} returned None for task {task.id}, field {field_key}"
-                                                )
-
-                                            import uuid as _ok_uuid
-
-                                            if metric == "llm_judge_falloesung":
-                                                # Phase 7 consolidation: route falloesung
-                                                # through extended's canonical row-builder
-                                                # so immediate-eval and bulk-eval persist
-                                                # the same nested {value, method, details,
-                                                # error} shape. Generic llm_judge_* metrics
-                                                # keep the legacy flat shape (else branch).
-                                                from benger_extended.workers.falloesung_tasks import (
-                                                    build_falloesung_row_dict,
-                                                )
-                                                per_judge_results.append({
-                                                    "id": str(_ok_uuid.uuid4()),
-                                                    "evaluation_id": evaluation_id,
-                                                    "judge_run_id": jr_id,
-                                                    "task_id": task.id,
-                                                    "generation_id": generation.id,
-                                                    "annotation_id": None,
-                                                    "field_name": field_key,
-                                                    "answer_type": "text",
-                                                    "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
-                                                    "prediction": str(prediction)[:1000] if prediction else "",
-                                                    "error_message": error_msg,
-                                                    "judge_prompts_used": judge_prompts,
-                                                    **build_falloesung_row_dict(result=result, error_message=error_msg),
-                                                })
-                                            else:
-                                                per_judge_results.append({
-                                                    "id": str(_ok_uuid.uuid4()),
-                                                    "evaluation_id": evaluation_id,
-                                                    "judge_run_id": jr_id,
-                                                    "task_id": task.id,
-                                                    "generation_id": generation.id,
-                                                    "field_name": field_key,
-                                                    "answer_type": "text",
-                                                    "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
-                                                    "prediction": str(prediction)[:1000] if prediction else "",
-                                                    "metrics": {
-                                                        metric: score,
-                                                        "raw_score": raw_score,
-                                                        f"{metric}_response": result,
-                                                        **(
-                                                            {f"{metric}_grade_points": result["grade_points"]}
-                                                            if result and result.get("grade_points") is not None
-                                                            else {}
-                                                        ),
-                                                        **(
-                                                            {f"{metric}_passed": 1.0 if result["passed"] else 0.0}
-                                                            if result and "passed" in result
-                                                            else {}
-                                                        ),
-                                                    },
-                                                    "passed": (
-                                                        result.get("passed", score > 0.5)
-                                                        if result and "passed" in result
-                                                        else (score > 0.5 if score is not None else False)
-                                                    ),
-                                                    "error_message": error_msg,
-                                                    "judge_prompts_used": judge_prompts,
-                                                    **_llm_judge_columns_from_result(result),
-                                                })
-
-                                        # Push every per-judge result through the
-                                        # shared aggregation + commit path below.
-                                        for sample_result in per_judge_results:
-                                            sample_results.append(sample_result)
-                                            samples_evaluated += 1
-                                            if sample_result["passed"]:
-                                                samples_passed += 1
-                                            else:
-                                                samples_failed += 1
-                                            metric_key = f"{field_key}|{metric}"
-                                            # Falloesung's canonical nested shape stores the
-                                            # numeric value at metrics[metric].value;
-                                            # generic llm_judge_* metrics store it directly
-                                            # as metrics[metric]. Handle both.
-                                            primary_raw = sample_result["metrics"].get(metric)
-                                            if isinstance(primary_raw, dict):
-                                                primary_value = primary_raw.get("value")
-                                            else:
-                                                primary_value = primary_raw
-                                            if primary_value is not None and isinstance(primary_value, (int, float)):
-                                                aggregate_metrics.setdefault(metric_key, []).append(primary_value)
-                                            if metric == "llm_judge_falloesung":
-                                                # Sub-metric extracts come from the nested
-                                                # details blob via the extended helper.
-                                                from benger_extended.workers.falloesung_tasks import (
-                                                    build_falloesung_aggregate_extracts,
-                                                )
-                                                for sub_key, sub_value in build_falloesung_aggregate_extracts(sample_result).items():
-                                                    aggregate_metrics.setdefault(
-                                                        f"{field_key}|{metric}_{sub_key}", []
-                                                    ).append(sub_value)
-                                            else:
-                                                for suffix in ("_grade_points", "_passed"):
-                                                    sub_key_name = f"{metric}{suffix}"
-                                                    sub_value = sample_result["metrics"].get(sub_key_name)
-                                                    if sub_value is not None and isinstance(sub_value, (int, float)):
-                                                        sub_metric_key = f"{field_key}|{sub_key_name}"
-                                                        aggregate_metrics.setdefault(sub_metric_key, []).append(sub_value)
-
-                                        if sample_results:
-                                            for r in sample_results:
-                                                db.add(TaskEvaluation(**r))
-                                            evaluation.samples_evaluated = samples_evaluated
-                                            evaluation.has_sample_results = True
-                                            db.commit()
-                                            sample_results = []
-                                        # Skip the legacy single-result path
-                                        # below — we already appended + committed
-                                        # one row per judge_run for this sample.
-                                        continue
-                                    else:
-                                        # Use standard SampleEvaluator for non-LLM metrics
-                                        sample_result = sample_evaluator.evaluate_sample(
-                                            task_id=task.id,
-                                            field_name=field_key,
-                                            ground_truth=ground_truth,
-                                            prediction=prediction,
-                                            metrics_to_compute=[metric],
-                                            generation_id=generation.id,
-                                            parse_status=generation.parse_status,
-                                            allow_unparsed=allow_unparsed,
-                                        )
-                                        # Migration 042: deterministic metrics
-                                        # don't have a judge — point them at the
-                                        # default judge_run created up front for
-                                        # FK consistency.
-                                        if isinstance(sample_result, dict):
-                                            sample_result["judge_run_id"] = default_judge_run_id
-
-                                    sample_results.append(sample_result)
-                                    samples_evaluated += 1
-
-                                    if sample_result["passed"]:
-                                        samples_passed += 1
-                                    else:
-                                        samples_failed += 1
-
-                                    # Accumulate primary metric score only (not raw_score or sub-metrics)
-                                    metric_key = f"{field_key}|{metric}"
-                                    primary_value = sample_result["metrics"].get(metric)
-                                    if primary_value is not None and isinstance(
-                                        primary_value, (int, float)
-                                    ):
-                                        if metric_key not in aggregate_metrics:
-                                            aggregate_metrics[metric_key] = []
-                                        aggregate_metrics[metric_key].append(primary_value)
-
-                                    # Aggregate Falloesung sub-metrics under their own keys
-                                    for suffix in ("_grade_points", "_passed"):
-                                        sub_key_name = f"{metric}{suffix}"
-                                        sub_value = sample_result["metrics"].get(sub_key_name)
-                                        if sub_value is not None and isinstance(
-                                            sub_value, (int, float)
-                                        ):
-                                            sub_metric_key = f"{field_key}|{sub_key_name}"
-                                            if sub_metric_key not in aggregate_metrics:
-                                                aggregate_metrics[sub_metric_key] = []
-                                            aggregate_metrics[sub_metric_key].append(sub_value)
-
-                                    # Commit each result immediately so the frontend
-                                    # can show live progress via SSE stream
-                                    if sample_results:
-                                        for result in sample_results:
-                                            db.add(TaskEvaluation(**result))
-                                        evaluation.samples_evaluated = samples_evaluated
-                                        evaluation.has_sample_results = True
-                                        db.commit()
-                                        sample_results = []
-
-                                except ValueError as e:
-                                    logger.warning(f"Skipping sample: {e}")
-                                    continue
-                                except Exception as e:
-                                    logger.error(f"Error evaluating sample: {e}")
-                                    import uuid as _uuid
-                                    sample_results.append({
-                                        "id": str(_uuid.uuid4()),
-                                        "evaluation_id": evaluation_id,
-                                        # Migration 043 NOT NULL fallback (see guard
-                                        # branch above for rationale).
-                                        "judge_run_id": default_judge_run_id,
-                                        "task_id": task.id,
-                                        "generation_id": generation.id,
-                                        "field_name": field_key,
-                                        "answer_type": "text",
-                                        "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
-                                        "prediction": str(prediction)[:1000] if prediction else "",
-                                        "metrics": {},
-                                        "passed": False,
-                                        "error_message": str(e),
-                                    })
-                                    samples_evaluated += 1
-                                    samples_failed += 1
-                                    continue
-
-            # Evaluate human annotations for configs with human: fields or __all_human__
-            # Also handles backward compat: llm_judge_falloesung with unprefixed prediction fields
-            from annotation_utils import extract_all_field_values as _extract_all_fields
-            import uuid as _ann_uuid
-
-            # Pre-load all annotations once (avoids N+1 queries per config x task)
-            task_id_list = [t.id for t in tasks]
-            ann_query = db.query(Annotation).filter(
-                Annotation.task_id.in_(task_id_list),
-                Annotation.was_cancelled == False,
-            )
-            if annotator_user_ids:
-                ann_pre_count = ann_query.count()
-                ann_query = ann_query.filter(Annotation.completed_by.in_(annotator_user_ids))
-            all_annotations = ann_query.all()
-            if annotator_user_ids:
-                # E3: same observability story as the model_ids log above —
-                # log the scope-driven reduction so reproducibility/debugging
-                # has a paper trail beyond the eval_metadata blob.
-                logger.info(
-                    f"[evaluation {evaluation_id}] annotator_user_ids filter "
-                    f"active ({len(annotator_user_ids)} ids); annotation pool "
-                    f"reduced from {ann_pre_count} to {len(all_annotations)}"
+            if has_human_config:
+                task_id_list = [t.id for t in tasks]
+                ann_query = db.query(Annotation).filter(
+                    Annotation.task_id.in_(task_id_list),
+                    Annotation.was_cancelled == False,  # noqa: E712
                 )
-            annotations_by_task: dict[str, list] = {}
-            for ann in all_annotations:
-                annotations_by_task.setdefault(ann.task_id, []).append(ann)
-
-            # Pre-load existing annotation evaluations once (shared across all configs)
-            evaluated_by_ann: dict[str, set[str]] = {}
-            if evaluate_missing_only:
-                # Same EvaluationRun.status filter as the generation-side
-                # block above — keep the two queries in lockstep so the
-                # missing-detector's view of "already evaluated" matches
-                # what the read path in results.py actually surfaces.
-                existing_ann = (
-                    db.query(
-                        TaskEvaluation.annotation_id,
-                        TaskEvaluation.field_name,
-                        TaskEvaluation.metrics,
+                if annotator_user_ids:
+                    ann_pre_count = ann_query.count()
+                    ann_query = ann_query.filter(
+                        Annotation.completed_by.in_(annotator_user_ids)
                     )
-                    .join(EvaluationRun, TaskEvaluation.evaluation_id == EvaluationRun.id)
-                    .filter(
-                        TaskEvaluation.task_id.in_(task_id_list),
-                        TaskEvaluation.annotation_id.isnot(None),
-                        EvaluationRun.status.in_(("completed", "running", "pending")),
-                    )
-                    .all()
-                )
-                for r in existing_ann:
-                    # Same gating as the generation side — terminal-error rows
-                    # block retries so we don't loop on a hopeless annotation.
-                    if _row_has_score(r.metrics) or _row_is_terminal_error(r.metrics):
-                        evaluated_by_ann.setdefault(r.annotation_id, set()).add(
-                            _normalize_field_key(r.field_name, is_annotation=True)
-                        )
-
-            for config in enabled_configs:
-                config_id = config.get("id", "unknown")
-                metric = config.get("metric", "")
-                prediction_fields = config.get("prediction_fields", [])
-                reference_fields = config.get("reference_fields", [])
-
-                # Korrektur (Classic / Standard Falllösung) is human-graded.
-                # The score is written by the API when a corrector submits;
-                # the worker must never persist a row for it. Skip the entire
-                # config — otherwise we'd write 0.0/"Bestanden" placeholder
-                # rows that the leaderboards/evaluations page would display
-                # as if the human had already graded.
-                if metric.startswith("korrektur_"):
+                all_annotations = ann_query.all()
+                if annotator_user_ids:
                     logger.info(
-                        f"Skipping config {config_id} (metric: {metric}) — "
-                        "human-graded; persisted by API at grade time."
+                        f"[evaluation {evaluation_id}] annotator_user_ids filter active "
+                        f"({len(annotator_user_ids)} ids); annotation pool reduced from "
+                        f"{ann_pre_count} to {len(all_annotations)}"
                     )
-                    continue
 
-                # Collect human prediction fields from this config.
-                # Classification (including the falloesung backward-compat rule
-                # and any metric rules registered by extended) is centralized
-                # in `services/shared/eval_field_classification.py` so the
-                # worker and the cost endpoint stay in lockstep.
-                from eval_field_classification import classify_pred_fields
-                human_fields_raw, _llm_fields = classify_pred_fields(metric, prediction_fields)
-                human_pred_fields = []
-                for pf in human_fields_raw:
-                    if pf == "__all_human__":
-                        human_pred_fields.append(("__all_human__", "__all_human__"))
-                    elif pf.startswith("human:"):
-                        human_pred_fields.append((pf, pf[6:]))  # (prefixed, base)
-                    else:
-                        # Backward-compat path returned an unprefixed field —
-                        # synthesize the prefixed form for the downstream
-                        # `human:<base>` lookup against extracted annotation
-                        # values.
-                        human_pred_fields.append((f"human:{pf}", pf))
+                evaluated_by_ann: Dict[str, set] = {}
+                if evaluate_missing_only:
+                    existing_ann = (
+                        db.query(
+                            TaskEvaluation.annotation_id,
+                            TaskEvaluation.field_name,
+                            TaskEvaluation.metrics,
+                        )
+                        .join(EvaluationRun, TaskEvaluation.evaluation_id == EvaluationRun.id)
+                        .filter(
+                            TaskEvaluation.task_id.in_(task_id_list),
+                            TaskEvaluation.annotation_id.isnot(None),
+                            EvaluationRun.status.in_(("completed", "running", "pending")),
+                        )
+                        .all()
+                    )
+                    for r in existing_ann:
+                        if _row_has_score(r.metrics) or _row_is_terminal_error(r.metrics):
+                            evaluated_by_ann.setdefault(r.annotation_id, set()).add(
+                                _normalize_field_key(r.field_name, is_annotation=True)
+                            )
 
-                if not human_pred_fields:
-                    continue
+                for ann in all_annotations:
+                    if evaluate_missing_only:
+                        ann_done = evaluated_by_ann.get(ann.id, set())
+                        if all_expected_field_keys and all_expected_field_keys.issubset(ann_done):
+                            continue
+                    ann_cells.append((ann.task_id, ann.id))
 
-                logger.info(f"Evaluating human annotations for config {config_id} (metric: {metric})...")
-
-                # Ground truth cache per (task_id, ref_field) — same for all annotations
-                gt_cache: dict[tuple, any] = {}
-
-                for task in tasks:
-                    annotations = annotations_by_task.get(task.id, [])
-
-                    for annotation in annotations:
-                        for pred_field_prefixed, base_field in human_pred_fields:
-                            # Extract prediction from annotation
-                            if base_field == "__all_human__":
-                                all_values = _extract_all_fields(annotation.result or [])
-                                field_predictions = [
-                                    (f"human:{fn}", v) for fn, v in all_values.items()
-                                    if isinstance(v, str)
-                                ]
-                            else:
-                                value = _extract_field_value_from_annotation(
-                                    annotation.result or [], base_field
-                                )
-                                field_predictions = [(pred_field_prefixed, value)] if value else []
-
-                            for actual_pred_field, prediction in field_predictions:
-                                for ref_field in reference_fields:
-                                    field_key = f"{config_id}|{actual_pred_field}|{ref_field}"
-
-                                    # Skip already-evaluated (using pre-loaded set).
-                                    # Normalize on lookup so legacy formats match.
-                                    if evaluate_missing_only and _normalize_field_key(
-                                        field_key, is_annotation=True
-                                    ) in evaluated_by_ann.get(annotation.id, set()):
-                                        continue
-
-                                    # Extract ground truth (cached per task+ref_field)
-                                    gt_key = (task.id, ref_field)
-                                    if gt_key not in gt_cache:
-                                        if ref_field.startswith("task."):
-                                            data_field = ref_field[5:]
-                                            gt_cache[gt_key] = task.data.get(data_field) if task.data else None
-                                        else:
-                                            gt_cache[gt_key] = task.data.get(ref_field) if task.data else None
-                                    ground_truth = gt_cache[gt_key]
-                                    if ground_truth is None:
-                                        continue
-
-                                    try:
-                                        # Same guard as the generation-side
-                                        # loop above: don't silently fall
-                                        # through to sample_evaluator when an
-                                        # llm_judge_* config has no
-                                        # initialized evaluator. Persist a
-                                        # terminal-error row so missing-only
-                                        # stops retrying this target.
-                                        if (
-                                            metric.startswith("llm_judge_")
-                                            and config_id not in llm_judge_evaluators
-                                        ):
-                                            sample_results.append({
-                                                "id": str(_ann_uuid.uuid4()),
-                                                "evaluation_id": evaluation_id,
-                                                # Migration 043 NOT NULL fallback —
-                                                # mirrors the gen-side guard above.
-                                                "judge_run_id": default_judge_run_id,
-                                                "task_id": task.id,
-                                                "generation_id": None,
-                                                "annotation_id": annotation.id,
-                                                "field_name": field_key,
-                                                "answer_type": "text",
-                                                "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
-                                                "prediction": str(prediction)[:1000] if prediction else "",
-                                                "metrics": {
-                                                    metric: {
-                                                        "value": None,
-                                                        "method": metric,
-                                                        "error": (
-                                                            f"LLM judge evaluator not initialized for config "
-                                                            f"{config_id} — likely missing API key for the "
-                                                            f"triggering user/org. Run skipped this metric."
-                                                        ),
-                                                        "details": {},
-                                                    },
-                                                },
-                                                "passed": False,
-                                                "error_message": (
-                                                    f"LLM judge evaluator not initialized for config "
-                                                    f"{config_id}"
-                                                ),
-                                            })
-                                            samples_evaluated += 1
-                                            samples_failed += 1
-                                            continue
-                                        if metric.startswith("llm_judge_") and config_id in llm_judge_evaluators:
-                                            # ── Multi-judge / multi-run fan-out (annotation path) ──
-                                            # Mirror of the generation-side fan-out: one LLM call per
-                                            # (judge_model, run_index) entry, one TaskEvaluation row per
-                                            # call with judge_run_id pointing at the right child run.
-                                            context = (
-                                                _get_insensitive(task.data, "text")
-                                                or _get_insensitive(task.data, "input")
-                                                or _get_insensitive(task.data, "sachverhalt")
-                                                or ""
-                                            ) if task.data else ""
-
-                                            eval_ground_truth = str(ground_truth) if ground_truth else ""
-                                            if metric == "llm_judge_falloesung" and task.data:
-                                                muster = _get_insensitive(task.data, "musterloesung") or _get_insensitive(task.data, "musterlösung")
-                                                if muster:
-                                                    eval_ground_truth = str(muster)
-
-                                            criterion = metric.replace("llm_judge_", "")
-                                            if criterion == "custom":
-                                                criterion = "correctness"
-                                            elif criterion == "overall":
-                                                criterion = "correctness"
-
-                                            per_judge_results: List[Dict[str, Any]] = []
-                                            for jr_entry in judge_runs_by_config.get(config_id, []):
-                                                jr_evaluator = jr_entry["evaluator"]
-                                                jr_id = jr_entry["judge_run_id"]
-                                                jr_judge_model = jr_entry["judge_model_id"]
-                                                jr_run_index = jr_entry["run_index"]
-
-                                                if jr_evaluator is None:
-                                                    per_judge_results.append({
-                                                        "id": str(_ann_uuid.uuid4()),
-                                                        "evaluation_id": evaluation_id,
-                                                        "judge_run_id": jr_id,
-                                                        "task_id": task.id,
-                                                        "generation_id": None,
-                                                        "annotation_id": annotation.id,
-                                                        "field_name": field_key,
-                                                        "answer_type": "text",
-                                                        "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
-                                                        "prediction": str(prediction)[:1000] if prediction else "",
-                                                        "metrics": {
-                                                            metric: {
-                                                                "value": None,
-                                                                "method": metric,
-                                                                "error": f"judge {jr_judge_model} run {jr_run_index} not initialized",
-                                                                "details": {},
-                                                            },
-                                                        },
-                                                        "passed": False,
-                                                        "error_message": f"judge {jr_judge_model} run {jr_run_index} not initialized",
-                                                    })
-                                                    continue
-
-                                                # Falloesung dispatched through extended (see
-                                                # symmetric branch on the generation side); platform
-                                                # owns persistence, extended owns compute.
-                                                if metric == "llm_judge_falloesung":
-                                                    try:
-                                                        from benger_extended.workers import (
-                                                            get_falloesung_bulk_compute_fn,
-                                                        )
-                                                    except ImportError as exc:
-                                                        raise RuntimeError(
-                                                            "Metric 'llm_judge_falloesung' requires the "
-                                                            "benger_extended package; it is not installed "
-                                                            "in this worker."
-                                                        ) from exc
-                                                    falloesung_bulk_fn = get_falloesung_bulk_compute_fn()
-                                                    sachverhalt = (
-                                                        _get_insensitive(task.data, "sachverhalt")
-                                                        if task.data
-                                                        else ""
-                                                    )
-                                                    result = falloesung_bulk_fn(
-                                                        ai_service=jr_evaluator.ai_service,
-                                                        judge_model=jr_evaluator.judge_model,
-                                                        temperature=jr_evaluator.temperature,
-                                                        max_tokens=jr_evaluator.max_tokens,
-                                                        sachverhalt=str(sachverhalt) if sachverhalt else "",
-                                                        musterloesung=eval_ground_truth,
-                                                        prediction=str(prediction) if prediction else "",
-                                                        thinking_budget=getattr(jr_evaluator, "thinking_budget", None),
-                                                        reasoning_effort=getattr(jr_evaluator, "reasoning_effort", None),
-                                                    )
-                                                else:
-                                                    result = jr_evaluator._evaluate_single_criterion(
-                                                        context=context,
-                                                        ground_truth=eval_ground_truth,
-                                                        prediction=str(prediction) if prediction else "",
-                                                        criterion=criterion,
-                                                        task_data=task.data,
-                                                    )
-
-                                                judge_prompts = (
-                                                    result.pop("_judge_prompts_used", None)
-                                                    if result
-                                                    else None
-                                                )
-                                                raw_score = (
-                                                    result.get("score") if result is not None else None
-                                                )
-                                                error_msg = None
-                                                if raw_score is not None:
-                                                    if jr_evaluator.score_scale == "0-1":
-                                                        score = raw_score
-                                                    elif jr_evaluator.score_scale == "0-100":
-                                                        score = raw_score / 100.0
-                                                    else:
-                                                        score = (raw_score - 1) / 4
-                                                else:
-                                                    score = None
-                                                    error_msg = (
-                                                        (result.get("error_message") if result else None)
-                                                        or "LLM judge evaluation failed"
-                                                    )
-
-                                                if metric == "llm_judge_falloesung":
-                                                    # Phase 7 consolidation (annotation-side
-                                                    # mirror of the gen-side branch above):
-                                                    # canonical nested shape via
-                                                    # build_falloesung_row_dict.
-                                                    from benger_extended.workers.falloesung_tasks import (
-                                                        build_falloesung_row_dict,
-                                                    )
-                                                    per_judge_results.append({
-                                                        "id": str(_ann_uuid.uuid4()),
-                                                        "evaluation_id": evaluation_id,
-                                                        "judge_run_id": jr_id,
-                                                        "task_id": task.id,
-                                                        "generation_id": None,
-                                                        "annotation_id": annotation.id,
-                                                        "field_name": field_key,
-                                                        "answer_type": "text",
-                                                        "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
-                                                        "prediction": str(prediction)[:1000] if prediction else "",
-                                                        "error_message": error_msg,
-                                                        "judge_prompts_used": judge_prompts,
-                                                        **build_falloesung_row_dict(result=result, error_message=error_msg),
-                                                    })
-                                                else:
-                                                    per_judge_results.append({
-                                                        "id": str(_ann_uuid.uuid4()),
-                                                        "evaluation_id": evaluation_id,
-                                                        "judge_run_id": jr_id,
-                                                        "task_id": task.id,
-                                                        "generation_id": None,
-                                                        "annotation_id": annotation.id,
-                                                        "field_name": field_key,
-                                                        "answer_type": "text",
-                                                        "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
-                                                        "prediction": str(prediction)[:1000] if prediction else "",
-                                                        "metrics": {
-                                                            metric: score,
-                                                            "raw_score": raw_score,
-                                                            f"{metric}_response": result,
-                                                            **(
-                                                                {f"{metric}_grade_points": result["grade_points"]}
-                                                                if result and result.get("grade_points") is not None
-                                                                else {}
-                                                            ),
-                                                            **(
-                                                                {f"{metric}_passed": 1.0 if result["passed"] else 0.0}
-                                                                if result and "passed" in result
-                                                                else {}
-                                                            ),
-                                                        },
-                                                        "passed": (
-                                                            result.get("passed", score > 0.5)
-                                                            if result and "passed" in result
-                                                            else (score > 0.5 if score is not None else False)
-                                                        ),
-                                                        "error_message": error_msg,
-                                                        "judge_prompts_used": judge_prompts,
-                                                        **_llm_judge_columns_from_result(result),
-                                                    })
-
-                                            for sample_result in per_judge_results:
-                                                sample_results.append(sample_result)
-                                                samples_evaluated += 1
-                                                if sample_result["passed"]:
-                                                    samples_passed += 1
-                                                else:
-                                                    samples_failed += 1
-                                                metric_key = f"{field_key}|{metric}"
-                                                # Falloesung canonical nested shape vs
-                                                # generic flat — see gen-side comments.
-                                                primary_raw = sample_result["metrics"].get(metric)
-                                                if isinstance(primary_raw, dict):
-                                                    primary_value = primary_raw.get("value")
-                                                else:
-                                                    primary_value = primary_raw
-                                                if primary_value is not None and isinstance(primary_value, (int, float)):
-                                                    aggregate_metrics.setdefault(metric_key, []).append(primary_value)
-                                                if metric == "llm_judge_falloesung":
-                                                    from benger_extended.workers.falloesung_tasks import (
-                                                        build_falloesung_aggregate_extracts,
-                                                    )
-                                                    for sub_key, sub_value in build_falloesung_aggregate_extracts(sample_result).items():
-                                                        aggregate_metrics.setdefault(
-                                                            f"{field_key}|{metric}_{sub_key}", []
-                                                        ).append(sub_value)
-                                                else:
-                                                    for suffix in ("_grade_points", "_passed"):
-                                                        sub_key_name = f"{metric}{suffix}"
-                                                        sub_value = sample_result["metrics"].get(sub_key_name)
-                                                        if sub_value is not None and isinstance(sub_value, (int, float)):
-                                                            sub_metric_key = f"{field_key}|{sub_key_name}"
-                                                            aggregate_metrics.setdefault(sub_metric_key, []).append(sub_value)
-
-                                            if sample_results:
-                                                for sr in sample_results:
-                                                    db.add(TaskEvaluation(**sr))
-                                                evaluation.samples_evaluated = samples_evaluated
-                                                evaluation.has_sample_results = True
-                                                db.commit()
-                                                sample_results = []
-                                            # Skip the legacy single-result append+commit path below.
-                                            continue
-                                        else:
-                                            # Standard metric (ROUGE, BLEU, etc.)
-                                            annotation_result = sample_evaluator.evaluate_sample(
-                                                task_id=task.id,
-                                                field_name=field_key,
-                                                ground_truth=ground_truth,
-                                                prediction=prediction,
-                                                metrics_to_compute=[metric],
-                                                annotation_id=annotation.id,
-                                            )
-                                            annotation_result["annotation_id"] = annotation.id
-                                            annotation_result["generation_id"] = None
-                                            # Migration 042: deterministic annotation metric — point at default judge_run.
-                                            if isinstance(annotation_result, dict):
-                                                annotation_result["judge_run_id"] = default_judge_run_id
-
-                                        sample_results.append(annotation_result)
-                                        samples_evaluated += 1
-                                        if annotation_result.get("passed"):
-                                            samples_passed += 1
-                                        else:
-                                            samples_failed += 1
-
-                                        # Accumulate primary metric only (match generation loop pattern)
-                                        metric_key = f"{field_key}|{metric}"
-                                        primary_value = annotation_result.get("metrics", {}).get(metric)
-                                        if primary_value is not None and isinstance(primary_value, (int, float)):
-                                            if metric_key not in aggregate_metrics:
-                                                aggregate_metrics[metric_key] = []
-                                            aggregate_metrics[metric_key].append(primary_value)
-
-                                        # Aggregate Falloesung sub-metrics
-                                        for suffix in ("_grade_points", "_passed"):
-                                            sub_key_name = f"{metric}{suffix}"
-                                            sub_value = annotation_result.get("metrics", {}).get(sub_key_name)
-                                            if sub_value is not None and isinstance(sub_value, (int, float)):
-                                                sub_metric_key = f"{field_key}|{sub_key_name}"
-                                                if sub_metric_key not in aggregate_metrics:
-                                                    aggregate_metrics[sub_metric_key] = []
-                                                aggregate_metrics[sub_metric_key].append(sub_value)
-
-                                        # Commit each result immediately so the frontend
-                                        # can show live progress via SSE stream
-                                        if sample_results:
-                                            for sr in sample_results:
-                                                db.add(TaskEvaluation(**sr))
-                                            evaluation.samples_evaluated = samples_evaluated
-                                            evaluation.has_sample_results = True
-                                            db.commit()
-                                            sample_results = []
-
-                                    except ValueError as e:
-                                        logger.warning(f"Skipping annotation sample: {e}")
-                                        continue
-                                    except Exception as e:
-                                        logger.warning(
-                                            f"Annotation eval failed for annotation {annotation.id}: {e}"
-                                        )
-                                        sample_results.append({
-                                            "id": str(_ann_uuid.uuid4()),
-                                            "evaluation_id": evaluation_id,
-                                            # Migration 043 NOT NULL fallback —
-                                            # mirrors the gen-side bare-except above.
-                                            "judge_run_id": default_judge_run_id,
-                                            "task_id": task.id,
-                                            "generation_id": None,
-                                            "annotation_id": annotation.id,
-                                            "field_name": field_key,
-                                            "answer_type": "text",
-                                            "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
-                                            "prediction": str(prediction)[:1000] if prediction else "",
-                                            "metrics": {},
-                                            "passed": False,
-                                            "error_message": str(e),
-                                        })
-                                        samples_evaluated += 1
-                                        samples_failed += 1
-
-            # Store remaining sample results (not yet stored in batches)
-            if sample_results:
-                for result in sample_results:
-                    sample_record = TaskEvaluation(**result)
-                    db.add(sample_record)
-                db.commit()
-                logger.info(f"📦 Stored final batch of {len(sample_results)} results")
-
-            # Compute aggregate metrics
-            final_metrics = {}
-            for metric_key, values in aggregate_metrics.items():
-                if values:
-                    final_metrics[metric_key] = sum(values) / len(values)
-
-            # ── Finalize per-judge_run + parent EvaluationRun status ──
-            # Walk every EvaluationJudgeRun we created, count its rows, and
-            # mark it completed/failed based on whether at least one row
-            # landed. The parent EvaluationRun aggregates: completed only when
-            # every child terminated and at least one child succeeded; failed
-            # otherwise. Mirrors the generation policy "first failure → parent
-            # failed" but is forgiving here because eval failures are usually
-            # rate-limit transients and the user can re-run a single judge.
-            from models import EvaluationJudgeRun as _EJR_finalize
-
-            child_runs = db.query(_EJR_finalize).filter(
-                _EJR_finalize.evaluation_id == evaluation_id
-            ).all()
-            any_child_failed = False
-            any_child_completed = False
-            for child in child_runs:
-                if child.status == "failed":
-                    any_child_failed = True
-                    continue
-                # Count TaskEvaluation rows that landed on this judge_run.
-                child_rows = db.query(TaskEvaluation).filter(
-                    TaskEvaluation.judge_run_id == child.id
-                ).count()
-                child.samples_evaluated = child_rows
-                child.completed_at = datetime.now()
-                if child_rows > 0:
-                    child.status = "completed"
-                    any_child_completed = True
-                else:
-                    child.status = "failed"
-                    child.error_message = child.error_message or "no rows produced"
-                    any_child_failed = True
-            db.commit()
-
-            # Update evaluation record
-            evaluation.status = "completed" if any_child_completed else "failed"
-            if not any_child_completed:
-                evaluation.error_message = (
-                    "no judge_run produced any rows"
-                    if not child_runs
-                    else "all judge_runs failed"
-                )
-            evaluation.completed_at = datetime.now()
-            evaluation.samples_evaluated = samples_evaluated
-            evaluation.metrics = final_metrics
-            evaluation.has_sample_results = True
-            # Build judge_models / judge_seeds maps directly from
-            # judge_runs_by_config so multi-judge ensembles are surfaced
-            # (the legacy llm_judge_evaluators dict only had the first judge).
-            # Build per-judge_run summary including final status + sample count
-            # so the frontend's Judges tab renders without an extra round-trip
-            # to the statistics endpoint. Reads back the just-finalized child
-            # rows from `child_runs` (loaded above) to capture the real numbers.
-            child_status_by_id: Dict[str, Any] = {c.id: c for c in child_runs}
-            judge_models_summary: Dict[str, List[Dict[str, Any]]] = {}
-            for cid, entries in judge_runs_by_config.items():
-                judge_models_summary[cid] = [
+            # ── Build serialized judge_run_ids_by_config for Celery kwargs ────
+            # The full `judge_runs_by_config` dict (built upstream during judge
+            # setup, lines 2516-2724) carries non-serializable `evaluator`
+            # instances. Sub-tasks reconstruct evaluators per-process via
+            # `_reconstruct_judge_evaluators_for_cell` — orchestrator only
+            # needs to pass the IDs they should attach to.
+            judge_run_ids_by_config_serializable = {
+                cid: [
                     {
-                        "judge_model_id": e["judge_model_id"],
-                        "run_index": e["run_index"],
-                        "judge_run_id": e["judge_run_id"],
-                        "status": (
-                            child_status_by_id[e["judge_run_id"]].status
-                            if e["judge_run_id"] in child_status_by_id
-                            else None
-                        ),
-                        "samples_evaluated": (
-                            child_status_by_id[e["judge_run_id"]].samples_evaluated
-                            if e["judge_run_id"] in child_status_by_id
-                            else None
-                        ),
+                        "judge_model_id": e.get("judge_model_id"),
+                        "run_index": e.get("run_index"),
+                        "judge_run_id": e.get("judge_run_id"),
                     }
                     for e in entries
                 ]
-            evaluation.eval_metadata = {
-                **evaluation.eval_metadata,
-                "samples_passed": samples_passed,
-                "samples_failed": samples_failed,
-                "configs_evaluated": len(enabled_configs),
-                "pass_rate": samples_passed / samples_evaluated if samples_evaluated > 0 else 0,
-                "any_judge_failed": any_child_failed,
-                **({"judges_by_config": judge_models_summary} if judge_models_summary else {}),
-                # Phase 6.6: per-config seed at the run level so researchers
-                # can group runs by seed without joining task_evaluations.
-                **({"judge_seeds": {
-                    cid: ev.seed for cid, ev in llm_judge_evaluators.items()
-                }} if llm_judge_evaluators else {}),
+                for cid, entries in judge_runs_by_config.items()
             }
+
+            # Persist dispatch metadata so finalize can find judge_run IDs
+            # when building the `judges_by_config` summary.
+            cells_dispatched = len(gen_cells) + len(ann_cells)
+            from sqlalchemy.orm.attributes import flag_modified
+
+            evaluation.eval_metadata = {
+                **(evaluation.eval_metadata or {}),
+                "dispatched_at": datetime.now().isoformat(),
+                "cells_dispatched": cells_dispatched,
+                "judge_run_ids_by_config": judge_run_ids_by_config_serializable,
+                "gen_cells_dispatched": len(gen_cells),
+                "ann_cells_dispatched": len(ann_cells),
+            }
+            flag_modified(evaluation, "eval_metadata")
             db.commit()
 
-            # Update report evaluation section
-            try:
-                api_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'api')
-                if api_dir not in sys.path:
-                    sys.path.insert(0, api_dir)
-                from report_service import update_report_evaluation_section
+            # Nothing to do — short-circuit (e.g. all targets already done in
+            # `missing-only` mode, or no generations exist for the project yet).
+            if cells_dispatched == 0:
+                evaluation.status = "completed"
+                evaluation.completed_at = datetime.now()
+                evaluation.samples_evaluated = 0
+                evaluation.has_sample_results = True
+                evaluation.metrics = {}
+                eval_meta_after = evaluation.eval_metadata or {}
+                eval_meta_after.update({
+                    "samples_passed": 0,
+                    "samples_failed": 0,
+                    "pass_rate": 0,
+                    "any_judge_failed": False,
+                    "note": "no cells to dispatch (missing-only short-circuit)",
+                })
+                evaluation.eval_metadata = eval_meta_after
+                flag_modified(evaluation, "eval_metadata")
+                db.commit()
+                logger.info(
+                    f"Eval {evaluation_id} short-circuited: 0 cells to dispatch"
+                )
+                return {
+                    "status": "success",
+                    "evaluation_id": evaluation_id,
+                    "cells_dispatched": 0,
+                    "samples_evaluated": 0,
+                }
 
-                update_report_evaluation_section(db, project_id)
-                logger.info(f"✅ Updated report evaluation section for project {project_id}")
-            except Exception as e:
-                logger.error(f"Failed to update report evaluation section: {e}")
+            # ── Chord dispatch ────────────────────────────────────────────────
+            # One Celery sub-task per cell, all dispatched to the dedicated
+            # `evaluation` queue. The chord callback `finalize_evaluation_run`
+            # runs exactly once after every header sub-task finishes (success
+            # or failure — chord doesn't gate on success).
+            from celery import chord
 
-            logger.info(
-                f"✅ Multi-field evaluation completed: {samples_evaluated} samples, "
-                f"pass rate: {samples_passed/samples_evaluated:.2%}"
-                if samples_evaluated > 0
-                else "✅ Multi-field evaluation completed: 0 samples"
+            triggered_by = (
+                evaluation.eval_metadata.get("triggered_by")
+                if evaluation.eval_metadata else None
             )
 
-            # Create notification for evaluation completion
-            try:
-                triggered_by = (
-                    evaluation.eval_metadata.get("triggered_by")
-                    if evaluation.eval_metadata
-                    else None
-                )
-                if triggered_by:
-                    pass_rate = samples_passed / samples_evaluated if samples_evaluated > 0 else 0
-                    NotificationService.create_notification(
-                        db=db,
-                        user_ids=[triggered_by],
-                        notification_type=NotificationType.EVALUATION_COMPLETED,
-                        title="Evaluation Complete",
-                        message=f"Evaluation completed: {samples_evaluated} samples evaluated ({pass_rate:.0%} pass rate)",
-                        data={
-                            "project_id": project_id,
+            header_sigs = []
+            for (cell_task_id, cell_gen_id) in gen_cells:
+                header_sigs.append(
+                    evaluate_generation_cell.signature(
+                        kwargs={
                             "evaluation_id": evaluation_id,
-                            "samples_evaluated": samples_evaluated,
-                            "samples_passed": samples_passed,
-                            "pass_rate": pass_rate,
+                            "task_id": cell_task_id,
+                            "generation_id": cell_gen_id,
+                            "project_id": project_id,
+                            "configs_for_cell": enabled_configs,
+                            "judge_run_ids_by_config": judge_run_ids_by_config_serializable,
+                            "default_judge_run_id": default_judge_run_id,
+                            "organization_id": organization_id,
+                            "triggered_by_user_id": triggered_by,
+                            "label_config_version": label_config_version,
                         },
+                        queue="evaluation",
                     )
-                    logger.info(f"📬 Created completion notification for user {triggered_by}")
-            except Exception as notif_err:
-                logger.error(f"Failed to create completion notification: {notif_err}")
+                )
+            for (cell_task_id, cell_ann_id) in ann_cells:
+                header_sigs.append(
+                    evaluate_annotation_cell.signature(
+                        kwargs={
+                            "evaluation_id": evaluation_id,
+                            "task_id": cell_task_id,
+                            "annotation_id": cell_ann_id,
+                            "project_id": project_id,
+                            "configs_for_cell": enabled_configs,
+                            "judge_run_ids_by_config": judge_run_ids_by_config_serializable,
+                            "default_judge_run_id": default_judge_run_id,
+                            "organization_id": organization_id,
+                            "triggered_by_user_id": triggered_by,
+                        },
+                        queue="evaluation",
+                    )
+                )
+
+            callback_sig = finalize_evaluation_run.signature(
+                kwargs={"evaluation_id": evaluation_id},
+                queue="evaluation",
+            )
+
+            chord_result = chord(header_sigs)(callback_sig)
+
+            logger.info(
+                f"✅ Dispatched {len(header_sigs)} eval cell sub-tasks for evaluation "
+                f"{evaluation_id} (gen: {len(gen_cells)}, ann: {len(ann_cells)}); "
+                f"chord callback id={chord_result.id}"
+            )
 
             return {
-                "status": "success",
+                "status": "dispatched",
                 "evaluation_id": evaluation_id,
                 "project_id": project_id,
-                "samples_evaluated": samples_evaluated,
-                "samples_passed": samples_passed,
-                "samples_failed": samples_failed,
-                "pass_rate": samples_passed / samples_evaluated if samples_evaluated > 0 else 0,
-                "metrics": final_metrics,
+                "cells_dispatched": cells_dispatched,
+                "gen_cells": len(gen_cells),
+                "ann_cells": len(ann_cells),
+                "chord_id": chord_result.id,
             }
 
         finally:
@@ -4751,3 +3772,1314 @@ try:
         # replace the handler with itself and emit a noisy warning.
 except ImportError:
     logger.info("Worker: community edition (no benger_extended package)")
+
+
+# =============================================================================
+# Per-cell evaluation fan-out (Phase 4 of the eval-parallelization refactor)
+#
+# `tasks.run_evaluation` is an ORCHESTRATOR. It does the heavy setup
+# (status flip, project load, judge_run pre-creation, sample_evaluator
+# preparation), enumerates the work units (one per task×generation and
+# one per task×annotation), and dispatches each as a per-cell Celery
+# sub-task via `chord(group(...))(finalize_evaluation_run)`. Cell
+# sub-tasks run in parallel across the worker pool. The chord callback
+# `finalize_evaluation_run` aggregates child judge-run statuses, recomputes
+# the metrics dict from `TaskEvaluation` rows, and sets the parent's
+# terminal status — exactly once when every header sub-task has finished.
+#
+# Concurrency hazards and their mitigations:
+#   * `EvaluationJudgeRun` UQ races → orchestrator pre-creates all
+#     judge_run rows before dispatch; sub-tasks never call _create_judge_run.
+#   * Evaluator cache thrashing → each sub-task instantiates its own
+#     `LLMJudgeEvaluator` per process; `SampleEvaluator` global model
+#     caches in `ml_evaluation/sample_evaluator.py` are process-local
+#     so the first cell per worker pays the load cost and the rest are free.
+#   * `evaluate_missing_only` double-eval → orchestrator pre-filters
+#     `configs_for_cell` against the existing-evaluations set; the partial
+#     unique index from migration 048 plus `ON CONFLICT DO NOTHING` at
+#     insert time is the defense-in-depth against concurrent triggers.
+#   * `samples_evaluated` lost updates → SQL `UPDATE ... SET col = col + :n`
+#     from each sub-task; Postgres serializes on the row.
+#   * Parent status finalization race → Celery chord callback fires
+#     exactly once after every sub-task terminates (success or failure).
+# =============================================================================
+
+
+def _reconstruct_judge_evaluators_for_cell(
+    *,
+    configs_for_cell: List[Dict[str, Any]],
+    judge_run_ids_by_config: Dict[str, List[Dict[str, Any]]],
+    triggered_by_user_id: str,
+    organization_id: Optional[str],
+    db,
+) -> tuple:
+    """Per-sub-task reconstruction of LLMJudgeEvaluator instances.
+
+    Mirrors the orchestrator's judge-evaluator init block (formerly at
+    `tasks.py` ~lines 2641-2661) but operates with judge_run_ids the
+    orchestrator already created (no `_create_judge_run` calls — those
+    happen exactly once in the orchestrator). Each call constructs fresh
+    instances in the sub-task's process; safe to call from multiple
+    workers concurrently because there's no shared state.
+
+    Returns (judge_runs_by_config, llm_judge_evaluators) where:
+      - judge_runs_by_config[cid] = list of {judge_model_id, run_index,
+        judge_run_id, evaluator} dicts (evaluator may be None if init
+        failed for that judge)
+      - llm_judge_evaluators[cid] = the FIRST initialized evaluator for
+        the config (for the legacy guard branches that still consult it
+        in scalar form)
+    """
+    from llm_judge_evaluator import create_llm_judge_for_user
+
+    judge_runs_by_config: Dict[str, List[Dict[str, Any]]] = {}
+    llm_judge_evaluators: Dict[str, Any] = {}
+
+    for config in configs_for_cell:
+        metric = config.get("metric", "")
+        if not metric.startswith("llm_judge_"):
+            continue
+        config_id = config.get("id", "unknown")
+        params = config.get("metric_parameters", {}) or {}
+        entries = judge_run_ids_by_config.get(config_id, []) or []
+        judge_runs_by_config.setdefault(config_id, [])
+
+        for entry in entries:
+            judge_model_id = entry["judge_model_id"]
+            run_index = entry["run_index"]
+            judge_run_id = entry["judge_run_id"]
+            try:
+                evaluator = create_llm_judge_for_user(
+                    user_id=triggered_by_user_id,
+                    db=db,
+                    metric_name=metric,
+                    organization_id=organization_id,
+                    judge_model_id=judge_model_id,
+                    score_scale=params.get("score_scale", "0-1"),
+                    answer_type=params.get("answer_type"),
+                    temperature=params.get("temperature"),
+                    max_tokens=params.get("max_tokens"),
+                    thinking_budget=params.get("thinking_budget"),
+                    reasoning_effort=params.get("reasoning_effort"),
+                    seed=params.get("seed"),
+                )
+            except Exception as init_err:
+                logger.warning(
+                    f"Sub-task: failed to init judge {judge_model_id} run {run_index} "
+                    f"for config {config_id}: {init_err}"
+                )
+                evaluator = None
+
+            judge_runs_by_config[config_id].append({
+                "judge_model_id": judge_model_id,
+                "run_index": run_index,
+                "judge_run_id": judge_run_id,
+                "evaluator": evaluator,
+            })
+            if evaluator is not None and config_id not in llm_judge_evaluators:
+                llm_judge_evaluators[config_id] = evaluator
+
+    return judge_runs_by_config, llm_judge_evaluators
+
+
+def _build_sample_evaluator_for_cell(
+    evaluation_id: str,
+    configs_for_cell: List[Dict[str, Any]],
+):
+    """Per-sub-task SampleEvaluator construction.
+
+    Lifted from the orchestrator's `field_configs` / `metric_parameters`
+    build at `tasks.py` ~lines 2796-2812. Each sub-task builds its own
+    instance, but the underlying transformer model caches in
+    `sample_evaluator.py` are module-level, so only the first sub-task
+    per worker process actually loads BERTScore/MoverScore/etc. weights.
+    """
+    from ml_evaluation.sample_evaluator import SampleEvaluator
+
+    field_configs: Dict[str, Dict[str, str]] = {}
+    metric_parameters: Dict[str, Dict[str, Any]] = {}
+    for config in configs_for_cell:
+        config_id = config.get("id", "unknown")
+        metric = config.get("metric", "")
+        params = config.get("metric_parameters", {})
+        for pred_field in config.get("prediction_fields", []):
+            for ref_field in config.get("reference_fields", []):
+                field_key = f"{config_id}|{pred_field}|{ref_field}"
+                field_configs[field_key] = {"type": "text"}
+                if params:
+                    metric_parameters[field_key] = {metric: params}
+    return SampleEvaluator(evaluation_id, field_configs, metric_parameters)
+
+
+def _bulk_upsert_task_evaluations(db, rows: List[Dict[str, Any]]) -> int:
+    """Insert TaskEvaluation rows with `ON CONFLICT DO NOTHING` against
+    the partial unique index `uq_task_evaluations_cell` from migration 048.
+
+    Returns the rowcount actually inserted (may be < len(rows) if some
+    were silently deduped against an existing row — that's the idempotency
+    guarantee under concurrent retries / redelivered Celery tasks).
+    """
+    if not rows:
+        return 0
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+    from models import TaskEvaluation
+
+    # The unique index uses COALESCE() expressions and a WHERE predicate,
+    # so SQLAlchemy's `index_elements` shortcut can't infer it. Reference
+    # the index by name via `constraint=`.
+    stmt = pg_insert(TaskEvaluation.__table__).values(rows)
+    stmt = stmt.on_conflict_do_nothing(index_elements=None)
+    # Force the conflict target to our partial expression index. psycopg2
+    # accepts `ON CONFLICT ON CONSTRAINT` syntax via `constraint=` for
+    # named constraints, but for expression indexes we must use the
+    # `index_where` clause. The simplest reliable form is to emit the
+    # raw conflict target.
+    from sqlalchemy import text as _text
+
+    # SQLAlchemy's on_conflict_do_nothing with index_elements=None emits
+    # bare `ON CONFLICT DO NOTHING` which Postgres treats as "any unique
+    # constraint" — that's what we want here (only one unique index that
+    # could fire is the one from migration 048).
+    result = db.execute(stmt)
+    return result.rowcount or 0
+
+
+def _bump_evaluation_counters(
+    db,
+    *,
+    evaluation_id: str,
+    samples_evaluated: int,
+    samples_passed: int,
+    samples_failed: int,
+) -> None:
+    """Atomic SQL UPDATE that bumps the parent EvaluationRun's counters.
+
+    Postgres serializes row-level UPDATEs on `id = :evaluation_id`, so
+    concurrent sub-task bumps don't lose updates. `samples_passed` and
+    `samples_failed` live inside the `eval_metadata` JSONB blob; bump
+    them with `jsonb_set` + `coalesce` so a missing key starts from 0.
+    """
+    from sqlalchemy import text as _text
+
+    if samples_evaluated == 0 and samples_passed == 0 and samples_failed == 0:
+        return
+    db.execute(
+        _text(
+            """
+            UPDATE evaluation_runs
+               SET samples_evaluated = COALESCE(samples_evaluated, 0) + :n,
+                   eval_metadata = jsonb_set(
+                       jsonb_set(
+                           COALESCE(eval_metadata, '{}'::jsonb),
+                           '{samples_passed}',
+                           to_jsonb(COALESCE((eval_metadata->>'samples_passed')::int, 0) + :p)
+                       ),
+                       '{samples_failed}',
+                       to_jsonb(COALESCE((eval_metadata->>'samples_failed')::int, 0) + :f)
+                   ),
+                   has_sample_results = true
+             WHERE id = :evaluation_id
+            """
+        ),
+        {
+            "n": samples_evaluated,
+            "p": samples_passed,
+            "f": samples_failed,
+            "evaluation_id": evaluation_id,
+        },
+    )
+
+
+@app.task(name="tasks.evaluate_generation_cell", bind=True, max_retries=2)
+def evaluate_generation_cell(
+    self,
+    evaluation_id: str,
+    task_id: str,
+    generation_id: str,
+    project_id: str,
+    configs_for_cell: List[Dict[str, Any]],
+    judge_run_ids_by_config: Dict[str, List[Dict[str, Any]]],
+    default_judge_run_id: str,
+    organization_id: Optional[str],
+    triggered_by_user_id: str,
+    label_config_version: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Per-(task, generation) sub-task dispatched by the eval orchestrator.
+
+    Loads the generation, task (and ground-truth annotation when needed),
+    reconstructs its own LLM judge evaluators per process, runs all
+    `configs_for_cell` × field_pairs × judges, and writes the resulting
+    TaskEvaluation rows via `ON CONFLICT DO NOTHING` so retries are
+    idempotent. At the end, atomically bumps the parent EvaluationRun's
+    `samples_evaluated`/`samples_passed`/`samples_failed` counters.
+
+    Returns a small breadcrumb dict for the chord header; the finalizer
+    doesn't consume the return value — it reads from the DB.
+    """
+    import uuid as _gen_uuid
+    from datetime import datetime as _dt
+
+    db = SessionLocal()
+    try:
+        from models import EvaluationRun, Generation, TaskEvaluation
+        from project_models import Annotation, Task
+
+        gen = db.query(Generation).filter(Generation.id == generation_id).first()
+        if not gen:
+            logger.warning(
+                f"evaluate_generation_cell: generation {generation_id} not found; "
+                f"skipping (eval {evaluation_id})"
+            )
+            return {"status": "skipped", "reason": "generation_not_found",
+                    "evaluation_id": evaluation_id, "generation_id": generation_id}
+        task = db.query(Task).filter(Task.id == task_id).first()
+        if not task:
+            logger.warning(
+                f"evaluate_generation_cell: task {task_id} not found; skipping"
+            )
+            return {"status": "skipped", "reason": "task_not_found",
+                    "evaluation_id": evaluation_id, "task_id": task_id}
+
+        uses_annotation_fields = any(
+            any(not ref.startswith("task.") for ref in c.get("reference_fields", []))
+            for c in configs_for_cell
+        )
+        ground_truth_annotation = None
+        if uses_annotation_fields:
+            ann = (
+                db.query(Annotation)
+                .filter(Annotation.task_id == task_id, Annotation.was_cancelled == False)  # noqa: E712
+                .first()
+            )
+            ground_truth_annotation = ann
+
+        # Reconstruct evaluators + sample_evaluator scoped to this cell's configs.
+        judge_runs_by_config, llm_judge_evaluators = _reconstruct_judge_evaluators_for_cell(
+            configs_for_cell=configs_for_cell,
+            judge_run_ids_by_config=judge_run_ids_by_config,
+            triggered_by_user_id=triggered_by_user_id,
+            organization_id=organization_id,
+            db=db,
+        )
+        sample_evaluator = _build_sample_evaluator_for_cell(evaluation_id, configs_for_cell)
+
+        # Local accumulators (returned to caller via counter bump at end).
+        sample_results: List[Dict[str, Any]] = []
+        local_samples_evaluated = 0
+        local_samples_passed = 0
+        local_samples_failed = 0
+
+        # Inner loop — lifted from orchestrator's per-generation block at
+        # ex-`tasks.py` ~lines 2882-3355. Logic preserved as-is except for:
+        #   * `evaluation_id` is a closure capture (not orchestrator-local)
+        #   * `evaluation.samples_evaluated = ...` per-batch commits removed
+        #     (counter bump happens atomically at end via _bump_evaluation_counters)
+        #   * Sample rows are accumulated and bulk-upserted at end
+        for config in configs_for_cell:
+            config_id = config.get("id", "unknown")
+            metric = config.get("metric", "")
+            prediction_fields = config.get("prediction_fields", [])
+            reference_fields = config.get("reference_fields", [])
+
+            if metric.startswith("korrektur_"):
+                continue
+
+            for pred_field in prediction_fields:
+                if pred_field.startswith("human:") or pred_field == "__all_human__":
+                    continue
+
+                for ref_field in reference_fields:
+                    field_key = f"{config_id}|{pred_field}|{ref_field}"
+
+                    # Ground truth extraction.
+                    if ref_field.startswith("task."):
+                        data_field = ref_field[5:]
+                        ground_truth = task.data.get(data_field) if task.data else None
+                    elif ground_truth_annotation:
+                        ground_truth = _extract_field_value_from_annotation(
+                            ground_truth_annotation.result or [], ref_field
+                        )
+                        if ground_truth is None and task.data and ref_field in task.data:
+                            ground_truth = task.data.get(ref_field)
+                    else:
+                        ground_truth = task.data.get(ref_field) if task.data else None
+                    if ground_truth is None:
+                        logger.warning(
+                            f"Evaluation skip: reference field '{ref_field}' not found "
+                            f"for task {task.id} (config {config_id})"
+                        )
+                        continue
+
+                    # Prediction extraction.
+                    base_field = pred_field
+                    if pred_field.startswith("model:"):
+                        base_field = pred_field[6:]
+                    if pred_field == "__all_model__":
+                        prediction = gen.response_content
+                    else:
+                        prediction = _extract_field_value_from_parsed_annotation(
+                            gen.parsed_annotation, base_field
+                        )
+                        if prediction is None and gen.response_content:
+                            prediction = gen.response_content
+                    if prediction is None:
+                        logger.warning(
+                            f"Evaluation skip: prediction field '{pred_field}' not found "
+                            f"for task {task.id}, model {gen.model_id} (config {config_id})"
+                        )
+                        continue
+
+                    allow_unparsed = pred_field == "__all_model__"
+                    try:
+                        # Terminal-error row when an llm_judge_* config has no init'd evaluator.
+                        if metric.startswith("llm_judge_") and config_id not in llm_judge_evaluators:
+                            sample_results.append({
+                                "id": str(_gen_uuid.uuid4()),
+                                "evaluation_id": evaluation_id,
+                                "judge_run_id": default_judge_run_id,
+                                "task_id": task.id,
+                                "generation_id": gen.id,
+                                "field_name": field_key,
+                                "answer_type": "text",
+                                "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
+                                "prediction": str(prediction)[:1000] if prediction else "",
+                                "metrics": {
+                                    metric: {
+                                        "value": None,
+                                        "method": metric,
+                                        "error": (
+                                            f"LLM judge evaluator not initialized for config "
+                                            f"{config_id} — likely missing API key for the "
+                                            f"triggering user/org. Run skipped this metric."
+                                        ),
+                                        "details": {},
+                                    },
+                                },
+                                "passed": False,
+                                "error_message": (
+                                    f"LLM judge evaluator not initialized for config {config_id}"
+                                ),
+                            })
+                            local_samples_evaluated += 1
+                            local_samples_failed += 1
+                            continue
+
+                        if metric.startswith("llm_judge_") and config_id in llm_judge_evaluators:
+                            # ── Multi-judge / multi-run fan-out (intra-cell) ──
+                            per_judge_results: List[Dict[str, Any]] = []
+                            context = (
+                                _get_insensitive(task.data, "text")
+                                or _get_insensitive(task.data, "input")
+                                or _get_insensitive(task.data, "sachverhalt")
+                                or ""
+                            )
+                            eval_ground_truth = str(ground_truth) if ground_truth else ""
+                            if metric == "llm_judge_falloesung" and task.data:
+                                muster = (
+                                    _get_insensitive(task.data, "musterloesung")
+                                    or _get_insensitive(task.data, "musterlösung")
+                                )
+                                if muster:
+                                    eval_ground_truth = str(muster)
+
+                            criterion = metric.replace("llm_judge_", "")
+                            if criterion in ("custom", "overall"):
+                                criterion = "correctness"
+
+                            for jr_entry in judge_runs_by_config.get(config_id, []):
+                                jr_evaluator = jr_entry["evaluator"]
+                                jr_id = jr_entry["judge_run_id"]
+                                jr_judge_model = jr_entry["judge_model_id"]
+                                jr_run_index = jr_entry["run_index"]
+
+                                if jr_evaluator is None:
+                                    per_judge_results.append({
+                                        "id": str(_gen_uuid.uuid4()),
+                                        "evaluation_id": evaluation_id,
+                                        "judge_run_id": jr_id,
+                                        "task_id": task.id,
+                                        "generation_id": gen.id,
+                                        "field_name": field_key,
+                                        "answer_type": "text",
+                                        "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
+                                        "prediction": str(prediction)[:1000] if prediction else "",
+                                        "metrics": {
+                                            metric: {
+                                                "value": None,
+                                                "method": metric,
+                                                "error": f"judge {jr_judge_model} run {jr_run_index} not initialized",
+                                                "details": {},
+                                            },
+                                        },
+                                        "passed": False,
+                                        "error_message": f"judge {jr_judge_model} run {jr_run_index} not initialized",
+                                    })
+                                    continue
+
+                                if metric == "llm_judge_falloesung":
+                                    try:
+                                        from benger_extended.workers import (
+                                            get_falloesung_bulk_compute_fn,
+                                        )
+                                    except ImportError as exc:
+                                        raise RuntimeError(
+                                            "Metric 'llm_judge_falloesung' requires the "
+                                            "benger_extended package; it is not installed."
+                                        ) from exc
+                                    falloesung_bulk_fn = get_falloesung_bulk_compute_fn()
+                                    sachverhalt = (
+                                        _get_insensitive(task.data, "sachverhalt")
+                                        if task.data
+                                        else ""
+                                    )
+                                    result = falloesung_bulk_fn(
+                                        ai_service=jr_evaluator.ai_service,
+                                        judge_model=jr_evaluator.judge_model,
+                                        temperature=jr_evaluator.temperature,
+                                        max_tokens=jr_evaluator.max_tokens,
+                                        sachverhalt=str(sachverhalt) if sachverhalt else "",
+                                        musterloesung=eval_ground_truth,
+                                        prediction=str(prediction) if prediction else "",
+                                        thinking_budget=getattr(jr_evaluator, "thinking_budget", None),
+                                        reasoning_effort=getattr(jr_evaluator, "reasoning_effort", None),
+                                    )
+                                else:
+                                    result = jr_evaluator._evaluate_single_criterion(
+                                        context=context,
+                                        ground_truth=eval_ground_truth,
+                                        prediction=str(prediction) if prediction else "",
+                                        criterion=criterion,
+                                        task_data=task.data,
+                                    )
+
+                                judge_prompts = (
+                                    result.pop("_judge_prompts_used", None)
+                                    if result
+                                    else None
+                                )
+                                raw_score = result.get("score") if result is not None else None
+                                error_msg = None
+                                if raw_score is not None:
+                                    if jr_evaluator.score_scale == "0-1":
+                                        score = raw_score
+                                    elif jr_evaluator.score_scale == "0-100":
+                                        score = raw_score / 100.0
+                                    else:
+                                        score = (raw_score - 1) / 4
+                                else:
+                                    score = None
+                                    error_msg = (
+                                        (result.get("error_message") if result else None)
+                                        or "LLM judge evaluation failed"
+                                    )
+                                    logger.warning(
+                                        f"LLM judge {jr_judge_model} run {jr_run_index} returned None "
+                                        f"for task {task.id}, field {field_key}"
+                                    )
+
+                                if metric == "llm_judge_falloesung":
+                                    from benger_extended.workers.falloesung_tasks import (
+                                        build_falloesung_row_dict,
+                                    )
+                                    per_judge_results.append({
+                                        "id": str(_gen_uuid.uuid4()),
+                                        "evaluation_id": evaluation_id,
+                                        "judge_run_id": jr_id,
+                                        "task_id": task.id,
+                                        "generation_id": gen.id,
+                                        "annotation_id": None,
+                                        "field_name": field_key,
+                                        "answer_type": "text",
+                                        "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
+                                        "prediction": str(prediction)[:1000] if prediction else "",
+                                        "error_message": error_msg,
+                                        "judge_prompts_used": judge_prompts,
+                                        **build_falloesung_row_dict(result=result, error_message=error_msg),
+                                    })
+                                else:
+                                    per_judge_results.append({
+                                        "id": str(_gen_uuid.uuid4()),
+                                        "evaluation_id": evaluation_id,
+                                        "judge_run_id": jr_id,
+                                        "task_id": task.id,
+                                        "generation_id": gen.id,
+                                        "field_name": field_key,
+                                        "answer_type": "text",
+                                        "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
+                                        "prediction": str(prediction)[:1000] if prediction else "",
+                                        "metrics": {
+                                            metric: score,
+                                            "raw_score": raw_score,
+                                            f"{metric}_response": result,
+                                            **(
+                                                {f"{metric}_grade_points": result["grade_points"]}
+                                                if result and result.get("grade_points") is not None
+                                                else {}
+                                            ),
+                                            **(
+                                                {f"{metric}_passed": 1.0 if result["passed"] else 0.0}
+                                                if result and "passed" in result
+                                                else {}
+                                            ),
+                                        },
+                                        "passed": (
+                                            result.get("passed", score > 0.5)
+                                            if result and "passed" in result
+                                            else (score > 0.5 if score is not None else False)
+                                        ),
+                                        "error_message": error_msg,
+                                        "judge_prompts_used": judge_prompts,
+                                        **_llm_judge_columns_from_result(result),
+                                    })
+
+                            for sr in per_judge_results:
+                                sample_results.append(sr)
+                                local_samples_evaluated += 1
+                                if sr["passed"]:
+                                    local_samples_passed += 1
+                                else:
+                                    local_samples_failed += 1
+                            continue
+
+                        # Deterministic metric (BLEU/ROUGE/METEOR/etc.) — SampleEvaluator path.
+                        sample_result = sample_evaluator.evaluate_sample(
+                            task_id=task.id,
+                            field_name=field_key,
+                            ground_truth=ground_truth,
+                            prediction=prediction,
+                            metrics_to_compute=[metric],
+                            generation_id=gen.id,
+                            parse_status=gen.parse_status,
+                            allow_unparsed=allow_unparsed,
+                        )
+                        if isinstance(sample_result, dict):
+                            sample_result["judge_run_id"] = default_judge_run_id
+
+                        sample_results.append(sample_result)
+                        local_samples_evaluated += 1
+                        if sample_result.get("passed"):
+                            local_samples_passed += 1
+                        else:
+                            local_samples_failed += 1
+
+                    except ValueError as e:
+                        logger.warning(f"Skipping sample: {e}")
+                        continue
+                    except Exception as e:
+                        logger.error(f"Error evaluating sample: {e}")
+                        sample_results.append({
+                            "id": str(_gen_uuid.uuid4()),
+                            "evaluation_id": evaluation_id,
+                            "judge_run_id": default_judge_run_id,
+                            "task_id": task.id,
+                            "generation_id": gen.id,
+                            "field_name": field_key,
+                            "answer_type": "text",
+                            "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
+                            "prediction": str(prediction)[:1000] if prediction else "",
+                            "metrics": {},
+                            "passed": False,
+                            "error_message": str(e),
+                        })
+                        local_samples_evaluated += 1
+                        local_samples_failed += 1
+
+        # Bulk upsert + atomic counter bump. One commit per sub-task.
+        _bulk_upsert_task_evaluations(db, sample_results)
+        _bump_evaluation_counters(
+            db,
+            evaluation_id=evaluation_id,
+            samples_evaluated=local_samples_evaluated,
+            samples_passed=local_samples_passed,
+            samples_failed=local_samples_failed,
+        )
+        db.commit()
+        return {
+            "status": "ok",
+            "evaluation_id": evaluation_id,
+            "task_id": task_id,
+            "generation_id": generation_id,
+            "samples_added": local_samples_evaluated,
+            "samples_passed": local_samples_passed,
+            "samples_failed": local_samples_failed,
+        }
+    except Exception as e:
+        logger.error(
+            f"evaluate_generation_cell failed (eval {evaluation_id}, gen {generation_id}): {e}",
+            exc_info=True,
+        )
+        db.rollback()
+        # Don't propagate — the chord finalizer must still fire. Best-effort
+        # increment of `samples_failed` so the finalizer's parent-status
+        # logic accounts for this cell.
+        try:
+            _bump_evaluation_counters(
+                db,
+                evaluation_id=evaluation_id,
+                samples_evaluated=0,
+                samples_passed=0,
+                samples_failed=1,
+            )
+            db.commit()
+        except Exception as bump_err:
+            logger.error(f"Failed to bump failed counter: {bump_err}")
+        return {
+            "status": "error",
+            "evaluation_id": evaluation_id,
+            "task_id": task_id,
+            "generation_id": generation_id,
+            "error": str(e),
+        }
+    finally:
+        db.close()
+
+
+@app.task(name="tasks.evaluate_annotation_cell", bind=True, max_retries=2)
+def evaluate_annotation_cell(
+    self,
+    evaluation_id: str,
+    task_id: str,
+    annotation_id: str,
+    project_id: str,
+    configs_for_cell: List[Dict[str, Any]],
+    judge_run_ids_by_config: Dict[str, List[Dict[str, Any]]],
+    default_judge_run_id: str,
+    organization_id: Optional[str],
+    triggered_by_user_id: str,
+) -> Dict[str, Any]:
+    """Per-(task, annotation) sub-task dispatched by the eval orchestrator.
+
+    Mirror of `evaluate_generation_cell` for the human-annotation
+    evaluation path (configs whose `prediction_fields` contain
+    `human:<field>` or `__all_human__`). Same structure: load + reconstruct
+    + run inner block + bulk upsert + atomic counter bump.
+    """
+    import uuid as _ann_uuid
+    from datetime import datetime as _dt
+
+    db = SessionLocal()
+    try:
+        from models import EvaluationRun, TaskEvaluation
+        from project_models import Annotation, Task
+        from annotation_utils import extract_all_field_values as _extract_all_fields
+        from eval_field_classification import classify_pred_fields
+
+        annotation = db.query(Annotation).filter(Annotation.id == annotation_id).first()
+        if not annotation:
+            logger.warning(
+                f"evaluate_annotation_cell: annotation {annotation_id} not found; skipping"
+            )
+            return {"status": "skipped", "reason": "annotation_not_found",
+                    "evaluation_id": evaluation_id, "annotation_id": annotation_id}
+        task = db.query(Task).filter(Task.id == task_id).first()
+        if not task:
+            logger.warning(f"evaluate_annotation_cell: task {task_id} not found; skipping")
+            return {"status": "skipped", "reason": "task_not_found",
+                    "evaluation_id": evaluation_id, "task_id": task_id}
+
+        judge_runs_by_config, llm_judge_evaluators = _reconstruct_judge_evaluators_for_cell(
+            configs_for_cell=configs_for_cell,
+            judge_run_ids_by_config=judge_run_ids_by_config,
+            triggered_by_user_id=triggered_by_user_id,
+            organization_id=organization_id,
+            db=db,
+        )
+        sample_evaluator = _build_sample_evaluator_for_cell(evaluation_id, configs_for_cell)
+
+        sample_results: List[Dict[str, Any]] = []
+        local_samples_evaluated = 0
+        local_samples_passed = 0
+        local_samples_failed = 0
+        gt_cache: Dict[tuple, Any] = {}
+
+        for config in configs_for_cell:
+            config_id = config.get("id", "unknown")
+            metric = config.get("metric", "")
+            prediction_fields = config.get("prediction_fields", [])
+            reference_fields = config.get("reference_fields", [])
+
+            if metric.startswith("korrektur_"):
+                continue
+
+            human_fields_raw, _llm_fields = classify_pred_fields(metric, prediction_fields)
+            human_pred_fields = []
+            for pf in human_fields_raw:
+                if pf == "__all_human__":
+                    human_pred_fields.append(("__all_human__", "__all_human__"))
+                elif pf.startswith("human:"):
+                    human_pred_fields.append((pf, pf[6:]))
+                else:
+                    human_pred_fields.append((f"human:{pf}", pf))
+
+            if not human_pred_fields:
+                continue
+
+            for pred_field_prefixed, base_field in human_pred_fields:
+                # Extract prediction from THIS annotation.
+                if base_field == "__all_human__":
+                    all_values = _extract_all_fields(annotation.result or [])
+                    field_predictions = [
+                        (f"human:{fn}", v) for fn, v in all_values.items()
+                        if isinstance(v, str)
+                    ]
+                else:
+                    value = _extract_field_value_from_annotation(
+                        annotation.result or [], base_field
+                    )
+                    field_predictions = [(pred_field_prefixed, value)] if value else []
+
+                for actual_pred_field, prediction in field_predictions:
+                    for ref_field in reference_fields:
+                        field_key = f"{config_id}|{actual_pred_field}|{ref_field}"
+
+                        gt_key = (task.id, ref_field)
+                        if gt_key not in gt_cache:
+                            if ref_field.startswith("task."):
+                                data_field = ref_field[5:]
+                                gt_cache[gt_key] = task.data.get(data_field) if task.data else None
+                            else:
+                                gt_cache[gt_key] = task.data.get(ref_field) if task.data else None
+                        ground_truth = gt_cache[gt_key]
+                        if ground_truth is None:
+                            continue
+
+                        try:
+                            if metric.startswith("llm_judge_") and config_id not in llm_judge_evaluators:
+                                sample_results.append({
+                                    "id": str(_ann_uuid.uuid4()),
+                                    "evaluation_id": evaluation_id,
+                                    "judge_run_id": default_judge_run_id,
+                                    "task_id": task.id,
+                                    "generation_id": None,
+                                    "annotation_id": annotation.id,
+                                    "field_name": field_key,
+                                    "answer_type": "text",
+                                    "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
+                                    "prediction": str(prediction)[:1000] if prediction else "",
+                                    "metrics": {
+                                        metric: {
+                                            "value": None,
+                                            "method": metric,
+                                            "error": (
+                                                f"LLM judge evaluator not initialized for config "
+                                                f"{config_id}"
+                                            ),
+                                            "details": {},
+                                        },
+                                    },
+                                    "passed": False,
+                                    "error_message": (
+                                        f"LLM judge evaluator not initialized for config {config_id}"
+                                    ),
+                                })
+                                local_samples_evaluated += 1
+                                local_samples_failed += 1
+                                continue
+
+                            if metric.startswith("llm_judge_") and config_id in llm_judge_evaluators:
+                                context = (
+                                    _get_insensitive(task.data, "text")
+                                    or _get_insensitive(task.data, "input")
+                                    or _get_insensitive(task.data, "sachverhalt")
+                                    or ""
+                                ) if task.data else ""
+                                eval_ground_truth = str(ground_truth) if ground_truth else ""
+                                if metric == "llm_judge_falloesung" and task.data:
+                                    muster = (
+                                        _get_insensitive(task.data, "musterloesung")
+                                        or _get_insensitive(task.data, "musterlösung")
+                                    )
+                                    if muster:
+                                        eval_ground_truth = str(muster)
+                                criterion = metric.replace("llm_judge_", "")
+                                if criterion in ("custom", "overall"):
+                                    criterion = "correctness"
+
+                                per_judge_results: List[Dict[str, Any]] = []
+                                for jr_entry in judge_runs_by_config.get(config_id, []):
+                                    jr_evaluator = jr_entry["evaluator"]
+                                    jr_id = jr_entry["judge_run_id"]
+                                    jr_judge_model = jr_entry["judge_model_id"]
+                                    jr_run_index = jr_entry["run_index"]
+
+                                    if jr_evaluator is None:
+                                        per_judge_results.append({
+                                            "id": str(_ann_uuid.uuid4()),
+                                            "evaluation_id": evaluation_id,
+                                            "judge_run_id": jr_id,
+                                            "task_id": task.id,
+                                            "generation_id": None,
+                                            "annotation_id": annotation.id,
+                                            "field_name": field_key,
+                                            "answer_type": "text",
+                                            "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
+                                            "prediction": str(prediction)[:1000] if prediction else "",
+                                            "metrics": {
+                                                metric: {
+                                                    "value": None,
+                                                    "method": metric,
+                                                    "error": f"judge {jr_judge_model} run {jr_run_index} not initialized",
+                                                    "details": {},
+                                                },
+                                            },
+                                            "passed": False,
+                                            "error_message": f"judge {jr_judge_model} run {jr_run_index} not initialized",
+                                        })
+                                        continue
+
+                                    if metric == "llm_judge_falloesung":
+                                        try:
+                                            from benger_extended.workers import (
+                                                get_falloesung_bulk_compute_fn,
+                                            )
+                                        except ImportError as exc:
+                                            raise RuntimeError(
+                                                "Metric 'llm_judge_falloesung' requires the "
+                                                "benger_extended package; it is not installed."
+                                            ) from exc
+                                        falloesung_bulk_fn = get_falloesung_bulk_compute_fn()
+                                        sachverhalt = (
+                                            _get_insensitive(task.data, "sachverhalt")
+                                            if task.data
+                                            else ""
+                                        )
+                                        result = falloesung_bulk_fn(
+                                            ai_service=jr_evaluator.ai_service,
+                                            judge_model=jr_evaluator.judge_model,
+                                            temperature=jr_evaluator.temperature,
+                                            max_tokens=jr_evaluator.max_tokens,
+                                            sachverhalt=str(sachverhalt) if sachverhalt else "",
+                                            musterloesung=eval_ground_truth,
+                                            prediction=str(prediction) if prediction else "",
+                                            thinking_budget=getattr(jr_evaluator, "thinking_budget", None),
+                                            reasoning_effort=getattr(jr_evaluator, "reasoning_effort", None),
+                                        )
+                                    else:
+                                        result = jr_evaluator._evaluate_single_criterion(
+                                            context=context,
+                                            ground_truth=eval_ground_truth,
+                                            prediction=str(prediction) if prediction else "",
+                                            criterion=criterion,
+                                            task_data=task.data,
+                                        )
+
+                                    judge_prompts = (
+                                        result.pop("_judge_prompts_used", None)
+                                        if result
+                                        else None
+                                    )
+                                    raw_score = result.get("score") if result is not None else None
+                                    error_msg = None
+                                    if raw_score is not None:
+                                        if jr_evaluator.score_scale == "0-1":
+                                            score = raw_score
+                                        elif jr_evaluator.score_scale == "0-100":
+                                            score = raw_score / 100.0
+                                        else:
+                                            score = (raw_score - 1) / 4
+                                    else:
+                                        score = None
+                                        error_msg = (
+                                            (result.get("error_message") if result else None)
+                                            or "LLM judge evaluation failed"
+                                        )
+
+                                    if metric == "llm_judge_falloesung":
+                                        from benger_extended.workers.falloesung_tasks import (
+                                            build_falloesung_row_dict,
+                                        )
+                                        per_judge_results.append({
+                                            "id": str(_ann_uuid.uuid4()),
+                                            "evaluation_id": evaluation_id,
+                                            "judge_run_id": jr_id,
+                                            "task_id": task.id,
+                                            "generation_id": None,
+                                            "annotation_id": annotation.id,
+                                            "field_name": field_key,
+                                            "answer_type": "text",
+                                            "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
+                                            "prediction": str(prediction)[:1000] if prediction else "",
+                                            "error_message": error_msg,
+                                            "judge_prompts_used": judge_prompts,
+                                            **build_falloesung_row_dict(result=result, error_message=error_msg),
+                                        })
+                                    else:
+                                        per_judge_results.append({
+                                            "id": str(_ann_uuid.uuid4()),
+                                            "evaluation_id": evaluation_id,
+                                            "judge_run_id": jr_id,
+                                            "task_id": task.id,
+                                            "generation_id": None,
+                                            "annotation_id": annotation.id,
+                                            "field_name": field_key,
+                                            "answer_type": "text",
+                                            "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
+                                            "prediction": str(prediction)[:1000] if prediction else "",
+                                            "metrics": {
+                                                metric: score,
+                                                "raw_score": raw_score,
+                                                f"{metric}_response": result,
+                                                **(
+                                                    {f"{metric}_grade_points": result["grade_points"]}
+                                                    if result and result.get("grade_points") is not None
+                                                    else {}
+                                                ),
+                                                **(
+                                                    {f"{metric}_passed": 1.0 if result["passed"] else 0.0}
+                                                    if result and "passed" in result
+                                                    else {}
+                                                ),
+                                            },
+                                            "passed": (
+                                                result.get("passed", score > 0.5)
+                                                if result and "passed" in result
+                                                else (score > 0.5 if score is not None else False)
+                                            ),
+                                            "error_message": error_msg,
+                                            "judge_prompts_used": judge_prompts,
+                                            **_llm_judge_columns_from_result(result),
+                                        })
+
+                                for sr in per_judge_results:
+                                    sample_results.append(sr)
+                                    local_samples_evaluated += 1
+                                    if sr["passed"]:
+                                        local_samples_passed += 1
+                                    else:
+                                        local_samples_failed += 1
+                                continue
+
+                            # Deterministic annotation metric.
+                            annotation_result = sample_evaluator.evaluate_sample(
+                                task_id=task.id,
+                                field_name=field_key,
+                                ground_truth=ground_truth,
+                                prediction=prediction,
+                                metrics_to_compute=[metric],
+                                annotation_id=annotation.id,
+                            )
+                            annotation_result["annotation_id"] = annotation.id
+                            annotation_result["generation_id"] = None
+                            if isinstance(annotation_result, dict):
+                                annotation_result["judge_run_id"] = default_judge_run_id
+
+                            sample_results.append(annotation_result)
+                            local_samples_evaluated += 1
+                            if annotation_result.get("passed"):
+                                local_samples_passed += 1
+                            else:
+                                local_samples_failed += 1
+
+                        except ValueError as e:
+                            logger.warning(f"Skipping annotation sample: {e}")
+                            continue
+                        except Exception as e:
+                            logger.warning(
+                                f"Annotation eval failed for annotation {annotation.id}: {e}"
+                            )
+                            sample_results.append({
+                                "id": str(_ann_uuid.uuid4()),
+                                "evaluation_id": evaluation_id,
+                                "judge_run_id": default_judge_run_id,
+                                "task_id": task.id,
+                                "generation_id": None,
+                                "annotation_id": annotation.id,
+                                "field_name": field_key,
+                                "answer_type": "text",
+                                "ground_truth": str(ground_truth)[:1000] if ground_truth else "",
+                                "prediction": str(prediction)[:1000] if prediction else "",
+                                "metrics": {},
+                                "passed": False,
+                                "error_message": str(e),
+                            })
+                            local_samples_evaluated += 1
+                            local_samples_failed += 1
+
+        _bulk_upsert_task_evaluations(db, sample_results)
+        _bump_evaluation_counters(
+            db,
+            evaluation_id=evaluation_id,
+            samples_evaluated=local_samples_evaluated,
+            samples_passed=local_samples_passed,
+            samples_failed=local_samples_failed,
+        )
+        db.commit()
+        return {
+            "status": "ok",
+            "evaluation_id": evaluation_id,
+            "task_id": task_id,
+            "annotation_id": annotation_id,
+            "samples_added": local_samples_evaluated,
+            "samples_passed": local_samples_passed,
+            "samples_failed": local_samples_failed,
+        }
+    except Exception as e:
+        logger.error(
+            f"evaluate_annotation_cell failed (eval {evaluation_id}, ann {annotation_id}): {e}",
+            exc_info=True,
+        )
+        db.rollback()
+        try:
+            _bump_evaluation_counters(
+                db,
+                evaluation_id=evaluation_id,
+                samples_evaluated=0,
+                samples_passed=0,
+                samples_failed=1,
+            )
+            db.commit()
+        except Exception as bump_err:
+            logger.error(f"Failed to bump failed counter: {bump_err}")
+        return {
+            "status": "error",
+            "evaluation_id": evaluation_id,
+            "task_id": task_id,
+            "annotation_id": annotation_id,
+            "error": str(e),
+        }
+    finally:
+        db.close()
+
+
+@app.task(name="tasks.finalize_evaluation_run", bind=True)
+def finalize_evaluation_run(
+    self,
+    _sub_task_results: Any,
+    evaluation_id: str,
+) -> Dict[str, Any]:
+    """Chord callback — runs exactly once after every cell sub-task finishes.
+
+    Aggregates per-judge_run statuses from `TaskEvaluation` row counts,
+    recomputes the `metrics` dict (mean of per-cell primary values), sets
+    the parent `EvaluationRun.status` (`completed` if any judge produced
+    rows, `failed` otherwise), and fires the report-section update and
+    user notification — both of which used to live at the end of the
+    monolithic `run_evaluation`.
+
+    Idempotent: re-entry on a terminal evaluation is a no-op (chord
+    callbacks can be redelivered if the worker dies).
+
+    The leading `_sub_task_results` positional is the Celery chord
+    convention — header sub-task return values are passed as the first
+    arg; we don't consume them (we read from DB).
+    """
+    from datetime import datetime as _dt
+    from sqlalchemy import text as _text
+
+    db = SessionLocal()
+    try:
+        from models import EvaluationJudgeRun, EvaluationRun, TaskEvaluation
+
+        evaluation = db.query(EvaluationRun).filter(EvaluationRun.id == evaluation_id).first()
+        if not evaluation:
+            logger.warning(f"finalize_evaluation_run: eval {evaluation_id} not found")
+            return {"status": "skipped", "reason": "evaluation_not_found"}
+
+        if evaluation.status in ("completed", "failed", "cancelled"):
+            logger.info(
+                f"finalize_evaluation_run: eval {evaluation_id} already terminal "
+                f"({evaluation.status}); no-op"
+            )
+            return {"status": "noop", "reason": "already_terminal",
+                    "evaluation_id": evaluation_id, "current_status": evaluation.status}
+
+        # Walk EvaluationJudgeRun children — lifted from ex-`tasks.py:3870-3893`.
+        child_runs = db.query(EvaluationJudgeRun).filter(
+            EvaluationJudgeRun.evaluation_id == evaluation_id
+        ).all()
+        any_child_failed = False
+        any_child_completed = False
+        for child in child_runs:
+            if child.status == "failed":
+                any_child_failed = True
+                continue
+            child_rows = db.query(TaskEvaluation).filter(
+                TaskEvaluation.judge_run_id == child.id
+            ).count()
+            child.samples_evaluated = child_rows
+            child.completed_at = _dt.now()
+            if child_rows > 0:
+                child.status = "completed"
+                any_child_completed = True
+            else:
+                child.status = "failed"
+                child.error_message = child.error_message or "no rows produced"
+                any_child_failed = True
+        db.commit()
+
+        # Recompute aggregate metrics from TaskEvaluation rows.
+        # Replaces the orchestrator's per-iteration `aggregate_metrics`
+        # accumulator; one SQL pass instead of in-memory state-sharing
+        # between sub-tasks (which we deliberately avoided).
+        rows = db.execute(
+            _text(
+                """
+                SELECT field_name, metrics
+                FROM task_evaluations
+                WHERE evaluation_id = :eid
+                """
+            ),
+            {"eid": evaluation_id},
+        ).all()
+        aggregate_metrics: Dict[str, List[float]] = {}
+        for r in rows:
+            field_name = r[0]
+            metrics_blob = r[1] or {}
+            for metric_name, metric_value in metrics_blob.items():
+                # Same shape handling as the orchestrator's old aggregator:
+                # llm_judge_falloesung uses nested {value, method, details}
+                # whereas other metrics expose the value at the top level.
+                if isinstance(metric_value, dict):
+                    primary = metric_value.get("value")
+                else:
+                    primary = metric_value
+                if primary is None or not isinstance(primary, (int, float)):
+                    # Numeric sub-metrics like `_grade_points` and `_passed`
+                    # are stored as their own top-level keys; pick them up
+                    # if they're numeric.
+                    continue
+                key = f"{field_name}|{metric_name}"
+                aggregate_metrics.setdefault(key, []).append(float(primary))
+        final_metrics: Dict[str, float] = {}
+        for k, vals in aggregate_metrics.items():
+            if vals:
+                final_metrics[k] = sum(vals) / len(vals)
+
+        # Re-read parent counter (incrementally bumped by sub-tasks).
+        db.refresh(evaluation)
+        samples_evaluated_total = int(evaluation.samples_evaluated or 0)
+        meta = evaluation.eval_metadata or {}
+        samples_passed_total = int(meta.get("samples_passed", 0) or 0)
+        samples_failed_total = int(meta.get("samples_failed", 0) or 0)
+
+        # Final parent status — mirror of ex-`tasks.py:3896` policy.
+        evaluation.status = "completed" if any_child_completed else "failed"
+        if not any_child_completed:
+            evaluation.error_message = (
+                "no judge_run produced any rows"
+                if not child_runs
+                else "all judge_runs failed"
+            )
+        evaluation.completed_at = _dt.now()
+        evaluation.metrics = final_metrics
+        evaluation.has_sample_results = True
+
+        # judges_by_config summary — see ex-`tasks.py:3914-3934`.
+        child_status_by_id = {c.id: c for c in child_runs}
+        judge_models_summary: Dict[str, List[Dict[str, Any]]] = {}
+        for cid, entries in (meta.get("judge_run_ids_by_config") or {}).items():
+            judge_models_summary[cid] = [
+                {
+                    "judge_model_id": e["judge_model_id"],
+                    "run_index": e["run_index"],
+                    "judge_run_id": e["judge_run_id"],
+                    "status": (
+                        child_status_by_id[e["judge_run_id"]].status
+                        if e["judge_run_id"] in child_status_by_id
+                        else None
+                    ),
+                    "samples_evaluated": (
+                        child_status_by_id[e["judge_run_id"]].samples_evaluated
+                        if e["judge_run_id"] in child_status_by_id
+                        else None
+                    ),
+                }
+                for e in entries
+            ]
+
+        evaluation.eval_metadata = {
+            **(meta or {}),
+            "samples_passed": samples_passed_total,
+            "samples_failed": samples_failed_total,
+            "pass_rate": (
+                samples_passed_total / samples_evaluated_total
+                if samples_evaluated_total > 0 else 0
+            ),
+            "any_judge_failed": any_child_failed,
+            **({"judges_by_config": judge_models_summary} if judge_models_summary else {}),
+        }
+        from sqlalchemy.orm.attributes import flag_modified
+        flag_modified(evaluation, "eval_metadata")
+        db.commit()
+
+        # Report section update — lifted from ex-`tasks.py:3956-3958`.
+        try:
+            api_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'api')
+            if api_dir not in sys.path:
+                sys.path.insert(0, api_dir)
+            from report_service import update_report_evaluation_section
+
+            update_report_evaluation_section(db, evaluation.project_id)
+            logger.info(f"✅ Updated report evaluation section for project {evaluation.project_id}")
+        except Exception as e:
+            logger.error(f"Failed to update report evaluation section: {e}")
+
+        # Notification — lifted from ex-`tasks.py:3970-3995`.
+        try:
+            triggered_by = (
+                evaluation.eval_metadata.get("triggered_by")
+                if evaluation.eval_metadata
+                else None
+            )
+            if triggered_by:
+                NotificationService.create_notification(
+                    db=db,
+                    user_ids=[triggered_by],
+                    notification_type=NotificationType.EVALUATION_COMPLETED,
+                    title="Evaluation Completed"
+                    if evaluation.status == "completed"
+                    else "Evaluation Failed",
+                    message=(
+                        f"Evaluation completed: {samples_evaluated_total} samples evaluated, "
+                        f"pass rate {samples_passed_total/samples_evaluated_total:.1%}"
+                        if evaluation.status == "completed" and samples_evaluated_total > 0
+                        else f"Evaluation {evaluation.status}"
+                    ),
+                    data={
+                        "project_id": evaluation.project_id,
+                        "evaluation_id": evaluation_id,
+                        "samples_evaluated": samples_evaluated_total,
+                        "pass_rate": (
+                            samples_passed_total / samples_evaluated_total
+                            if samples_evaluated_total > 0 else 0
+                        ),
+                    },
+                )
+        except Exception as notif_err:
+            logger.error(f"Failed to create completion notification: {notif_err}")
+
+        logger.info(
+            f"✅ finalize_evaluation_run: eval {evaluation_id} → {evaluation.status} "
+            f"({samples_evaluated_total} samples, "
+            f"{samples_passed_total/samples_evaluated_total:.2%} pass rate)"
+            if samples_evaluated_total > 0
+            else f"✅ finalize_evaluation_run: eval {evaluation_id} → {evaluation.status} (0 samples)"
+        )
+
+        return {
+            "status": "success",
+            "evaluation_id": evaluation_id,
+            "final_status": evaluation.status,
+            "samples_evaluated": samples_evaluated_total,
+            "samples_passed": samples_passed_total,
+            "samples_failed": samples_failed_total,
+            "metrics": final_metrics,
+        }
+    except Exception as e:
+        logger.error(f"finalize_evaluation_run failed for {evaluation_id}: {e}", exc_info=True)
+        # Last-ditch: mark eval failed so it doesn't sit in 'running' forever.
+        try:
+            db.rollback()
+            from models import EvaluationRun
+            ev = db.query(EvaluationRun).filter(EvaluationRun.id == evaluation_id).first()
+            if ev and ev.status not in ("completed", "failed", "cancelled"):
+                from datetime import datetime as _dt2
+                ev.status = "failed"
+                ev.error_message = f"finalize_evaluation_run crashed: {str(e)[:500]}"
+                ev.completed_at = _dt2.now()
+                db.commit()
+        except Exception:
+            pass
+        return {"status": "error", "evaluation_id": evaluation_id, "error": str(e)}
+    finally:
+        db.close()

--- a/services/workers/tasks.py
+++ b/services/workers/tasks.py
@@ -3969,8 +3969,25 @@ def _build_sample_evaluator_for_cell(
     return SampleEvaluator(evaluation_id, field_configs, metric_parameters)
 
 
-_CELL_ATTEMPT_TTL_SECS = 86400
+# 7-day TTL covers even pathologically slow evals (concurrency=1 with
+# 90s LLM judge timeouts compounding); a 1-day TTL would expire mid-run
+# and let a poison cell reset to "first attempt" exactly when it should
+# be bailed.
+_CELL_ATTEMPT_TTL_SECS = 7 * 86400
 _CELL_ATTEMPT_LIMIT = 3
+
+# Whitelist of failure-reason buckets the classifier can emit. Anything
+# off this list lands in `"other"` so a misbehaving LLM SDK emitting
+# one new exception class per call can't grow `failures_by_reason`
+# unboundedly inside the parent's JSON column.
+_FAILURE_REASON_BUCKETS = frozenset({
+    "rate_limit",
+    "timeout",
+    "content_policy",
+    "quota_exceeded",
+    "poison_cell_max_attempts",
+    "other",
+})
 
 
 def _record_cell_attempt(evaluation_id: str, cell_key: str) -> int:
@@ -4038,20 +4055,36 @@ def _record_cell_failure_reason(db, evaluation_id: str, reason: str) -> None:
 
 
 def _classify_cell_failure(exc: BaseException) -> str:
-    """Bucket a cell exception into a stable string the UI can group
-    on. Conservative: just use the exception class name if we don't
-    recognise a known LLM-provider error pattern."""
-    name = type(exc).__name__.lower()
+    """Bucket a cell exception into one of `_FAILURE_REASON_BUCKETS`.
+
+    Whitelist-only — unknown exception types map to `"other"` rather
+    than leak their class name into `eval_metadata.failures_by_reason`,
+    which would let a misbehaving SDK grow the JSON object unboundedly.
+
+    Exception-name match is anchored on substring (`endswith` /
+    suffix) so `EnumerateError` doesn't false-positive into
+    `rate_limit` just because "rate" appears inside "enumerate".
+    """
+    cls_name = type(exc).__name__
+    cls_lower = cls_name.lower()
     msg = str(exc).lower()
-    if "rate" in name or "rate_limit" in msg or "rate limit" in msg or "429" in msg:
+    # Known LLM-provider error class names typically end with the
+    # canonical suffix (RateLimitError, TimeoutError, ContentPolicyViolationError).
+    if (
+        cls_lower.endswith("ratelimiterror")
+        or cls_lower.endswith("ratelimit")
+        or "rate limit" in msg
+        or "rate_limit" in msg
+        or "429" in msg
+    ):
         return "rate_limit"
-    if "timeout" in name or "timeout" in msg:
+    if cls_lower.endswith("timeouterror") or cls_lower.endswith("timeout"):
         return "timeout"
     if "content" in msg and ("policy" in msg or "filter" in msg):
         return "content_policy"
-    if "quota" in msg or "exceeded" in msg:
+    if "quota" in msg and ("exceeded" in msg or "limit" in msg):
         return "quota_exceeded"
-    return type(exc).__name__
+    return "other"
 
 
 def _bulk_upsert_task_evaluations(

--- a/services/workers/tasks.py
+++ b/services/workers/tasks.py
@@ -2699,11 +2699,38 @@ def run_evaluation(
                                     _jr.completed_at = datetime.now()
                                     db.commit()
 
+                            # Stash the construction kwargs alongside the
+                            # in-memory evaluator. Sub-tasks (post-fan-out)
+                            # need to re-instantiate the evaluator per worker
+                            # process via `create_llm_judge_for_user` — they
+                            # can't be passed the already-built evaluator
+                            # instance (not picklable across Celery). The
+                            # orchestrator is the one place all the param
+                            # resolution (`_resolve_judge`, temperature
+                            # clamping, per-run seed perturbation) happens;
+                            # stashing the resolved kwargs here threads the
+                            # decision through to sub-tasks unchanged.
+                            judge_evaluator_kwargs = {
+                                "judge_model": judge_model,
+                                "provider": provider,
+                                "temperature": judge_temp,
+                                "max_tokens": judge_max_tokens,
+                                "criteria": params.get("dimensions"),
+                                "custom_criteria": params.get("custom_criteria"),
+                                "custom_prompt_template": params.get("custom_prompt_template"),
+                                "answer_type": params.get("answer_type"),
+                                "field_mappings": params.get("field_mappings"),
+                                "score_scale": params.get("score_scale", "1-5"),
+                                "thinking_budget": params.get("thinking_budget"),
+                                "reasoning_effort": params.get("reasoning_effort"),
+                                "seed": judge_seed,
+                            }
                             judge_runs_by_config[config_id].append({
                                 "judge_model_id": judge_model,
                                 "run_index": run_index,
                                 "judge_run_id": jr_id,
                                 "evaluator": evaluator,
+                                "judge_evaluator_kwargs": judge_evaluator_kwargs,
                             })
 
                     # Populate legacy single-judge maps from the first
@@ -2798,7 +2825,7 @@ def run_evaluation(
             uses_all_model = any(
                 "__all_model__" in c.get("prediction_fields", []) for c in enabled_configs
             )
-            gen_cells: List[tuple] = []  # (task_id, generation_id)
+            gen_cells: List[tuple] = []  # (task_id, generation_id, already_done_field_keys)
             for task in tasks:
                 generations_query = db.query(Generation).filter(Generation.task_id == task.id)
                 if not uses_all_model:
@@ -2815,12 +2842,16 @@ def run_evaluation(
                     )
                 generations = generations_query.all()
                 for gen in generations:
+                    gen_done = evaluated_by_gen.get(gen.id, set())
                     if evaluate_missing_only:
-                        gen_done = evaluated_by_gen.get(gen.id, set())
                         if all_expected_field_keys and all_expected_field_keys.issubset(gen_done):
                             # Fully evaluated already; nothing to dispatch for this cell.
                             continue
-                    gen_cells.append((task.id, gen.id))
+                    # Pass the per-cell already-done set to the sub-task so it
+                    # can skip already-evaluated field_keys WITHOUT firing the
+                    # LLM judge call (ON CONFLICT DO NOTHING would catch the
+                    # INSERT but the LLM call would already have happened).
+                    gen_cells.append((task.id, gen.id, sorted(gen_done) if gen_done else []))
 
             # Annotation-side enumeration. The legacy body at ~3357-3412
             # pre-loaded all annotations once (with the annotator_user_ids
@@ -2885,11 +2916,11 @@ def run_evaluation(
                             )
 
                 for ann in all_annotations:
+                    ann_done = evaluated_by_ann.get(ann.id, set())
                     if evaluate_missing_only:
-                        ann_done = evaluated_by_ann.get(ann.id, set())
                         if all_expected_field_keys and all_expected_field_keys.issubset(ann_done):
                             continue
-                    ann_cells.append((ann.task_id, ann.id))
+                    ann_cells.append((ann.task_id, ann.id, sorted(ann_done) if ann_done else []))
 
             # ── Build serialized judge_run_ids_by_config for Celery kwargs ────
             # The full `judge_runs_by_config` dict (built upstream during judge
@@ -2903,6 +2934,11 @@ def run_evaluation(
                         "judge_model_id": e.get("judge_model_id"),
                         "run_index": e.get("run_index"),
                         "judge_run_id": e.get("judge_run_id"),
+                        # Threaded through to sub-tasks so each worker process
+                        # can re-instantiate the LLMJudgeEvaluator without
+                        # redoing param resolution. See orchestrator's
+                        # judge-init block for the source of these values.
+                        "judge_evaluator_kwargs": e.get("judge_evaluator_kwargs"),
                     }
                     for e in entries
                 ]
@@ -2967,7 +3003,7 @@ def run_evaluation(
             )
 
             header_sigs = []
-            for (cell_task_id, cell_gen_id) in gen_cells:
+            for (cell_task_id, cell_gen_id, cell_already_done) in gen_cells:
                 header_sigs.append(
                     evaluate_generation_cell.signature(
                         kwargs={
@@ -2981,11 +3017,12 @@ def run_evaluation(
                             "organization_id": organization_id,
                             "triggered_by_user_id": triggered_by,
                             "label_config_version": label_config_version,
+                            "already_evaluated_field_keys": cell_already_done,
                         },
                         queue="evaluation",
                     )
                 )
-            for (cell_task_id, cell_ann_id) in ann_cells:
+            for (cell_task_id, cell_ann_id, cell_already_done) in ann_cells:
                 header_sigs.append(
                     evaluate_annotation_cell.signature(
                         kwargs={
@@ -2998,6 +3035,7 @@ def run_evaluation(
                             "default_judge_run_id": default_judge_run_id,
                             "organization_id": organization_id,
                             "triggered_by_user_id": triggered_by,
+                            "already_evaluated_field_keys": cell_already_done,
                         },
                         queue="evaluation",
                     )
@@ -3830,7 +3868,7 @@ def _reconstruct_judge_evaluators_for_cell(
         the config (for the legacy guard branches that still consult it
         in scalar form)
     """
-    from llm_judge_evaluator import create_llm_judge_for_user
+    from ml_evaluation.llm_judge_evaluator import create_llm_judge_for_user
 
     judge_runs_by_config: Dict[str, List[Dict[str, Any]]] = {}
     llm_judge_evaluators: Dict[str, Any] = {}
@@ -3840,7 +3878,6 @@ def _reconstruct_judge_evaluators_for_cell(
         if not metric.startswith("llm_judge_"):
             continue
         config_id = config.get("id", "unknown")
-        params = config.get("metric_parameters", {}) or {}
         entries = judge_run_ids_by_config.get(config_id, []) or []
         judge_runs_by_config.setdefault(config_id, [])
 
@@ -3848,20 +3885,19 @@ def _reconstruct_judge_evaluators_for_cell(
             judge_model_id = entry["judge_model_id"]
             run_index = entry["run_index"]
             judge_run_id = entry["judge_run_id"]
+            # The orchestrator stashed the fully-resolved construction
+            # kwargs at trigger time (`_resolve_judge` chain, temperature
+            # clamp, seed perturbation). Sub-tasks just unpack them; we
+            # never recompute or re-resolve here so a divergence between
+            # orchestrator + sub-task param logic is impossible.
+            construct_kwargs = entry.get("judge_evaluator_kwargs") or {}
+
             try:
                 evaluator = create_llm_judge_for_user(
-                    user_id=triggered_by_user_id,
                     db=db,
-                    metric_name=metric,
+                    user_id=triggered_by_user_id,
                     organization_id=organization_id,
-                    judge_model_id=judge_model_id,
-                    score_scale=params.get("score_scale", "0-1"),
-                    answer_type=params.get("answer_type"),
-                    temperature=params.get("temperature"),
-                    max_tokens=params.get("max_tokens"),
-                    thinking_budget=params.get("thinking_budget"),
-                    reasoning_effort=params.get("reasoning_effort"),
-                    seed=params.get("seed"),
+                    **construct_kwargs,
                 )
             except Exception as init_err:
                 logger.warning(
@@ -4003,6 +4039,7 @@ def evaluate_generation_cell(
     organization_id: Optional[str],
     triggered_by_user_id: str,
     label_config_version: Optional[str] = None,
+    already_evaluated_field_keys: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """Per-(task, generation) sub-task dispatched by the eval orchestrator.
 
@@ -4063,6 +4100,18 @@ def evaluate_generation_cell(
         )
         sample_evaluator = _build_sample_evaluator_for_cell(evaluation_id, configs_for_cell)
 
+        # Pre-normalize the orchestrator-supplied "already done" set so the
+        # per-field-pair skip check below is a cheap set membership lookup
+        # instead of re-normalizing each iteration. Skipping here avoids the
+        # wasted LLM-judge call that would otherwise happen (the ON CONFLICT
+        # DO NOTHING insert would drop the row, but the LLM call already
+        # happened — burning quota). Mirror of the legacy skip at
+        # ex-`tasks.py:2906-2909`.
+        _already_done_normalized = {
+            _normalize_field_key(fk, is_annotation=False)
+            for fk in (already_evaluated_field_keys or [])
+        }
+
         # Local accumulators (returned to caller via counter bump at end).
         sample_results: List[Dict[str, Any]] = []
         local_samples_evaluated = 0
@@ -4090,6 +4139,15 @@ def evaluate_generation_cell(
 
                 for ref_field in reference_fields:
                     field_key = f"{config_id}|{pred_field}|{ref_field}"
+
+                    # Per-field-pair skip when this cell already has a row
+                    # for this (config, pred, ref). Lifted from legacy
+                    # ex-`tasks.py:2906-2909`. Without this, partial-cell
+                    # retries would re-call the LLM judge for already-done
+                    # field_keys (ON CONFLICT only stops the INSERT, not
+                    # the upstream LLM call).
+                    if _normalize_field_key(field_key, is_annotation=False) in _already_done_normalized:
+                        continue
 
                     # Ground truth extraction.
                     if ref_field.startswith("task."):
@@ -4446,6 +4504,7 @@ def evaluate_annotation_cell(
     default_judge_run_id: str,
     organization_id: Optional[str],
     triggered_by_user_id: str,
+    already_evaluated_field_keys: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """Per-(task, annotation) sub-task dispatched by the eval orchestrator.
 
@@ -4485,6 +4544,14 @@ def evaluate_annotation_cell(
             db=db,
         )
         sample_evaluator = _build_sample_evaluator_for_cell(evaluation_id, configs_for_cell)
+
+        # Pre-normalize per-cell already-done set (annotation-side mirror of
+        # the generation-side skip). Same rationale — avoid the wasted
+        # LLM-judge call on partial-cell retries.
+        _already_done_normalized = {
+            _normalize_field_key(fk, is_annotation=True)
+            for fk in (already_evaluated_field_keys or [])
+        }
 
         sample_results: List[Dict[str, Any]] = []
         local_samples_evaluated = 0
@@ -4531,6 +4598,12 @@ def evaluate_annotation_cell(
                 for actual_pred_field, prediction in field_predictions:
                     for ref_field in reference_fields:
                         field_key = f"{config_id}|{actual_pred_field}|{ref_field}"
+
+                        # Per-field-pair skip — mirror of legacy
+                        # ex-`tasks.py:3485-3488`. Same wasted-LLM-call
+                        # rationale as the gen-side sub-task.
+                        if _normalize_field_key(field_key, is_annotation=True) in _already_done_normalized:
+                            continue
 
                         gt_key = (task.id, ref_field)
                         if gt_key not in gt_cache:

--- a/services/workers/tasks.py
+++ b/services/workers/tasks.py
@@ -2807,7 +2807,7 @@ def run_evaluation(
                     .filter(
                         TaskEvaluation.task_id.in_(task_id_list),
                         TaskEvaluation.generation_id.isnot(None),
-                        EvaluationRun.status.in_(("completed", "running", "pending")),
+                        EvaluationRun.status.in_(("completed", "running", "pending", "cancelled")),
                     )
                     .all()
                 )
@@ -2905,7 +2905,7 @@ def run_evaluation(
                         .filter(
                             TaskEvaluation.task_id.in_(task_id_list),
                             TaskEvaluation.annotation_id.isnot(None),
-                            EvaluationRun.status.in_(("completed", "running", "pending")),
+                            EvaluationRun.status.in_(("completed", "running", "pending", "cancelled")),
                         )
                         .all()
                     )

--- a/services/workers/tests/test_evaluation_fanout.py
+++ b/services/workers/tests/test_evaluation_fanout.py
@@ -267,6 +267,41 @@ def test_cell_sub_tasks_have_poison_cell_guard():
     )
 
 
+def test_classify_cell_failure_is_whitelisted():
+    """Unknown exception classes must NOT leak their class name into
+    `failures_by_reason` keys — that would let a misbehaving SDK
+    emitting one new exception per call grow the JSON object
+    unboundedly inside the parent's `eval_metadata`."""
+    from tasks import _FAILURE_REASON_BUCKETS, _classify_cell_failure
+
+    class WeirdSDKException(Exception):
+        pass
+
+    # An exception class the classifier doesn't recognise must bucket
+    # into the whitelist's catch-all, not leak the class name.
+    assert _classify_cell_failure(WeirdSDKException("boom")) == "other"
+    assert "WeirdSDKException" not in _FAILURE_REASON_BUCKETS
+
+
+def test_classify_cell_failure_no_substring_false_positives():
+    """The pre-fix classifier used `"rate" in exc.__class__.__name__.lower()`
+    which incorrectly bucketed `EnumerateError`, `AggregateError`,
+    `MigrateError` into `rate_limit`. Pin the fix: only classes whose
+    name actually ends in the canonical suffix get bucketed."""
+    from tasks import _classify_cell_failure
+
+    class EnumerateError(Exception): pass
+    class AggregateError(Exception): pass
+    class MigrateError(Exception): pass
+    class RateLimitError(Exception): pass
+
+    assert _classify_cell_failure(EnumerateError("...")) == "other"
+    assert _classify_cell_failure(AggregateError("...")) == "other"
+    assert _classify_cell_failure(MigrateError("...")) == "other"
+    # Real rate-limit class is still classified correctly.
+    assert _classify_cell_failure(RateLimitError("...")) == "rate_limit"
+
+
 def test_cell_sub_tasks_record_failure_reasons():
     """When a cell sub-task hits a transient error and bumps
     `samples_failed=1` without writing a TaskEvaluation row, the user

--- a/services/workers/tests/test_evaluation_fanout.py
+++ b/services/workers/tests/test_evaluation_fanout.py
@@ -156,6 +156,106 @@ def test_bulk_upsert_uses_on_conflict_do_nothing():
     )
 
 
+def test_bulk_upsert_returns_actual_inserts_for_redelivery_safety():
+    """`_bulk_upsert_task_evaluations` must use `RETURNING` and return
+    the count of rows that ACTUALLY landed (after `ON CONFLICT DO
+    NOTHING` skipped duplicates). Sub-tasks must bump the parent
+    counter by this returned count, NOT by the requested count.
+
+    Why: with `acks_late=True`, a worker crashing between task
+    completion and ack triggers Celery to redeliver. The redelivered
+    task re-runs, all its inserts conflict (returning 0 rows), and the
+    counter bump must be 0 — otherwise `samples_evaluated` over-counts
+    and `samples_passed`/`samples_failed` drift from reality."""
+    src = _tasks_source()
+    assert ".returning(" in src, (
+        "_bulk_upsert_task_evaluations must use RETURNING so callers "
+        "can bump by the actually-inserted count, not the requested count"
+    )
+    # The sub-tasks must unpack and use the three-tuple return.
+    assert "n_inserted, n_passed, n_failed = _bulk_upsert_task_evaluations" in src, (
+        "sub-tasks must derive counter-bump values from the helper's "
+        "RETURNING-derived tuple, not from local in-loop tallies"
+    )
+
+
+def test_sub_tasks_use_acks_late_for_chord_completeness():
+    """Cell sub-tasks must have `acks_late=True` + `reject_on_worker_lost=True`.
+
+    Without `acks_late`, a worker SIGKILL/OOM mid-cell loses the
+    message; the chord barrier never sees that header's result, and
+    the chord callback (`finalize_evaluation_run`) never fires. The
+    parent EvaluationRun then sits in `running` forever. At ~6940 cells
+    per real eval, lost cells are essentially guaranteed.
+
+    `reject_on_worker_lost=True` ensures the message goes back to the
+    broker when the worker dies, instead of disappearing."""
+    src = _tasks_source()
+    # Both sub-tasks + the finalizer get the same treatment.
+    for tag in (
+        "tasks.evaluate_generation_cell",
+        "tasks.evaluate_annotation_cell",
+        "tasks.finalize_evaluation_run",
+    ):
+        # Find the decorator block for this task and assert the flags appear in it.
+        m = re.search(
+            r'@app\.task\(\s*name="' + re.escape(tag) + r'".*?\)',
+            src, re.DOTALL,
+        )
+        assert m, f"could not locate decorator for {tag}"
+        deco = m.group(0)
+        assert "acks_late=True" in deco, (
+            f"{tag} must set acks_late=True so worker death triggers redelivery"
+        )
+        assert "reject_on_worker_lost=True" in deco, (
+            f"{tag} must set reject_on_worker_lost=True for redelivery on SIGKILL"
+        )
+
+
+def test_cell_sub_tasks_short_circuit_on_parent_cancel():
+    """Once chord dispatches ~6940 sub-tasks, cancelling the parent run
+    only marks status='cancelled'; the sub-tasks themselves keep
+    running and burn LLM quota unless they re-check parent status.
+
+    Pin: both cell sub-tasks must read parent status at entry and skip
+    when it's terminal. Cheap (one indexed SELECT)."""
+    src = _tasks_source()
+    import ast
+    tree = ast.parse(src)
+    for fn_name in ("evaluate_generation_cell", "evaluate_annotation_cell"):
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == fn_name:
+                body_src = ast.get_source_segment(src, node) or ""
+                assert "parent_status" in body_src and (
+                    '"cancelled"' in body_src or "'cancelled'" in body_src
+                ), (
+                    f"{fn_name} must read EvaluationRun.status at entry and "
+                    f"short-circuit on cancelled/terminal to avoid burning "
+                    f"LLM quota on already-cancelled evals"
+                )
+                break
+        else:
+            raise AssertionError(f"function {fn_name} not found in tasks.py")
+
+
+def test_counter_bump_skips_when_parent_terminal():
+    """Defense in depth against the finalize TOCTOU race: even if a
+    late sub-task bump lands between finalize's `db.refresh` and
+    `db.commit`, the SQL UPDATE filter `status NOT IN
+    ('completed','failed','cancelled')` makes it a no-op (rowcount=0).
+    Without this, the late bump silently clobbers the finalized
+    counters in `eval_metadata`."""
+    src = _tasks_source()
+    assert re.search(
+        r"status\s+NOT\s+IN\s*\(\s*'completed'\s*,\s*'failed'\s*,\s*'cancelled'\s*\)",
+        src,
+    ), (
+        "_bump_evaluation_counters UPDATE must include "
+        "`AND status NOT IN ('completed','failed','cancelled')` so late "
+        "bumps after finalize are no-ops"
+    )
+
+
 def test_counter_bump_uses_atomic_sql_increment():
     """`samples_evaluated` (and the JSON-blob counters
     `samples_passed`/`samples_failed`) must be bumped via SQL

--- a/services/workers/tests/test_evaluation_fanout.py
+++ b/services/workers/tests/test_evaluation_fanout.py
@@ -263,6 +263,14 @@ def test_orchestrator_preloads_missing_only_skip_sets():
             assert "all_expected_field_keys.issubset" in body_src, (
                 "orchestrator must skip fully-evaluated cells before dispatch"
             )
+            # Status filter must include 'cancelled' so successful rows
+            # under a cancelled parent run are still reused on re-trigger
+            # in missing-only mode (e.g. an admin cancels mid-run and the
+            # user re-triggers via the UI's "evaluate missing" path).
+            assert body_src.count('"cancelled"') >= 2, (
+                "preload status filter must include 'cancelled' at both "
+                "gen-side and ann-side sites"
+            )
             return
     raise AssertionError("run_evaluation function not found")
 

--- a/services/workers/tests/test_evaluation_fanout.py
+++ b/services/workers/tests/test_evaluation_fanout.py
@@ -197,17 +197,25 @@ def test_sub_tasks_use_acks_late_for_chord_completeness():
         "tasks.evaluate_annotation_cell",
         "tasks.finalize_evaluation_run",
     ):
-        # Find the decorator block for this task and assert the flags appear in it.
+        # Find the decorator block for this task. Anchor on `)\s*\ndef `
+        # rather than the lazy `.*?)` — the lazy form stops at the FIRST
+        # `)` it sees, which is fragile if a future kwarg value contains
+        # parens (e.g. `retry_backoff_max=timedelta(seconds=30)`). The
+        # `\)\s*\ndef ` anchor guarantees we capture through the actual
+        # decorator close.
         m = re.search(
-            r'@app\.task\(\s*name="' + re.escape(tag) + r'".*?\)',
+            r'@app\.task\(\s*name="' + re.escape(tag) + r'".*?\)\s*\ndef ',
             src, re.DOTALL,
         )
         assert m, f"could not locate decorator for {tag}"
         deco = m.group(0)
-        assert "acks_late=True" in deco, (
+        # Anchor on the actual kwarg (whitespace-tolerant) so a stray
+        # `acks_late=True` inside a docstring or comment block doesn't
+        # falsely satisfy the assertion.
+        assert re.search(r"\backs_late\s*=\s*True\b", deco), (
             f"{tag} must set acks_late=True so worker death triggers redelivery"
         )
-        assert "reject_on_worker_lost=True" in deco, (
+        assert re.search(r"\breject_on_worker_lost\s*=\s*True\b", deco), (
             f"{tag} must set reject_on_worker_lost=True for redelivery on SIGKILL"
         )
 

--- a/services/workers/tests/test_evaluation_fanout.py
+++ b/services/workers/tests/test_evaluation_fanout.py
@@ -1,0 +1,318 @@
+"""Worker-side tests for the per-cell evaluation fan-out refactor.
+
+Mirrors `test_run_evaluation_annotator_scope.py` style: signature
+contracts (Layer 1) + source contracts (Layer 2). DB-free, fast,
+catches architectural regressions without spinning up Celery or Postgres.
+
+What's being pinned:
+- The new sub-task signatures so the orchestrator's `chord(...)`
+  dispatch keyword arguments stay in lockstep with what the sub-tasks
+  accept. A drift here silently breaks dispatch at runtime.
+- The orchestrator actually uses Celery `chord` (no longer iterates
+  in-process) and dispatches sub-tasks to `queue="evaluation"`.
+- Sub-tasks use the bulk-upsert helper with `ON CONFLICT DO NOTHING`
+  (idempotent retries; defense-in-depth against concurrent triggers).
+- The atomic counter-bump SQL pattern is in place (not read-modify-write).
+- The finalizer has the idempotency guard against chord redelivery.
+- Sub-tasks never call `_create_judge_run` — that race-prone helper
+  remains orchestrator-only.
+
+The end-to-end "100 cells × 3 metrics through real chord" test belongs
+in `tests/integration/` and is intentionally out of scope here so this
+file stays runnable in the fast unit pass.
+"""
+
+import inspect
+import re
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: signature contracts
+#
+# `chord(group(sub_sigs))(finalize_sig)` passes kwargs by name through
+# Celery — a positional-arg shuffle in any of these three functions
+# breaks dispatch silently. The asserts below catch that.
+# ---------------------------------------------------------------------------
+
+
+def _unwrap(task):
+    """Get the plain Python callable behind an `@app.task` decorator."""
+    return getattr(task, "__wrapped__", task.run if hasattr(task, "run") else task)
+
+
+def test_evaluate_generation_cell_signature():
+    from tasks import evaluate_generation_cell
+
+    fn = _unwrap(evaluate_generation_cell)
+    params = inspect.signature(fn).parameters
+    expected = {
+        "evaluation_id",
+        "task_id",
+        "generation_id",
+        "project_id",
+        "configs_for_cell",
+        "judge_run_ids_by_config",
+        "default_judge_run_id",
+        "organization_id",
+        "triggered_by_user_id",
+        "label_config_version",
+    }
+    missing = expected - set(params.keys())
+    assert not missing, f"evaluate_generation_cell missing kwargs: {missing}"
+
+
+def test_evaluate_annotation_cell_signature():
+    from tasks import evaluate_annotation_cell
+
+    fn = _unwrap(evaluate_annotation_cell)
+    params = inspect.signature(fn).parameters
+    expected = {
+        "evaluation_id",
+        "task_id",
+        "annotation_id",
+        "project_id",
+        "configs_for_cell",
+        "judge_run_ids_by_config",
+        "default_judge_run_id",
+        "organization_id",
+        "triggered_by_user_id",
+    }
+    missing = expected - set(params.keys())
+    assert not missing, f"evaluate_annotation_cell missing kwargs: {missing}"
+
+
+def test_finalize_evaluation_run_signature():
+    """Celery chord callback convention: header sub-task return values are
+    injected as the first positional arg. Pin that the first parameter is
+    `_sub_task_results` (consumed only as a chord-protocol placeholder —
+    finalizer reads state from DB) and `evaluation_id` is the keyword arg
+    the orchestrator passes."""
+    from tasks import finalize_evaluation_run
+
+    fn = _unwrap(finalize_evaluation_run)
+    params = list(inspect.signature(fn).parameters.items())
+    # First param is `self` (bind=True) or `_sub_task_results` (bind=False).
+    # Celery's bind=True prepends `self` so the chord-injected list lands
+    # at index 1; without bind it lands at index 0. Accept either to keep
+    # this test independent of whether we toggle `bind=`.
+    names = [n for n, _ in params]
+    assert (
+        names[0] in ("self", "_sub_task_results")
+        and "_sub_task_results" in names
+        and "evaluation_id" in names
+    ), f"finalize_evaluation_run param order looks wrong: {names}"
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: source contracts
+#
+# Pin the architectural decisions in the source string. Each `assert`
+# names the specific decision so failures point at what regressed.
+# ---------------------------------------------------------------------------
+
+
+def _tasks_source() -> str:
+    import tasks
+    return inspect.getsource(tasks)
+
+
+def test_orchestrator_uses_celery_chord_dispatch():
+    """The orchestrator must dispatch sub-tasks via a Celery chord. If
+    someone reintroduces an in-process loop here, the chord callback
+    won't fire and the parent EvaluationRun hangs in `running` forever."""
+    src = _tasks_source()
+    assert "from celery import chord" in src, (
+        "orchestrator must import chord from celery"
+    )
+    assert re.search(r"chord\([^)]*header_sigs[^)]*\)\(", src) or re.search(
+        r"chord\(\s*header_sigs\s*\)\(", src
+    ), "expected `chord(header_sigs)(callback_sig)` dispatch shape"
+
+
+def test_sub_tasks_dispatch_to_evaluation_queue():
+    """Both cell sub-tasks and the finalizer must be dispatched to the
+    dedicated `evaluation` queue so they don't compete with generation
+    on the shared `celery`/`default` pool (the contention that prompted
+    this refactor in the first place)."""
+    src = _tasks_source()
+    # The orchestrator dispatches three signatures; each must set the queue.
+    assert src.count('queue="evaluation"') >= 3, (
+        "orchestrator must dispatch all three sub-task signatures to "
+        "queue=\"evaluation\""
+    )
+
+
+def test_bulk_upsert_uses_on_conflict_do_nothing():
+    """Sub-tasks must use `ON CONFLICT DO NOTHING` against the partial
+    unique index from migration 048. Without this, concurrent retries
+    or chord redeliveries duplicate-write TaskEvaluation rows and
+    pollute the metric aggregates."""
+    src = _tasks_source()
+    assert "on_conflict_do_nothing" in src, (
+        "sub-tasks must use postgresql.insert(...).on_conflict_do_nothing()"
+    )
+    assert "_bulk_upsert_task_evaluations" in src, (
+        "expected the shared bulk-upsert helper to be defined and used"
+    )
+
+
+def test_counter_bump_uses_atomic_sql_increment():
+    """`samples_evaluated` (and the JSON-blob counters
+    `samples_passed`/`samples_failed`) must be bumped via SQL
+    `col = col + :n` so concurrent sub-tasks don't lose updates. A
+    Python-side `evaluation.samples_evaluated += local_n` would race."""
+    src = _tasks_source()
+    assert re.search(
+        r"samples_evaluated\s*=\s*COALESCE\(samples_evaluated,\s*0\)\s*\+\s*:n",
+        src,
+    ), "expected atomic `samples_evaluated = COALESCE(...) + :n` SQL bump"
+    assert "jsonb_set" in src, (
+        "expected jsonb_set for atomic samples_passed/samples_failed bumps"
+    )
+
+
+def test_finalizer_has_idempotency_guard():
+    """The chord callback can be redelivered if the worker dies between
+    `finalize_evaluation_run` completing its work and Celery ack'ing the
+    result. The finalizer must short-circuit if the parent is already
+    terminal (`completed`/`failed`/`cancelled`) so a redelivery doesn't
+    e.g. re-fire the completion notification."""
+    src = _tasks_source()
+    assert re.search(
+        r"evaluation\.status\s+in\s*\(\s*[\"']completed[\"']\s*,\s*[\"']failed[\"']",
+        src,
+    ), "finalize_evaluation_run must guard against re-entry on terminal status"
+
+
+def test_sub_tasks_do_not_create_judge_runs():
+    """`_create_judge_run` does a non-atomic SELECT-then-INSERT against
+    the `uq_evaluation_judge_runs_eval_model_index` unique constraint.
+    Under fan-out, concurrent sub-tasks would race here. The
+    orchestrator must own judge_run creation; sub-tasks only consume IDs
+    the orchestrator pre-populated."""
+    src = _tasks_source()
+    # Locate the two sub-task function bodies and assert _create_judge_run
+    # is not referenced inside either.
+    import ast
+    tree = ast.parse(src)
+    sub_task_names = {"evaluate_generation_cell", "evaluate_annotation_cell"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name in sub_task_names:
+            body_src = ast.get_source_segment(src, node) or ""
+            assert "_create_judge_run" not in body_src, (
+                f"{node.name} must not call _create_judge_run — orchestrator "
+                f"pre-creates all judge_runs to avoid UQ races"
+            )
+
+
+def test_orchestrator_pre_creates_judge_runs_synchronously():
+    """The orchestrator must call `_create_judge_run` synchronously
+    BEFORE dispatching the chord. Otherwise sub-tasks would be the only
+    callers and we'd hit the race condition that motivated the previous
+    test."""
+    src = _tasks_source()
+    import ast
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "run_evaluation":
+            body_src = ast.get_source_segment(src, node) or ""
+            assert "_create_judge_run" in body_src, (
+                "orchestrator must call _create_judge_run during setup phase"
+            )
+            assert "chord(" in body_src, (
+                "orchestrator must dispatch the chord (no in-process loop)"
+            )
+            # Order: _create_judge_run calls come before the chord dispatch.
+            idx_create = body_src.index("_create_judge_run")
+            idx_chord = body_src.index("chord(")
+            assert idx_create < idx_chord, (
+                "_create_judge_run must run BEFORE chord dispatch"
+            )
+            return
+    raise AssertionError("run_evaluation function not found")
+
+
+def test_orchestrator_persists_judge_run_ids_for_finalizer():
+    """The finalizer rebuilds the `judges_by_config` summary from
+    `eval_metadata.judge_run_ids_by_config`. If the orchestrator stops
+    persisting it, the frontend's Judges tab silently shows blank."""
+    src = _tasks_source()
+    assert '"judge_run_ids_by_config"' in src, (
+        "orchestrator must persist judge_run_ids_by_config into eval_metadata"
+    )
+
+
+def test_orchestrator_preloads_missing_only_skip_sets():
+    """Pre-filtering the chord header against the existing-evaluations
+    skip set keeps Celery message count under control on retries (we
+    don't fan out N×K cells just to ON-CONFLICT them away inside each
+    sub-task)."""
+    src = _tasks_source()
+    import ast
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "run_evaluation":
+            body_src = ast.get_source_segment(src, node) or ""
+            # Both skip sets get materialized in the orchestrator's pre-filter.
+            assert "evaluated_by_gen" in body_src, (
+                "orchestrator must build the gen-side missing-only skip set"
+            )
+            assert "evaluated_by_ann" in body_src, (
+                "orchestrator must build the ann-side missing-only skip set"
+            )
+            assert "all_expected_field_keys.issubset" in body_src, (
+                "orchestrator must skip fully-evaluated cells before dispatch"
+            )
+            return
+    raise AssertionError("run_evaluation function not found")
+
+
+def test_finalizer_recomputes_metrics_from_db():
+    """Per-sub-task aggregate state can't be shared safely under fan-out,
+    so the finalizer recomputes from `TaskEvaluation` rows. Pin that the
+    SELECT happens (not just reads back the parent's pre-existing
+    `metrics` field)."""
+    src = _tasks_source()
+    import ast
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "finalize_evaluation_run":
+            body_src = ast.get_source_segment(src, node) or ""
+            assert re.search(
+                r"SELECT\s+field_name,\s*metrics\s+FROM\s+task_evaluations",
+                body_src,
+                re.IGNORECASE,
+            ), "finalizer must SELECT field_name + metrics from task_evaluations"
+            return
+    raise AssertionError("finalize_evaluation_run function not found")
+
+
+def test_sub_tasks_reconstruct_evaluators_per_process():
+    """Each sub-task instantiates its own `LLMJudgeEvaluator` per worker
+    process via the helper. The helper signature is the contract — if it
+    drifts (e.g. starts requiring a shared cache), sub-tasks will fail
+    silently when run under real Celery."""
+    src = _tasks_source()
+    assert "_reconstruct_judge_evaluators_for_cell" in src, (
+        "expected the per-cell judge-evaluator reconstruction helper"
+    )
+    assert "create_llm_judge_for_user" in src, (
+        "helper must call create_llm_judge_for_user (mirrors orchestrator init)"
+    )
+
+
+def test_orchestrator_short_circuits_on_zero_cells():
+    """A `missing-only` run that finds nothing left to do should mark
+    the EvaluationRun as `completed` immediately (not dispatch an empty
+    chord, which would never invoke the finalizer)."""
+    src = _tasks_source()
+    import ast
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "run_evaluation":
+            body_src = ast.get_source_segment(src, node) or ""
+            assert "cells_dispatched == 0" in body_src, (
+                "orchestrator must short-circuit when no cells need dispatch"
+            )
+            return
+    raise AssertionError("run_evaluation function not found")

--- a/services/workers/tests/test_evaluation_fanout.py
+++ b/services/workers/tests/test_evaluation_fanout.py
@@ -267,6 +267,77 @@ def test_cell_sub_tasks_have_poison_cell_guard():
     )
 
 
+def test_bulk_upsert_emits_on_conflict_do_nothing_returning_passed():
+    """Real check on the SQL that `_bulk_upsert_task_evaluations`
+    generates. Source-grep tests catch deleted call sites but miss
+    a refactor that e.g. swaps `.on_conflict_do_nothing()` for
+    `.on_conflict_do_update(...)` or drops the RETURNING clause —
+    both would silently break the redelivery-safe counter math.
+
+    Compiles the actual SQLAlchemy statement with literal binds and
+    asserts the dialect-rendered SQL contains the two clauses we
+    depend on (`ON CONFLICT DO NOTHING` and `RETURNING ...passed`).
+    """
+    from unittest.mock import MagicMock
+    from sqlalchemy.dialects import postgresql
+
+    # Stub the import of `tasks` enough that `_bulk_upsert_task_evaluations`
+    # is callable. The function constructs and executes a stmt — patch
+    # `db.execute` to capture the stmt, then compile it ourselves.
+    from tasks import _bulk_upsert_task_evaluations
+
+    captured = {}
+
+    def fake_execute(stmt):
+        captured["stmt"] = stmt
+        # Empty result set so the function returns (0, 0, 0) cleanly.
+        result = MagicMock()
+        result.fetchall.return_value = []
+        return result
+
+    fake_db = MagicMock()
+    fake_db.execute.side_effect = fake_execute
+
+    rows = [{
+        "id": "11111111-1111-1111-1111-111111111111",
+        "evaluation_id": "22222222-2222-2222-2222-222222222222",
+        "judge_run_id": "33333333-3333-3333-3333-333333333333",
+        "task_id": "44444444-4444-4444-4444-444444444444",
+        "generation_id": "55555555-5555-5555-5555-555555555555",
+        "annotation_id": None,
+        "field_name": "cfg|p|r",
+        "answer_type": "text",
+        "ground_truth": "x",
+        "prediction": "y",
+        "metrics": {},
+        "passed": False,
+    }]
+    result = _bulk_upsert_task_evaluations(fake_db, rows)
+
+    # Function contract: empty fetchall → (0, 0, 0) regardless of input size.
+    assert result == (0, 0, 0)
+    # Captured stmt compiles with the postgresql dialect and contains
+    # the two clauses we care about.
+    compiled = str(
+        captured["stmt"].compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": False},
+        )
+    ).upper()
+    assert "ON CONFLICT DO NOTHING" in compiled, (
+        "_bulk_upsert_task_evaluations must emit ON CONFLICT DO NOTHING "
+        "so redelivered cells silently skip-insert instead of erroring"
+    )
+    assert "RETURNING" in compiled, (
+        "_bulk_upsert_task_evaluations must use RETURNING so caller can "
+        "bump parent counter by actual inserted count, not requested count"
+    )
+    assert "PASSED" in compiled, (
+        "RETURNING clause must include `passed` so the helper can split "
+        "(n_inserted, n_passed, n_failed)"
+    )
+
+
 def test_classify_cell_failure_is_whitelisted():
     """Unknown exception classes must NOT leak their class name into
     `failures_by_reason` keys — that would let a misbehaving SDK

--- a/services/workers/tests/test_evaluation_fanout.py
+++ b/services/workers/tests/test_evaluation_fanout.py
@@ -246,6 +246,71 @@ def test_cell_sub_tasks_short_circuit_on_parent_cancel():
             raise AssertionError(f"function {fn_name} not found in tasks.py")
 
 
+def test_cell_sub_tasks_have_poison_cell_guard():
+    """A cell that deterministically OOMs would be redelivered
+    indefinitely under `reject_on_worker_lost=True` (broker-level
+    redeliveries don't decrement `max_retries`). The Redis-backed
+    `_record_cell_attempt` counter caps redeliveries and short-circuits
+    after `_CELL_ATTEMPT_LIMIT` so the chord still completes."""
+    src = _tasks_source()
+    assert "_record_cell_attempt" in src, "missing poison-cell counter helper"
+    assert "_CELL_ATTEMPT_LIMIT" in src, "missing poison-cell limit constant"
+    # Both sub-tasks invoke the guard near entry and short-circuit
+    # past the limit. Grep for both call sites and the bail-out branch.
+    assert src.count("_record_cell_attempt(evaluation_id, ") >= 2, (
+        "both cell sub-tasks must call _record_cell_attempt to share the cap"
+    )
+    assert 'reason": "poison_cell_max_attempts' in src or \
+        "poison_cell_max_attempts" in src, (
+        "poison-cell skip path must tag the failure_reason so the UI can "
+        "surface 'N cells went poison'"
+    )
+
+
+def test_cell_sub_tasks_record_failure_reasons():
+    """When a cell sub-task hits a transient error and bumps
+    `samples_failed=1` without writing a TaskEvaluation row, the user
+    sees a pass-rate drop with no signal as to *why*. Both sub-tasks
+    must classify the exception and increment
+    `eval_metadata.failures_by_reason[<reason>]` so the InflightRunsBanner
+    can display 'rate_limit: 139, timeout: 12' on the runs view."""
+    src = _tasks_source()
+    assert "_record_cell_failure_reason" in src, (
+        "missing failure-reason tracker helper"
+    )
+    assert "_classify_cell_failure" in src, (
+        "missing exception → reason classifier"
+    )
+    # Both cell sub-tasks should call the recorder in their outer
+    # except block.
+    assert src.count("_record_cell_failure_reason(db, evaluation_id, ") >= 2, (
+        "both cell sub-tasks must record the failure reason in the outer "
+        "exception handler so the UI can surface a breakdown"
+    )
+
+
+def test_orchestrator_pre_chord_cancel_check():
+    """Orchestrator setup (judge_run creation + work-unit enumeration +
+    missing-only preload) takes ~25s on a ZJS-scale eval. If the user
+    cancels DURING setup, we must skip the chord dispatch — otherwise
+    we fan out 6940 sub-tasks that each immediately short-circuit on
+    their own parent-status check (Celery message churn + worker CPU
+    for no useful work)."""
+    src = _tasks_source()
+    import ast
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "run_evaluation":
+            body_src = ast.get_source_segment(src, node) or ""
+            assert "cancelled_before_dispatch" in body_src, (
+                "orchestrator must re-check EvaluationRun.status just before "
+                "chord dispatch and bail (status 'cancelled_before_dispatch') "
+                "rather than fan out useless sub-tasks"
+            )
+            return
+    raise AssertionError("run_evaluation function not found")
+
+
 def test_counter_bump_skips_when_parent_terminal():
     """Defense in depth against the finalize TOCTOU race: even if a
     late sub-task bump lands between finalize's `db.refresh` and

--- a/services/workers/tests/test_evaluation_fanout.py
+++ b/services/workers/tests/test_evaluation_fanout.py
@@ -169,6 +169,16 @@ def test_counter_bump_uses_atomic_sql_increment():
     assert "jsonb_set" in src, (
         "expected jsonb_set for atomic samples_passed/samples_failed bumps"
     )
+    # Postgres 18 (the post-Broadcom Bitnami image content) enforces
+    # FIPS-strict OpenSSL and refuses implicit json↔jsonb coercion. The
+    # `eval_metadata` column is `json` (legacy), so the bump UPDATE must
+    # cast explicitly: read as `::jsonb`, write back as `::json`.
+    assert "eval_metadata::jsonb" in src, (
+        "expected explicit ::jsonb cast on read side (Postgres 18 FIPS-strict)"
+    )
+    assert ")::json" in src, (
+        "expected explicit ::json cast on write side (Postgres 18 FIPS-strict)"
+    )
 
 
 def test_finalizer_has_idempotency_guard():


### PR DESCRIPTION
## Why

Today `tasks.run_evaluation` is a single bundled Celery task — one process serially loops over (task × generation × config × field_pair × judge) tuples. Measured ETA for a ZJS-scale run (581 tasks × 12 models × 7 metrics): **~9.5 days**, with 15 of 16 worker slots idle the whole time.

`tasks.generate_response` already parallelizes by dispatching one Celery task per (cell, run_index) (`generation_task_list.py:649-688`). This PR aligns evaluation with that pattern.

Expected outcome: same 7-metric × 6,940-cell run in **~1–2h instead of 9 days**, with no correctness regressions, no double-evaluation, clean parent-status finalization.

## What changes

**Orchestrator (`tasks.run_evaluation`)** becomes a slim dispatcher. Keeps Phase 1–3 setup verbatim (project load, enabled_configs filter, judge_run pre-creation via `_create_judge_run`, default_judge_run). Replaces Phase 4–7 (the ~1,280-line inner-loop body) with work-unit enumeration + `chord(group(per_cell_sigs))(finalize_evaluation_run)` dispatch. Returns immediately.

**Three new tasks** (all in `services/workers/tasks.py`):
- `tasks.evaluate_generation_cell` — per-(task, generation) sub-task. Lifts the prior in-process inner block (terminal-error rows, multi-judge fan-out, Falllösung extended dispatch, deterministic SampleEvaluator path). Bulk-upserts TaskEvaluation rows via `ON CONFLICT DO NOTHING`, then atomically bumps the parent EvaluationRun's counters.
- `tasks.evaluate_annotation_cell` — mirror for the human-annotation eval path.
- `tasks.finalize_evaluation_run` — chord callback. Walks `EvaluationJudgeRun` children for the row-count tally, recomputes the `metrics` aggregate from `TaskEvaluation` rows in one SQL pass, sets parent status, fires the report-section update + completion notification. Idempotent against chord redelivery.

**Migration 048** adds a partial unique index on `task_evaluations(evaluation_id, judge_run_id, COALESCE(generation_id), COALESCE(annotation_id), field_name) WHERE evaluation_id IS NOT NULL`. Dedups any pre-existing duplicates before creating. Required as the conflict target for `ON CONFLICT DO NOTHING` and as a defense-in-depth against concurrent eval triggers.

**Dedicated `evaluation` Celery queue.** Helm worker deployment adds it to the `-Q` list; API dispatcher routes `tasks.run_evaluation` (and the three sub-tasks) to it. Eval no longer competes with generation on the shared `celery`/`default` pool.

## Concurrency hazards addressed

| Hazard | Mitigation |
|---|---|
| `EvaluationJudgeRun` UQ races (`tasks.py:2508-2534`) | Orchestrator pre-creates all judge_runs before chord dispatch; sub-tasks never call `_create_judge_run`. |
| `llm_judge_evaluators` cache thrashing | Each sub-task constructs its own `LLMJudgeEvaluator` per process via `_reconstruct_judge_evaluators_for_cell`. |
| `SampleEvaluator` model reload thrashing | Module-level caches in `sample_evaluator.py:147,155` are process-local — first cell per worker pays the model-load cost, rest are free. |
| `evaluate_missing_only` double-eval race | Orchestrator pre-filters skip set before dispatch; partial unique index + `ON CONFLICT DO NOTHING` at insert time as defense-in-depth against concurrent triggers. |
| `evaluation.samples_evaluated` lost updates | SQL `UPDATE ... SET col = col + :n` (`_bump_evaluation_counters`); Postgres serializes on the row. JSONB-blob counters via `jsonb_set`. |
| Parent status finalization race | Chord callback fires exactly once after every header sub-task terminates. Idempotency guard against redelivery. |

## Test plan

`services/workers/tests/test_evaluation_fanout.py` — DB-free signature + source contracts (mirrors `test_run_evaluation_annotator_scope.py` style):
- [ ] Three sub-task signatures accept the kwargs the orchestrator's chord dispatch passes
- [ ] Orchestrator uses `chord(...)` (no in-process loop)
- [ ] All three sub-task signatures get `queue=\"evaluation\"`
- [ ] Bulk upsert uses `ON CONFLICT DO NOTHING`
- [ ] Atomic SQL counter bumps (`col = col + :n`, `jsonb_set`)
- [ ] Finalizer has terminal-status idempotency guard
- [ ] Sub-tasks never call `_create_judge_run`
- [ ] Orchestrator calls `_create_judge_run` before chord dispatch
- [ ] Orchestrator persists `judge_run_ids_by_config` for the finalizer
- [ ] Orchestrator pre-loads gen-side + ann-side missing-only skip sets
- [ ] Finalizer recomputes metrics aggregate from `task_evaluations` (SQL)
- [ ] Orchestrator short-circuits on zero cells

End-to-end \"real chord round-trip + 100 cells × 3 metrics\" deferred to `tests/integration/` — not in this PR to keep the unit pass fast.

## Deploy ordering

1. Merge this PR (CI runs full test suite first).
2. Worker pod must roll first so it consumes the new `evaluation` queue — the helm template change is in this PR; the platform `main` → extended `core-updated` dispatch handles deploy ordering.
3. Alembic upgrade for migration 048 must run before the new worker code starts. Standard CI/CD ordering already handles this (migrations run pre-deploy).

## Backwards compatibility

- Backward-compat alias `tasks.run_multi_field_evaluation` still points at `run_evaluation` — legacy task names still dispatch.
- Human-graded eval path (`korrektur_*` configs) unchanged — those are persisted by the API at grade time, not by any worker task.
- Immediate-eval task `tasks.run_single_sample_evaluation` unchanged — already per-annotation by design.
- API `/api/evaluations/run` endpoint signature unchanged — only its dispatched `queue=` flips from `celery` to `evaluation`.

## Plan reference

Full plan in `/Users/sebastiannagl/.claude/plans/i-set-up-the-purrfect-moonbeam.md` (already approved).