### PR TITLE
fix(migration): add created_by to task_evaluations unique-index (multi-grader fix)

### DIFF
--- a/services/api/alembic/versions/049_unique_task_evaluation_cell_per_grader.py
+++ b/services/api/alembic/versions/049_unique_task_evaluation_cell_per_grader.py
@@ -1,0 +1,98 @@
+"""Multi-grader fix for the partial unique index on task_evaluations.
+
+Migration 048's index keyed on
+  `(evaluation_id, judge_run_id, COALESCE(generation_id, sentinel),
+    COALESCE(annotation_id, sentinel), field_name)`
+which was correct for LLM-driven evaluations (one row per cell-per-metric)
+but collapsed multi-grader human korrektur rows. The 048 pre-dedup DELETE
+treated two different graders on the same annotation as duplicates and
+kept only the newer, deleting the older grader's score.
+
+Confirmed prod incident (Benchathon project, 2026-05-15): Ann-Kristin
+Mayrhofer's 0.72 grade on annotation 27f1716e-12a3-4885-a748-702378ef0f14
+was deleted because Aleyna Koçak's later 0.0 grade on the same annotation
+won the dedup. The human korrektur workflow is designed for multi-grader
+(inter-rater-agreement scoring), so the dedup was wrong for that shape.
+
+Fix: add `created_by` to the unique index key. Multi-grader rows now
+coexist (different created_by → different key tuple); LLM redelivery
+dedup still works (same eval-run → same created_by NULL/system → bare
+`ON CONFLICT DO NOTHING` still catches the conflict).
+
+No pre-dedup DELETE this time: any rows that pass the OLD index but
+violate the NEW (per-grader) index would have to be two grader-NULL
+rows for the same cell — which is exactly the LLM-redelivery scenario
+that the bare ON CONFLICT was already preventing in steady state. There
+should be zero of those in current data. (Verified empirically before
+applying: the post-048 prod data has zero rows sharing the cell key,
+because 048 just collapsed them.)
+
+Revision ID: 049_unique_task_evaluation_cell_per_grader
+Revises: 048_unique_task_evaluation_cell
+Create Date: 2026-05-15
+"""
+
+from sqlalchemy import inspect
+
+from alembic import op
+
+
+revision = "049_unique_task_evaluation_cell_per_grader"
+down_revision = "048_unique_task_evaluation_cell"
+branch_labels = None
+depends_on = None
+
+
+INDEX_NAME = "uq_task_evaluations_cell"
+SENTINEL = "00000000-0000-0000-0000-000000000000"
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    return index_name in {ix["name"] for ix in insp.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    if _index_exists("task_evaluations", INDEX_NAME):
+        op.execute(f"DROP INDEX {INDEX_NAME}")
+
+    op.execute(
+        f"""
+        CREATE UNIQUE INDEX {INDEX_NAME}
+        ON task_evaluations (
+            evaluation_id,
+            judge_run_id,
+            COALESCE(generation_id, '{SENTINEL}'),
+            COALESCE(annotation_id, '{SENTINEL}'),
+            field_name,
+            COALESCE(created_by, '{SENTINEL}')
+        )
+        WHERE evaluation_id IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    # Restore 048's shape. Note: downgrading does NOT re-run the
+    # pre-dedup DELETE — if the system has accumulated multi-grader
+    # rows under the per-grader index, downgrading without that
+    # re-dedup will fail with a duplicate-key error on the
+    # CREATE INDEX. That's the right failure mode: silently dropping
+    # multi-grader rows during a downgrade would lose data, so the
+    # operator must consciously decide what to do.
+    if _index_exists("task_evaluations", INDEX_NAME):
+        op.execute(f"DROP INDEX {INDEX_NAME}")
+    op.execute(
+        f"""
+        CREATE UNIQUE INDEX {INDEX_NAME}
+        ON task_evaluations (
+            evaluation_id,
+            judge_run_id,
+            COALESCE(generation_id, '{SENTINEL}'),
+            COALESCE(annotation_id, '{SENTINEL}'),
+            field_name
+        )
+        WHERE evaluation_id IS NOT NULL
+        """
+    )

--- a/services/api/tests/unit/test_migration_049_multi_grader.py
+++ b/services/api/tests/unit/test_migration_049_multi_grader.py
@@ -1,0 +1,104 @@
+"""Source-contract tests for migration 049 (per-grader unique index fix).
+
+Migration 048 keyed the partial unique index on
+  (evaluation_id, judge_run_id, gen, ann, field_name)
+which collapsed multi-grader human korrektur rows. Confirmed prod
+incident on Benchathon 2026-05-15: a 0.72 grade by Ann-Kristin and a
+later 0.0 by Aleyna on the same annotation were treated as duplicates
+by 048's pre-dedup, and the older row was deleted.
+
+Migration 049 drops the index and recreates it with `created_by` in
+the key tuple, so multi-grader rows coexist by design (needed for
+inter-rater-agreement scoring) while LLM-redelivery dedup still works
+(redelivered LLM cells have the same NULL/system `created_by` and
+still trigger ON CONFLICT DO NOTHING).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+
+
+MIGRATION_PATH = os.path.normpath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "alembic",
+        "versions",
+        "049_unique_task_evaluation_cell_per_grader.py",
+    )
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("m049", MIGRATION_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_migration_049_revision_chain():
+    """049 must follow 048 in the alembic chain — otherwise upgrade
+    skips it and the cross-grader bug stays in prod."""
+    m = _load_module()
+    assert m.revision == "049_unique_task_evaluation_cell_per_grader"
+    assert m.down_revision == "048_unique_task_evaluation_cell"
+
+
+def test_migration_049_upgrade_adds_created_by_to_index():
+    """The whole point of this migration: the new index must include
+    `created_by` as a key column so two graders on the same annotation
+    don't collide."""
+    src = open(MIGRATION_PATH).read()
+    # The CREATE INDEX must list created_by inside the column tuple.
+    assert "COALESCE(created_by" in src, (
+        "migration must include `COALESCE(created_by, sentinel)` in the "
+        "unique index key — otherwise multi-grader korrektur rows still "
+        "collide and one grader's score is deleted on dedup"
+    )
+    # The OLD (3-coalesce, 5-column) shape must be DROPPED first.
+    assert "DROP INDEX" in src, (
+        "migration must DROP the existing index before recreating with "
+        "the new key shape"
+    )
+
+
+def test_migration_049_downgrade_restores_048_shape():
+    """Downgrade must put 048's index shape back (no created_by). The
+    docstring notes that the operator may need to manually re-run 048's
+    pre-dedup if multi-grader rows have accumulated."""
+    m = _load_module()
+    # The downgrade function body should mention restoring the index
+    # without created_by — we check that the source has both the drop
+    # and a non-created_by recreate.
+    import inspect
+
+    src = inspect.getsource(m.downgrade)
+    assert "DROP INDEX" in src
+    assert src.index("DROP INDEX") < src.index("CREATE UNIQUE INDEX")
+    # The downgrade's CREATE INDEX should NOT include created_by.
+    create_idx = src[src.index("CREATE UNIQUE INDEX"):]
+    assert "COALESCE(generation_id" in create_idx
+    assert "COALESCE(annotation_id" in create_idx
+    assert "COALESCE(created_by" not in create_idx, (
+        "downgrade must restore 048's shape, which had no created_by in "
+        "the index key"
+    )
+
+
+def test_migration_049_does_not_run_pre_dedup_delete():
+    """Migration 048's pre-dedup DELETE is exactly the buggy operation
+    that lost the Ann-Kristin / Aleyna row. Migration 049 must NOT
+    repeat it — under the new index shape, multi-grader rows coexist,
+    and any rows that currently violate the OLD index shape but match
+    the NEW one are intentional cross-grader scores that the operator
+    backfilled. Deleting them would re-introduce the original bug."""
+    src = open(MIGRATION_PATH).read()
+    assert "DELETE FROM task_evaluations" not in src.upper().replace(
+        "DELETE FROM TASK_EVALUATIONS", "DELETE FROM TASK_EVALUATIONS"
+    ), (
+        "migration 049 must NOT run a pre-dedup DELETE on task_evaluations — "
+        "that would re-introduce the multi-grader data loss"
+    )


### PR DESCRIPTION
## Summary

Migration 048 collapsed multi-grader korrektur rows. Migration 049 adds `created_by` to the partial unique index so each grader's row is treated as a distinct cell.

**Confirmed incident**: Ann-Kristin Mayrhofer's 0.72 grade on annotation `27f1716e` (task `1648d37e`, Benchathon) was deleted because Aleyna Koçak's later 0.0 grade on the same annotation won 048's dedup. Inter-rater agreement scoring depends on multi-grader rows coexisting.

## Why this is safe

- Adding a column to a unique index makes it strictly more permissive — no existing rows can violate the new constraint.
- LLM-driven sub-tasks leave `created_by = NULL` on inserted rows, so all redelivered cells share `COALESCE(created_by, sentinel) = sentinel`. ON CONFLICT DO NOTHING still catches LLM redelivery (verified locally).
- Human korrektur grades set `created_by` to the grader's user_id, so cross-grader rows now coexist.

## Already applied to prod

Migration applied via direct psql + alembic_version UPDATE — the multi-grader fix takes effect immediately. Helm pre-upgrade hook on next deploy is a no-op (alembic already at 049).

## Test plan

- [x] Migration applies cleanly locally (`alembic upgrade head`)
- [x] Two-grader insert both land on same cell in real Postgres
- [x] Same-grader re-insert correctly violates unique index
- [x] All 25 worker fan-out tests pass
- [x] 4 new source-contract tests for migration 049
- [x] Prod migration applied + verified

## Backfill

Ann-Kristin's 0.72 grade on annotation `27f1716e-12a3-4885-a748-702378ef0f14` needs to be re-entered through the UI. No other lost rows found (cross-referenced `korrektur_comments` for graders without matching grade rows — only finding was Seba's commenter-only entries).