### PR TITLE
feat(korrektur): i18n keys for Bewertungsanleitung collapsible

### DIFF
--- a/services/frontend/src/locales/de/common.json
+++ b/services/frontend/src/locales/de/common.json
@@ -7448,6 +7448,12 @@
     "blindTooltipPersistent": "Blinde Korrektur (dauerhaft): {what} verborgen — auch nach Ihrer Einreichung",
     "blindTooltipLifted": "Blinde Korrektur für dieses Item aufgehoben — Sie haben bereits eingereicht, {what} sind jetzt sichtbar",
     "blindTooltipInactive": "Alle Bewertungen sichtbar",
+    "bewertung": {
+      "bewertungsanleitung": {
+        "label": "Bewertungsanleitung anzeigen",
+        "subtitle": "Identisch zur LLM-Korrektor-Anleitung"
+      }
+    },
     "stats": {
       "totalTasks": "Aufgaben gesamt",
       "withFeedback": "Mit Korrektur",

--- a/services/frontend/src/locales/en/common.json
+++ b/services/frontend/src/locales/en/common.json
@@ -7391,6 +7391,12 @@
     "blindTooltipPersistent": "Blind grading (persistent): {what} hidden — also after you submit",
     "blindTooltipLifted": "Blind grading lifted for this item — you've already submitted, so {what} are now visible",
     "blindTooltipInactive": "All evaluations visible",
+    "bewertung": {
+      "bewertungsanleitung": {
+        "label": "Show evaluation guidance",
+        "subtitle": "Same instructions the LLM corrector uses"
+      }
+    },
     "stats": {
       "totalTasks": "Total Tasks",
       "withFeedback": "With Correction",


### PR DESCRIPTION
## Summary

- Adds two i18n keys per locale (DE + EN) under `korrekturWorkflow.bewertung.bewertungsanleitung`: `label` and `subtitle`.
- Used by the extended-side Korrektur modal's new "Bewertungsanleitung" disclosure on the Bewertung tab (`FalloesungGradingForm.tsx`).
- Keys are optional — the extended component passes German strings as fallbacks to `t()`. Landing them in platform keeps the open-core split clean and enables future translation work.

## Test plan

- [x] JSON parses for both locales.
- [ ] CI green.
- [ ] Once the extended PR is also live, confirm the disclosure renders the localized labels (DE: "Bewertungsanleitung anzeigen" / EN: "Show evaluation guidance").