### PR TITLE
fix(api): prod stability cleanup — WS leak, async email, OOM export

### DIFF
--- a/infra/helm/benger/templates/deployment-api.yaml
+++ b/infra/helm/benger/templates/deployment-api.yaml
@@ -43,7 +43,10 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health
+              # /healthz is dependency-free (no DB, no Redis). /health pings
+              # Redis and is reserved for readiness — a sick Redis should
+              # pull the pod from the LB but not get it SIGKILLed.
+              path: /healthz
               port: http
             initialDelaySeconds: 120
             periodSeconds: 15

--- a/infra/helm/benger/values.yaml
+++ b/infra/helm/benger/values.yaml
@@ -9,8 +9,13 @@ global:
 
 api:
   name: api
-  replicaCount: 1
-  workers: 1  # uvicorn workers (keep at 1 — multiple workers hang on startup)
+  # 2 replicas removes the SPOF — rolling restarts no longer cause downtime.
+  # 4 uvicorn workers per replica matches the Dockerfile CMD. Both bumps are
+  # safe now that main.py wraps `alembic upgrade` in a Postgres advisory lock
+  # (the prior `workers: 1` comment was hiding that startup race).
+  # Effective DB pool budget: 2 × 4 × (10 + 20) = 240 slots.
+  replicaCount: 2
+  workers: 4
   deploymentStrategy:
     type: RollingUpdate
     rollingUpdate:

--- a/services/api/auth_module/__init__.py
+++ b/services/api/auth_module/__init__.py
@@ -35,6 +35,7 @@ from .models import (
 
 # Import all public functions and classes for easy access
 from .service import (
+    WebSocketAuthError,
     authenticate_user,
     create_access_token,
     create_tokens_with_refresh,
@@ -43,6 +44,7 @@ from .service import (
     revoke_refresh_token,
     verify_token,
     verify_token_cookie_or_header,
+    verify_token_for_websocket,
 )
 from .token_service import RefreshTokenService, TokenService
 from .user_service import (
@@ -79,6 +81,8 @@ __all__ = [
     "revoke_refresh_token",
     "verify_token",
     "verify_token_cookie_or_header",
+    "verify_token_for_websocket",
+    "WebSocketAuthError",
     "logout_user",
     # Dependencies
     "require_user",

--- a/services/api/auth_module/service.py
+++ b/services/api/auth_module/service.py
@@ -7,7 +7,7 @@ This module contains the core authentication logic consolidated from auth.py
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from fastapi import HTTPException, Request, status
+from fastapi import HTTPException, Request, WebSocket, status
 from jose import JWTError, jwt
 from sqlalchemy.orm import Session
 
@@ -113,6 +113,42 @@ def verify_token_cookie_or_header(request: Request) -> dict:
         )
 
     return verify_token(token)
+
+
+class WebSocketAuthError(Exception):
+    """Raised when a WebSocket handshake fails authentication.
+
+    WS handlers catch this and respond with `await websocket.close(code=4401)`
+    before `accept()`, so unauthenticated clients never consume server
+    resources (DB sessions, in-memory state) past the handshake.
+    """
+
+
+def verify_token_for_websocket(websocket: WebSocket) -> dict:
+    """Verify an access token presented during a WebSocket handshake.
+
+    Reads the JWT from (in order):
+      1. the `access_token` cookie — same-origin browser handshakes send this
+         automatically; this is the primary path used by the frontend
+      2. the `Authorization: Bearer <token>` header — non-browser callers
+
+    Returns the decoded payload. Raises `WebSocketAuthError` on any failure;
+    raising HTTPException would not work because there is no HTTP response
+    cycle past the WS upgrade.
+    """
+    token = websocket.cookies.get("access_token")
+    if not token:
+        auth_header = websocket.headers.get("Authorization") or ""
+        if auth_header.startswith("Bearer "):
+            token = auth_header.split(" ", 1)[1]
+
+    if not token:
+        raise WebSocketAuthError("No access token provided")
+
+    try:
+        return jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except JWTError as e:
+        raise WebSocketAuthError(f"Invalid token: {e}")
 
 
 def create_tokens_with_refresh(

--- a/services/api/database.py
+++ b/services/api/database.py
@@ -31,13 +31,27 @@ if not DATABASE_URL:
 # Configure pool based on environment for E2E test performance
 is_e2e_test = os.getenv("ENVIRONMENT") == "test"
 pool_config = {
-    "pool_size": 20 if is_e2e_test else 3,
-    "max_overflow": 30 if is_e2e_test else 7,
-    "pool_pre_ping": True,  # Verify connections before use
-    "pool_recycle": 3600,  # Recycle connections after 1 hour
+    "pool_size": 20 if is_e2e_test else 10,
+    "max_overflow": 30 if is_e2e_test else 20,
+    "pool_pre_ping": True,
+    "pool_recycle": 3600,
+    "pool_timeout": 5,
 }
 
-engine = create_engine(DATABASE_URL, **pool_config)
+# Postgres-side timeouts so a single hot path can't pin a backend forever.
+# statement_timeout: kill any query that runs longer than 15s.
+# idle_in_transaction_session_timeout: Postgres force-closes a backend that
+#   sits with an open transaction for 30s (the failure mode that wedged the
+#   pool in the 2026-05-18 incident — a streaming endpoint held a Session
+#   across `await asyncio.sleep(2)` and SQLAlchemy's auto-begin left the
+#   connection IDLE IN TRANSACTION between polls).
+# application_name: makes pg_stat_activity immediately diagnostic.
+connect_args = {
+    "options": "-c statement_timeout=15000 -c idle_in_transaction_session_timeout=30000",
+    "application_name": "benger-api",
+}
+
+engine = create_engine(DATABASE_URL, connect_args=connect_args, **pool_config)
 
 # Create session factory
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -129,19 +129,31 @@ async def lifespan(app: FastAPI):
                         settings.database_url
                     )
 
-                    with engine.connect() as conn:
-                        context = MigrationContext.configure(conn)
-                        current_rev = context.get_current_revision()
+                    # Postgres advisory lock so concurrent processes (multiple
+                    # uvicorn workers, replicas) don't race on `alembic
+                    # upgrade`. The first holder runs migrations; the rest
+                    # block on `pg_advisory_lock` until the lock is released,
+                    # then see "Already at head" and proceed. The constant ID
+                    # (0xBE9E70 ≈ "BENGER0") is arbitrary but stable.
+                    ALEMBIC_LOCK_ID = 0xBE9E70
 
-                    if current_rev is None:
-                        logger.info("No migrations found, running initial setup...")
-                        command.upgrade(alembic_cfg, "head")
-                        logger.info("Database schema created via Alembic migrations")
-                    else:
-                        logger.info(f"Current migration: {current_rev}")
-                        # Check if we need to upgrade
-                        command.upgrade(alembic_cfg, "head")
-                        logger.info("Database migrations up to date")
+                    with engine.connect() as conn:
+                        from sqlalchemy import text
+                        conn.execute(text(f"SELECT pg_advisory_lock({ALEMBIC_LOCK_ID})"))
+                        try:
+                            context = MigrationContext.configure(conn)
+                            current_rev = context.get_current_revision()
+
+                            if current_rev is None:
+                                logger.info("No migrations found, running initial setup...")
+                                command.upgrade(alembic_cfg, "head")
+                                logger.info("Database schema created via Alembic migrations")
+                            else:
+                                logger.info(f"Current migration: {current_rev}")
+                                command.upgrade(alembic_cfg, "head")
+                                logger.info("Database migrations up to date")
+                        finally:
+                            conn.execute(text(f"SELECT pg_advisory_unlock({ALEMBIC_LOCK_ID})"))
 
                 except Exception as migration_error:
                     logger.warning(f"Migration error (non-fatal): {migration_error}")

--- a/services/api/routers/evaluations/status.py
+++ b/services/api/routers/evaluations/status.py
@@ -65,7 +65,6 @@ async def stream_evaluation_status(
     evaluation_id: str,
     request: Request,
     current_user: User = Depends(require_user),
-    db: Session = Depends(get_db),
 ):
     """
     Stream evaluation status updates via Server-Sent Events.
@@ -82,16 +81,42 @@ async def stream_evaluation_status(
 
     Authentication:
     - Uses cookie-based authentication (withCredentials: true from EventSource)
+
+    Session lifecycle: each poll iteration opens and closes its own DB
+    session instead of holding one across `await`. Holding a session for
+    the SSE lifetime would leave the connection IDLE IN TRANSACTION between
+    polls and drain the pool — see 2026-05-18 postmortem.
     """
-    # Check project access before starting stream
-    evaluation = db.query(DBEvaluationRun).filter(DBEvaluationRun.id == evaluation_id).first()
-    if evaluation and not check_project_accessible(db, current_user, evaluation.project_id, get_org_context_from_request(request)):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You don't have access to this evaluation's project",
-        )
+    # One-shot session for the up-front access check.
+    org_context = get_org_context_from_request(request)
+    db = next(get_db())
+    try:
+        evaluation = db.query(DBEvaluationRun).filter(DBEvaluationRun.id == evaluation_id).first()
+        if evaluation and not check_project_accessible(db, current_user, evaluation.project_id, org_context):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You don't have access to this evaluation's project",
+            )
+    finally:
+        db.close()
 
     logger.info(f"SSE stream started for evaluation {evaluation_id} by user {current_user.id}")
+
+    def _snapshot() -> Optional[dict]:
+        """Open a short-lived session, return the current status dict (or
+        None if the evaluation has been deleted)."""
+        s = next(get_db())
+        try:
+            ev = s.query(DBEvaluationRun).filter(DBEvaluationRun.id == evaluation_id).first()
+            if not ev:
+                return None
+            return {
+                "status": ev.status,
+                "samples_evaluated": ev.samples_evaluated or 0,
+                "error_message": ev.error_message,
+            }
+        finally:
+            s.close()
 
     async def event_generator():
         last_status = None
@@ -103,38 +128,21 @@ async def stream_evaluation_status(
             iteration += 1
 
             try:
-                # Refresh the session to get latest data
-                db.expire_all()
-                evaluation = db.query(DBEvaluationRun).filter(DBEvaluationRun.id == evaluation_id).first()
-
-                if not evaluation:
+                snapshot = _snapshot()
+                if snapshot is None:
                     yield {"event": "error", "data": json.dumps({"error": "Evaluation not found"})}
                     break
 
-                current_status = evaluation.status
-                current_samples = evaluation.samples_evaluated or 0
+                current_status = snapshot["status"]
+                current_samples = snapshot["samples_evaluated"]
 
-                # Only send update if status or samples changed
                 if current_status != last_status or current_samples != last_samples:
-                    status_data = {
-                        "status": current_status,
-                        "samples_evaluated": current_samples,
-                        "error_message": evaluation.error_message,
-                    }
-
-                    yield {"event": "status", "data": json.dumps(status_data)}
-
+                    yield {"event": "status", "data": json.dumps(snapshot)}
                     last_status = current_status
                     last_samples = current_samples
 
-                # Send done event and close stream when evaluation finishes
                 if current_status in ["completed", "failed"]:
-                    done_data = {
-                        "status": current_status,
-                        "samples_evaluated": current_samples,
-                        "error_message": evaluation.error_message,
-                    }
-                    yield {"event": "done", "data": json.dumps(done_data)}
+                    yield {"event": "done", "data": json.dumps(snapshot)}
                     break
 
                 await asyncio.sleep(1)

--- a/services/api/routers/evaluations/ws.py
+++ b/services/api/routers/evaluations/ws.py
@@ -16,32 +16,66 @@ connected client — cheap given typical project usage.
 
 Auto-closes when no in-flight runs remain for the project for 30s,
 freeing the connection for the client's reconnect-with-fallback path.
+
+Session lifecycle (important — see 2026-05-18 incident postmortem):
+the polling loop opens and closes a fresh DB session per iteration
+instead of holding one across ``await asyncio.sleep(2)``. Holding a
+``Depends(get_db)`` session for the WS lifetime was leaving the
+underlying connection IDLE IN TRANSACTION between polls and draining
+the per-process pool with a handful of open browser tabs.
 """
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 
-from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from sqlalchemy import func
-from sqlalchemy.orm import Session
 
+from auth_module import WebSocketAuthError, verify_token_for_websocket
+from auth_module.user_service import get_user_by_id
 from database import get_db
 from models import EvaluationRun as DBEvaluationRun
 from models import TaskEvaluation
 from project_models import Task
+from routers.projects.helpers import check_project_accessible
 
 logger = logging.getLogger(__name__)
 
 ws_router = APIRouter(prefix="/api/ws", tags=["websocket"])
 
 
+def _snapshot_project_progress(project_id: str) -> tuple[int, int]:
+    """Open a short-lived DB session, return (row_count, active_runs).
+
+    The session is opened and closed inside this call so the WS handler
+    never holds a connection across ``await``.
+    """
+    db = next(get_db())
+    try:
+        row_count = (
+            db.query(func.count(TaskEvaluation.id))
+            .join(Task, TaskEvaluation.task_id == Task.id)
+            .filter(Task.project_id == project_id)
+            .scalar()
+        ) or 0
+        active_runs = (
+            db.query(func.count(DBEvaluationRun.id))
+            .filter(
+                DBEvaluationRun.project_id == project_id,
+                DBEvaluationRun.status.in_(("pending", "running")),
+            )
+            .scalar()
+        ) or 0
+        return int(row_count), int(active_runs)
+    finally:
+        db.close()
+
+
 @ws_router.websocket("/projects/{project_id}/evaluation-progress")
 async def evaluation_progress_websocket(
     websocket: WebSocket,
     project_id: str,
-    db: Session = Depends(get_db),
 ):
     """Push a "tick" event whenever the project's in-flight evaluation
     state changes (row count delta or run-status flip). Frontend
@@ -53,6 +87,26 @@ async def evaluation_progress_websocket(
         {"type": "idle", "message": "..."}                # no in-flight runs
         {"type": "connection", "status": "connected"}     # one-shot on accept
     """
+    # Authenticate and authorize BEFORE accepting the upgrade. An
+    # unauthenticated client must never consume server resources past the
+    # handshake (frontend reconnect storms would otherwise drain the pool).
+    try:
+        payload = verify_token_for_websocket(websocket)
+    except WebSocketAuthError as e:
+        logger.info(f"WS auth rejected for project {project_id}: {e}")
+        await websocket.close(code=4401)
+        return
+
+    user_id = payload.get("user_id")
+    db = next(get_db())
+    try:
+        user = get_user_by_id(db, user_id) if user_id else None
+        if not user or not check_project_accessible(db, user, project_id):
+            await websocket.close(code=4403)
+            return
+    finally:
+        db.close()
+
     await websocket.accept()
     await websocket.send_json({
         "type": "connection",
@@ -67,30 +121,16 @@ async def evaluation_progress_websocket(
 
     try:
         while True:
-            # Snapshot: total row count + in-flight run count for this project.
-            row_count = (
-                db.query(func.count(TaskEvaluation.id))
-                .join(Task, TaskEvaluation.task_id == Task.id)
-                .filter(Task.project_id == project_id)
-                .scalar()
-            ) or 0
-            active_runs = (
-                db.query(func.count(DBEvaluationRun.id))
-                .filter(
-                    DBEvaluationRun.project_id == project_id,
-                    DBEvaluationRun.status.in_(("pending", "running")),
-                )
-                .scalar()
-            ) or 0
+            row_count, active_runs = _snapshot_project_progress(project_id)
 
             if row_count != last_row_count or active_runs != last_active_runs:
                 await websocket.send_json({
                     "type": "tick",
-                    "row_count": int(row_count),
-                    "active_runs": int(active_runs),
+                    "row_count": row_count,
+                    "active_runs": active_runs,
                 })
-                last_row_count = int(row_count)
-                last_active_runs = int(active_runs)
+                last_row_count = row_count
+                last_active_runs = active_runs
 
             if active_runs == 0:
                 idle_ticks += 1

--- a/services/api/routers/generation.py
+++ b/services/api/routers/generation.py
@@ -24,7 +24,8 @@ from fastapi import (
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from auth_module import User, require_user
+from auth_module import User, WebSocketAuthError, require_user, verify_token_for_websocket
+from auth_module.user_service import get_user_by_id
 from database import get_db
 from models import Generation as DBLLMResponse
 from models import ResponseGeneration as DBResponseGeneration
@@ -678,12 +679,34 @@ async def get_parse_metrics(
 
 @ws_router.websocket("/projects/{project_id}/generation-progress")
 async def generation_progress_websocket(
-    websocket: WebSocket, project_id: str, db: Session = Depends(get_db)
+    websocket: WebSocket, project_id: str
 ):
     """
     WebSocket endpoint for real-time generation progress updates.
     Clients connect to receive live updates about generation status.
+
+    Auth: cookie-based JWT validated before `accept()`. Session lifecycle:
+    the polling fallback opens a fresh session per iteration instead of
+    holding one across `await asyncio.sleep(2)` (see 2026-05-18 postmortem).
     """
+    # Authenticate + authorize BEFORE the upgrade.
+    try:
+        payload = verify_token_for_websocket(websocket)
+    except WebSocketAuthError as e:
+        logger.info(f"WS auth rejected for project {project_id}: {e}")
+        await websocket.close(code=4401)
+        return
+
+    user_id = payload.get("user_id")
+    auth_db = next(get_db())
+    try:
+        user = get_user_by_id(auth_db, user_id) if user_id else None
+        if not user or not check_project_accessible(auth_db, user, project_id):
+            await websocket.close(code=4403)
+            return
+    finally:
+        auth_db.close()
+
     await websocket.accept()
 
     redis_client = None
@@ -752,14 +775,21 @@ async def generation_progress_websocket(
 
             while True:
                 try:
-                    # Get latest generation status from database
-                    generations = (
-                        db.query(DBResponseGeneration)
-                        .filter(DBResponseGeneration.project_id == project_id)
-                        .order_by(DBResponseGeneration.created_at.desc())
-                        .limit(5)
-                        .all()
-                    )
+                    # Open a per-iteration session so we never hold a
+                    # connection across `await asyncio.sleep(2)`. The fallback
+                    # path runs whenever Redis is unavailable; same pool-leak
+                    # rules apply as the primary path.
+                    poll_db = next(get_db())
+                    try:
+                        generations = (
+                            poll_db.query(DBResponseGeneration)
+                            .filter(DBResponseGeneration.project_id == project_id)
+                            .order_by(DBResponseGeneration.created_at.desc())
+                            .limit(5)
+                            .all()
+                        )
+                    finally:
+                        poll_db.close()
 
                     if generations:
                         # Send status update

--- a/services/api/routers/projects/tasks.py
+++ b/services/api/routers/projects/tasks.py
@@ -919,19 +919,34 @@ async def bulk_delete_tasks(
 
 
 @router.post("/{project_id}/tasks/bulk-export")
-async def bulk_export_tasks(
+def bulk_export_tasks(
     project_id: str,
     data: dict,
     request: Request,
     current_user: AuthUser = Depends(require_user),
     db: Session = Depends(get_db),
 ):
-    """Bulk export tasks from a project"""
+    """Bulk export tasks from a project.
 
+    Streams the response chunk-by-chunk and uses `yield_per` on the heavy
+    queries so peak memory stays bounded regardless of project size.
+    Previously the handler loaded every task / annotation / generation /
+    evaluation row into Python with `.all()`, built one nested dict, and
+    `json.dumps(...)`-ed it with `indent=2` — that OOMKilled the API pod on
+    2026-05-18 when a 581-task / 8k-generation / 57k-eval project was
+    exported (1.5 GiB container limit).
+
+    Also `def` (not `async def`) so FastAPI runs it in the threadpool — the
+    sync DB iteration no longer blocks the event loop during the export.
+    """
     task_ids = data.get("task_ids", [])
     format = data.get("format", "json")
 
-    # Verify project exists and user has access
+    if format not in ("json", "csv", "tsv"):
+        raise HTTPException(status_code=400, detail=f"Unsupported format: {format}")
+
+    # Project + access check up front (still uses the request-scoped session;
+    # closes naturally when the threadpool worker returns).
     project = db.query(Project).filter(Project.id == project_id).first()
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
@@ -940,83 +955,57 @@ async def bulk_export_tasks(
     if not check_project_accessible(db, current_user, project_id, org_context):
         raise HTTPException(status_code=403, detail="Access denied")
 
-    # Get tasks
-    tasks = db.query(Task).filter(Task.id.in_(task_ids), Task.project_id == project_id).all()
+    # Capture scalars now — we'll reference them inside the generator after
+    # the closure has been handed off to StreamingResponse.
+    project_title = project.title
+    exported_at_iso = datetime.now().isoformat()
+    filename_ts = datetime.now().strftime("%Y%m%d_%H%M%S")
 
-    # Get annotations for these tasks
-    annotations = db.query(Annotation).filter(Annotation.task_id.in_(task_ids)).all()
-
-    # Get generations for these tasks
-    generations = db.query(Generation).filter(Generation.task_id.in_(task_ids)).all()
-
-    # Get questionnaire responses for these tasks
-    questionnaire_responses = (
-        db.query(PostAnnotationResponse)
-        .filter(PostAnnotationResponse.task_id.in_(task_ids))
-        .all()
-    )
-    qr_by_annotation = {qr.annotation_id: qr for qr in questionnaire_responses}
-
-    # Get evaluation runs and per-task evaluations for this project
-    evaluation_runs = (
-        db.query(EvaluationRun)
-        .filter(EvaluationRun.project_id == project_id)
-        .all()
-    )
-    eval_run_ids = [er.id for er in evaluation_runs]
-    task_evaluations = (
-        db.query(TaskEvaluation)
-        .filter(
-            TaskEvaluation.evaluation_id.in_(eval_run_ids),
-            TaskEvaluation.task_id.in_(task_ids),
-        )
-        .all()
-        if eval_run_ids
-        else []
-    )
-
+    from project_models import KorrekturComment as _KC
     from routers.projects.serializers import (
         build_evaluation_indexes,
         build_judge_model_lookup,
         serialize_annotation,
         serialize_evaluation_run,
         serialize_generation,
+        serialize_human_evaluation_data,
+        serialize_korrektur_comment,
         serialize_task,
         serialize_task_evaluation,
     )
 
-    eval_run_by_id = {er.id: er for er in evaluation_runs}
-    judge_model_lookup = build_judge_model_lookup(evaluation_runs)
-    te_by_task, te_by_generation = build_evaluation_indexes(task_evaluations)
-
-    export_data = {
-        "project_id": project_id,
-        "project_title": project.title,
-        "exported_at": datetime.now().isoformat(),
-        "evaluation_runs": [
-            serialize_evaluation_run(er, mode="data") for er in evaluation_runs
-        ],
-        "tasks": [],
-    }
-
-    for task in tasks:
+    def _build_task_obj(task: Task,
+                        eval_run_by_id: dict, judge_model_lookup: dict) -> dict:
+        """Build the per-task export dict. Queries this task's related rows
+        on the request session so peak memory stays one-task-wide."""
         task_data = serialize_task(task, mode="data")
         task_data["annotations"] = []
         task_data["generations"] = []
         task_data["evaluations"] = []
 
-        # Add annotations for this task (with questionnaire responses)
-        task_annotations = [a for a in annotations if a.task_id == task.id]
-        for ann in task_annotations:
-            qr = qr_by_annotation.get(ann.id)
+        anns = db.query(Annotation).filter(Annotation.task_id == task.id).all()
+        qrs = db.query(PostAnnotationResponse).filter(
+            PostAnnotationResponse.task_id == task.id
+        ).all()
+        qr_by_annotation = {qr.annotation_id: qr for qr in qrs}
+        for ann in anns:
             task_data["annotations"].append(
-                serialize_annotation(ann, mode="data", questionnaire_response=qr)
+                serialize_annotation(
+                    ann, mode="data", questionnaire_response=qr_by_annotation.get(ann.id)
+                )
             )
 
-        # Add generations for this task (with nested evaluations)
-        task_generations = [g for g in generations if g.task_id == task.id]
-        for gen in task_generations:
-            gen_evals = te_by_generation.get(gen.id, [])
+        gens = db.query(Generation).filter(Generation.task_id == task.id).all()
+        task_te = []
+        if eval_run_by_id:
+            task_te = db.query(TaskEvaluation).filter(
+                TaskEvaluation.task_id == task.id,
+                TaskEvaluation.evaluation_id.in_(eval_run_by_id.keys()),
+            ).all()
+        te_by_task_id, te_by_gen_id = build_evaluation_indexes(task_te)
+
+        for gen in gens:
+            gen_evals = te_by_gen_id.get(gen.id, [])
             eval_dicts = [
                 serialize_task_evaluation(
                     te, mode="data",
@@ -1029,10 +1018,9 @@ async def bulk_export_tasks(
                 serialize_generation(gen, mode="data", evaluations=eval_dicts)
             )
 
-        # Add task-level evaluations (annotation/ground-truth evals without a generation)
-        for te in te_by_task.get(task.id, []):
+        for te in te_by_task_id.get(task.id, []):
             if te.generation_id is not None:
-                continue  # Already nested under the generation above
+                continue
             task_data["evaluations"].append(
                 serialize_task_evaluation(
                     te, mode="data",
@@ -1041,110 +1029,114 @@ async def bulk_export_tasks(
                 )
             )
 
-        export_data["tasks"].append(task_data)
+        return task_data
 
-    # Top-level human-eval + Korrektur blocks. Mirrors `GET /export` so the
-    # bulk-export → import round-trip stays complete.
-    from routers.projects.serializers import (
-        serialize_human_evaluation_data,
-        serialize_korrektur_comment,
-    )
-    from project_models import KorrekturComment as _KC
+    # The streaming generators below capture the request-scoped `db` via
+    # closure. FastAPI keeps the Depends(get_db) session open until the
+    # response body is fully consumed (i.e. until the generator returns),
+    # so iterating `yield_per` against it is safe. The per-iteration-session
+    # pattern that fixes the WS/SSE leaks does NOT apply here: exports are
+    # short-lived and continuously query the DB, not idle in transaction.
 
-    export_data.update(
-        serialize_human_evaluation_data(db, project_id, task_ids)
-    )
-    export_data["korrektur_comments"] = [
-        serialize_korrektur_comment(c)
-        for c in db.query(_KC).filter(_KC.project_id == project_id).all()
-    ]
+    def _json_stream():
+        eval_runs = db.query(EvaluationRun).filter(
+            EvaluationRun.project_id == project_id
+        ).all()
+        eval_run_by_id = {er.id: er for er in eval_runs}
+        judge_model_lookup = build_judge_model_lookup(eval_runs)
 
-    # Format the response
+        header = {
+            "project_id": project_id,
+            "project_title": project_title,
+            "exported_at": exported_at_iso,
+            "evaluation_runs": [serialize_evaluation_run(er, mode="data") for er in eval_runs],
+        }
+        # Compact, no indent — ~30% smaller than indent=2 and faster.
+        prefix = json.dumps(header)[:-1]  # drop closing `}` so we can append more keys
+        yield prefix + ', "tasks": ['
+
+        first = True
+        task_q = db.query(Task).filter(
+            Task.id.in_(task_ids), Task.project_id == project_id
+        )
+        for task in task_q.yield_per(50):
+            obj = _build_task_obj(task, eval_run_by_id, judge_model_lookup)
+            yield ("" if first else ",") + json.dumps(obj)
+            first = False
+
+        yield "], "
+
+        # Human-eval block. The helper does its own queries and returns a
+        # dict; serialize each top-level key as its own JSON fragment.
+        human_eval = serialize_human_evaluation_data(db, project_id, task_ids) or {}
+        human_eval_items = list(human_eval.items())
+        for idx, (k, v) in enumerate(human_eval_items):
+            yield json.dumps(k) + ":" + json.dumps(v)
+            if idx < len(human_eval_items) - 1:
+                yield ","
+        if human_eval_items:
+            yield ","
+
+        yield '"korrektur_comments": ['
+        first = True
+        kc_q = db.query(_KC).filter(_KC.project_id == project_id)
+        for kc in kc_q.yield_per(100):
+            yield ("" if first else ",") + json.dumps(serialize_korrektur_comment(kc))
+            first = False
+        yield "]}"
+
+    def _csv_or_tsv_stream(delimiter: str):
+        """Stream CSV/TSV one task at a time. Each row is `task_id, task_data,
+        is_labeled, annotation_count, generation_count, evaluation_count, created_at`
+        (matches the legacy shape)."""
+        import csv
+        import io
+
+        buf = io.StringIO()
+        writer = csv.writer(buf, delimiter=delimiter)
+        writer.writerow([
+            "task_id", "task_data", "is_labeled",
+            "annotation_count", "generation_count", "evaluation_count",
+            "created_at",
+        ])
+        yield buf.getvalue()
+        buf.seek(0); buf.truncate()
+
+        eval_runs = db.query(EvaluationRun).filter(
+            EvaluationRun.project_id == project_id
+        ).all()
+        eval_run_by_id = {er.id: er for er in eval_runs}
+        judge_model_lookup = build_judge_model_lookup(eval_runs)
+
+        task_q = db.query(Task).filter(
+            Task.id.in_(task_ids), Task.project_id == project_id
+        )
+        for task in task_q.yield_per(50):
+            obj = _build_task_obj(task, eval_run_by_id, judge_model_lookup)
+            writer.writerow([
+                obj["id"],
+                json.dumps(obj["data"]),
+                obj["is_labeled"],
+                len(obj["annotations"]),
+                len(obj["generations"]),
+                len(obj["evaluations"]),
+                obj["created_at"],
+            ])
+            yield buf.getvalue()
+            buf.seek(0); buf.truncate()
+
+    from fastapi.responses import StreamingResponse
+
     if format == "json":
-        content = json.dumps(export_data, indent=2)
-        media_type = "application/json"
-        filename = f"tasks_export_{project_id}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        gen, media_type, ext = _json_stream(), "application/json", "json"
     elif format == "csv":
-        import csv
-        import io
+        gen, media_type, ext = _csv_or_tsv_stream(","), "text/csv", "csv"
+    else:  # tsv
+        gen, media_type, ext = _csv_or_tsv_stream("\t"), "text/tab-separated-values", "tsv"
 
-        output = io.StringIO()
-        writer = csv.writer(output)
-
-        # Header
-        writer.writerow(
-            [
-                "task_id",
-                "task_data",
-                "is_labeled",
-                "annotation_count",
-                "generation_count",
-                "evaluation_count",
-                "created_at",
-            ]
-        )
-
-        # Data rows
-        for task in export_data["tasks"]:
-            writer.writerow(
-                [
-                    task["id"],
-                    json.dumps(task["data"]),
-                    task["is_labeled"],
-                    len(task["annotations"]),
-                    len(task["generations"]),
-                    len(task["evaluations"]),
-                    task["created_at"],
-                ]
-            )
-
-        content = output.getvalue()
-        media_type = "text/csv"
-        filename = f"tasks_export_{project_id}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.csv"
-    elif format == "tsv":
-        import csv
-        import io
-
-        output = io.StringIO()
-        writer = csv.writer(output, delimiter="\t")
-
-        # Header
-        writer.writerow(
-            [
-                "task_id",
-                "task_data",
-                "is_labeled",
-                "annotation_count",
-                "generation_count",
-                "evaluation_count",
-                "created_at",
-            ]
-        )
-
-        # Data rows
-        for task in export_data["tasks"]:
-            writer.writerow(
-                [
-                    task["id"],
-                    json.dumps(task["data"]),
-                    task["is_labeled"],
-                    len(task["annotations"]),
-                    len(task["generations"]),
-                    len(task["evaluations"]),
-                    task["created_at"],
-                ]
-            )
-
-        content = output.getvalue()
-        media_type = "text/tab-separated-values"
-        filename = f"tasks_export_{project_id}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.tsv"
-    else:
-        raise HTTPException(status_code=400, detail=f"Unsupported format: {format}")
-
-    from fastapi.responses import Response
-
-    return Response(
-        content=content,
+    filename = f"tasks_export_{project_id}_{filename_ts}.{ext}"
+    return StreamingResponse(
+        gen,
         media_type=media_type,
         headers={"Content-Disposition": f"attachment; filename={filename}"},
     )

--- a/services/api/services/email/notification_service.py
+++ b/services/api/services/email/notification_service.py
@@ -8,7 +8,6 @@ This service handles:
 4. Notification cleanup and archival
 """
 
-import asyncio
 import logging
 import uuid
 from datetime import datetime, timedelta
@@ -40,6 +39,16 @@ except ImportError:
 
     async def send_notification_email(*args, **kwargs):
         return False
+
+# Celery client for dispatching email-send tasks to the workers. Imported
+# at module level (not inside the function) so unit tests can patch
+# `notification_service.get_celery_app` without depending on import side
+# effects. Tolerates absence so the module still loads in trimmed envs.
+try:
+    from celery_client import get_celery_app
+except ImportError:
+    def get_celery_app():
+        raise RuntimeError("celery_client not available — email dispatch disabled")
 
 
 # Import Project model for project-based notifications
@@ -156,18 +165,26 @@ class NotificationService:
                 )
             return []
 
-        # Send email notifications asynchronously for users who have email enabled.
-        # Schedule on the running event loop when available; in sync test/CLI
-        # contexts there is no loop and we silently skip the email side-effect.
-        if EMAIL_SERVICE_AVAILABLE and notifications:
+        # Dispatch email sends to a Celery worker. The worker opens its own
+        # DB session, hydrates a minimal Notification per recipient, and
+        # calls SendGrid synchronously. Previously this was
+        # `asyncio.create_task(_send_email_notifications(db, ...))` which
+        # (a) handed the request-scoped `db` to a fire-and-forget task and
+        # (b) blocked the API event loop on sync `requests.post()` per
+        # recipient. The fan-out from notify_project_created (every org
+        # member + every superadmin) wedged the only API replica on
+        # 2026-05-18.
+        if EMAIL_SERVICE_AVAILABLE and notification_data:
             try:
-                asyncio.create_task(
-                    NotificationService._send_email_notifications(db, notification_data)
+                get_celery_app().send_task(
+                    "emails.send_notification_batch",
+                    args=[notification_data],
+                    queue="emails",
                 )
-            except RuntimeError:
-                logger.debug(
-                    "No running event loop; skipping async email dispatch"
-                )
+            except Exception as e:
+                # Never let an email-dispatch failure surface to the caller;
+                # the in-app notification already committed above.
+                logger.warning(f"Failed to enqueue notification emails: {e}")
 
         return notifications
 

--- a/services/api/services/email/sendgrid_client.py
+++ b/services/api/services/email/sendgrid_client.py
@@ -90,7 +90,11 @@ class SendGridClient:
             }
 
         try:
-            # Send request to SendGrid
+            # Send request to SendGrid. The timeout is critical: this used to
+            # be called from an async handler via asyncio.create_task — a
+            # hanging SendGrid response would freeze the event loop. The send
+            # path now runs on a Celery worker, but the timeout stays
+            # belt-and-suspenders.
             response = requests.post(
                 self.api_url,
                 headers={
@@ -98,6 +102,7 @@ class SendGridClient:
                     "Content-Type": "application/json",
                 },
                 json=payload,
+                timeout=(5, 15),
             )
 
             if response.status_code in [200, 201, 202]:

--- a/services/api/tests/integration/test_generation_flow.py
+++ b/services/api/tests/integration/test_generation_flow.py
@@ -332,11 +332,15 @@ class TestWebSocketGeneration:
     """Test WebSocket functionality for real-time updates"""
 
     @pytest.mark.asyncio
-    async def test_websocket_connection(self, test_project):
+    async def test_websocket_connection(self, test_project, test_user):
         """Test WebSocket connection for generation progress"""
         from fastapi.testclient import TestClient
 
         client = TestClient(app)
+        # WS handshake now authenticates via the access_token cookie before
+        # `accept()` (see auth_module.verify_token_for_websocket). Without
+        # this the server closes with 4401.
+        client.cookies.set("access_token", test_user.token)
 
         with patch('routers.generation.get_redis_client') as mock_redis:
             # Mock Redis client to trigger polling fallback (no pubsub attribute)

--- a/services/api/tests/routers/projects/test_bulk_export_tasks.py
+++ b/services/api/tests/routers/projects/test_bulk_export_tasks.py
@@ -12,12 +12,32 @@ Tests cover:
 Uses the shared PostgreSQL test database with per-test transaction rollback.
 """
 
+import asyncio
 import json
 import os
 import sys
 import uuid
 
 import pytest
+
+
+def _collect_stream(response) -> str:
+    """Drain a StreamingResponse's body iterator into a single string.
+
+    bulk_export_tasks is now a sync `def` handler that returns a
+    StreamingResponse; tests call it directly (no ASGI), so we have to
+    iterate the (always-async) body_iterator ourselves.
+    """
+    async def _consume():
+        chunks = []
+        async for chunk in response.body_iterator:
+            if isinstance(chunk, bytes):
+                chunks.append(chunk.decode("utf-8"))
+            else:
+                chunks.append(chunk)
+        return "".join(chunks)
+
+    return asyncio.run(_consume())
 
 # Add path for imports
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
@@ -277,14 +297,11 @@ class TestBulkExportTasks:
         mock_user.id = data["tasks"][0].created_by
 
         # Call endpoint
-        from asyncio import run
-
-        response = run(
-            bulk_export_tasks(project_id, request_data, request=_make_mock_request(), current_user=mock_user, db=session)
+        response = bulk_export_tasks(
+            project_id, request_data, request=_make_mock_request(),
+            current_user=mock_user, db=session,
         )
-
-        # Parse JSON response
-        content = response.body.decode("utf-8")
+        content = _collect_stream(response)
         export_data = json.loads(content)
 
         # Verify structure
@@ -327,14 +344,11 @@ class TestBulkExportTasks:
         mock_user.id = data["tasks"][0].created_by
 
         # Call endpoint
-        from asyncio import run
-
-        response = run(
-            bulk_export_tasks(project_id, request_data, request=_make_mock_request(), current_user=mock_user, db=session)
+        response = bulk_export_tasks(
+            project_id, request_data, request=_make_mock_request(),
+            current_user=mock_user, db=session,
         )
-
-        # Parse JSON response
-        content = response.body.decode("utf-8")
+        content = _collect_stream(response)
         export_data = json.loads(content)
 
         # Verify structure
@@ -376,14 +390,11 @@ class TestBulkExportTasks:
         mock_user.id = data["tasks"][0].created_by
 
         # Call endpoint
-        from asyncio import run
-
-        response = run(
-            bulk_export_tasks(project_id, request_data, request=_make_mock_request(), current_user=mock_user, db=session)
+        response = bulk_export_tasks(
+            project_id, request_data, request=_make_mock_request(),
+            current_user=mock_user, db=session,
         )
-
-        # Parse JSON response
-        content = response.body.decode("utf-8")
+        content = _collect_stream(response)
         export_data = json.loads(content)
 
         # Verify structure
@@ -420,14 +431,10 @@ class TestBulkExportTasks:
         mock_user.id = data["tasks"][0].created_by
 
         # Call endpoint
-        from asyncio import run
-
-        response = run(
-            bulk_export_tasks(project_id, request_data, request=_make_mock_request(), current_user=mock_user, db=session)
+        response = bulk_export_tasks(
+            project_id, request_data, request=_make_mock_request(), current_user=mock_user, db=session,
         )
-
-        # Parse CSV response
-        content = response.body.decode("utf-8")
+        content = _collect_stream(response)
         csv_reader = csv.reader(io.StringIO(content))
 
         rows = list(csv_reader)
@@ -476,14 +483,10 @@ class TestBulkExportTasks:
         mock_user.id = data["tasks"][0].created_by
 
         # Call endpoint
-        from asyncio import run
-
-        response = run(
-            bulk_export_tasks(project_id, request_data, request=_make_mock_request(), current_user=mock_user, db=session)
+        response = bulk_export_tasks(
+            project_id, request_data, request=_make_mock_request(), current_user=mock_user, db=session,
         )
-
-        # Parse TSV response
-        content = response.body.decode("utf-8")
+        content = _collect_stream(response)
         tsv_reader = csv.reader(io.StringIO(content), delimiter="\t")
 
         rows = list(tsv_reader)
@@ -528,14 +531,10 @@ class TestBulkExportTasks:
         mock_user.id = test_user.id
 
         # Call endpoint
-        from asyncio import run
-
-        response = run(
-            bulk_export_tasks(test_project.id, request_data, request=_make_mock_request(), current_user=mock_user, db=session)
+        response = bulk_export_tasks(
+            test_project.id, request_data, request=_make_mock_request(), current_user=mock_user, db=session,
         )
-
-        # Parse JSON response
-        content = response.body.decode("utf-8")
+        content = _collect_stream(response)
         export_data = json.loads(content)
 
         # Verify empty arrays (not None or missing)
@@ -564,14 +563,10 @@ class TestBulkExportTasks:
         mock_user = Mock()
         mock_user.id = data["tasks"][0].created_by
 
-        from asyncio import run
-
-        response = run(
-            bulk_export_tasks(project_id, request_data, request=_make_mock_request(), current_user=mock_user, db=session)
+        response = bulk_export_tasks(
+            project_id, request_data, request=_make_mock_request(), current_user=mock_user, db=session,
         )
-
-        # Parse export
-        content = response.body.decode("utf-8")
+        content = _collect_stream(response)
         export_data = json.loads(content)
 
         # Verify export has required structure for import
@@ -617,13 +612,10 @@ class TestBulkExportTasks:
         mock_user = Mock()
         mock_user.id = test_user.id
 
-        from asyncio import run
-
-        response = run(
-            bulk_export_tasks(project_id, request_data, request=_make_mock_request(), current_user=mock_user, db=session)
+        response = bulk_export_tasks(
+            project_id, request_data, request=_make_mock_request(), current_user=mock_user, db=session,
         )
-
-        content = response.body.decode("utf-8")
+        content = _collect_stream(response)
         export_data = json.loads(content)
 
         # Find the annotation with the questionnaire response
@@ -834,13 +826,10 @@ class TestBulkExportTasks:
         mock_user = Mock()
         mock_user.id = test_user.id
 
-        from asyncio import run
-
-        response = run(
-            bulk_export_tasks(project_id, request_data, request=_make_mock_request(), current_user=mock_user, db=session)
+        response = bulk_export_tasks(
+            project_id, request_data, request=_make_mock_request(), current_user=mock_user, db=session,
         )
-
-        content = response.body.decode("utf-8")
+        content = _collect_stream(response)
         export_data = json.loads(content)
 
         # Find the target task in export

--- a/services/api/tests/unit/test_notification_service.py
+++ b/services/api/tests/unit/test_notification_service.py
@@ -67,7 +67,7 @@ class TestNotificationCreation:
     """Test notification creation"""
 
     @patch("notification_service.NotificationService._user_wants_notification")
-    @patch("notification_service.asyncio.create_task")
+    @patch("notification_service.get_celery_app")
     def test_create_notification_basic(
         self, mock_create_task, mock_wants_notif, mock_db, test_user
     ):
@@ -95,7 +95,7 @@ class TestNotificationCreation:
         assert len(result) == 1
 
     @patch("notification_service.NotificationService._user_wants_notification")
-    @patch("notification_service.asyncio.create_task")
+    @patch("notification_service.get_celery_app")
     def test_create_notification_with_organization(
         self, mock_create_task, mock_wants_notif, mock_db, test_user, test_organization
     ):
@@ -234,7 +234,7 @@ class TestNotificationIntegration:
 
     @patch("notification_service.NotificationService._user_wants_notification")
     @patch("notification_service.EMAIL_SERVICE_AVAILABLE", True)
-    @patch("notification_service.asyncio.create_task")
+    @patch("notification_service.get_celery_app")
     def test_create_and_send_notification(
         self, mock_create_task, mock_wants_notif, mock_db, test_user
     ):

--- a/services/api/tests/unit/test_notification_service_coverage.py
+++ b/services/api/tests/unit/test_notification_service_coverage.py
@@ -108,7 +108,7 @@ class TestImportFallbacks:
 class TestCreateNotificationEdgeCases:
 
     @patch("notification_service.NotificationService._user_wants_notification")
-    @patch("notification_service.asyncio.create_task")
+    @patch("notification_service.get_celery_app")
     def test_create_notification_with_string_type(
         self, mock_task, mock_wants, mock_db, user_id
     ):
@@ -178,7 +178,7 @@ class TestCreateNotificationEdgeCases:
         assert result == []
         mock_db.rollback.assert_called_once()
 
-    @patch("services.email.notification_service.asyncio.create_task")
+    @patch("services.email.notification_service.get_celery_app")
     @patch("services.email.notification_service.NotificationService._user_wants_notification")
     def test_create_notification_email_service_unavailable(
         self, mock_wants, mock_task, mock_db, user_id

--- a/services/api/tests/unit/test_notification_service_extended.py
+++ b/services/api/tests/unit/test_notification_service_extended.py
@@ -85,7 +85,7 @@ class TestCreateNotification:
     def test_empty_user_ids_commits_nothing(self):
         from services.email.notification_service import NotificationService
         db = MagicMock()
-        with patch("services.email.notification_service.asyncio", MagicMock()):
+        with patch("services.email.notification_service.get_celery_app", MagicMock()):
             result = NotificationService.create_notification(
                 db=db, user_ids=[],
                 notification_type="project_created",
@@ -113,7 +113,7 @@ class TestCreateNotification:
         pref.email_enabled = False
         db = MagicMock()
         db.query.return_value.filter.return_value.first.return_value = pref
-        with patch("services.email.notification_service.asyncio", MagicMock()):
+        with patch("services.email.notification_service.get_celery_app", MagicMock()):
             result = NotificationService.create_notification(
                 db=db, user_ids=["user-1"],
                 notification_type="project_created",

--- a/services/frontend/src/components/evaluation/EvaluationResults.tsx
+++ b/services/frontend/src/components/evaluation/EvaluationResults.tsx
@@ -732,8 +732,19 @@ export function EvaluationResults({
           // Let onclose handle reconnect/fallback so we don't double-fire.
         }
 
-        ws.onclose = () => {
+        ws.onclose = (ev) => {
           if (closed) return
+          // 4401 / 4403 are application-defined close codes the backend
+          // emits when the WS handshake fails auth (no/invalid token) or
+          // access (no project membership). Reconnecting cannot fix these
+          // and a stale browser tab would otherwise hammer the server
+          // forever with bad tokens. Drop straight to polling — the HTTP
+          // request will return 401 and the global auth interceptor will
+          // bounce the user to login if the session is genuinely expired.
+          if (ev.code === 4401 || ev.code === 4403) {
+            startPollingFallback()
+            return
+          }
           // Exponential backoff up to 5 attempts, then drop to polling.
           if (reconnectAttempts < 5) {
             const delay = Math.min(1000 * 2 ** reconnectAttempts, 10000)

--- a/services/frontend/src/components/generation/GenerationProgress.tsx
+++ b/services/frontend/src/components/generation/GenerationProgress.tsx
@@ -165,10 +165,18 @@ export function GenerationProgress({
           setConnectionError(t('generation.connectionError'))
         }
 
-        ws.onclose = () => {
-          logger.debug('WebSocket disconnected')
+        ws.onclose = (ev) => {
+          logger.debug('WebSocket disconnected', ev.code)
           setIsConnected(false)
           wsRef.current = null
+
+          // 4401 / 4403 = backend rejected the WS handshake on auth/access.
+          // Reconnecting can't fix it; drop to polling so we don't loop.
+          if (ev.code === 4401 || ev.code === 4403) {
+            setConnectionError(t('generation.connectionFallback'))
+            startPolling()
+            return
+          }
 
           // Attempt to reconnect with exponential backoff
           if (reconnectAttemptsRef.current < 5) {

--- a/services/frontend/src/components/generation/GenerationTaskList.tsx
+++ b/services/frontend/src/components/generation/GenerationTaskList.tsx
@@ -262,8 +262,12 @@ export function GenerationTaskList({
           console.error('WebSocket error:', error)
         }
 
-        ws.onclose = () => {
-          logger.debug('WebSocket disconnected')
+        ws.onclose = (ev) => {
+          logger.debug('WebSocket disconnected', ev.code)
+
+          // 4401 / 4403 = backend rejected the WS handshake on auth/access.
+          // Reconnecting can't fix it; stop so we don't hammer the server.
+          if (ev.code === 4401 || ev.code === 4403) return
 
           // Attempt to reconnect with exponential backoff (only if still mounted)
           if (mounted && reconnectAttemptsRef.current < 5) {

--- a/services/workers/tasks.py
+++ b/services/workers/tasks.py
@@ -2184,6 +2184,100 @@ def send_bulk_invitations_task(invitations_data: List[Dict]) -> Dict[str, Any]:
     return {"sent": sent, "failed": failed, "total": len(invitations_data), "results": results}
 
 
+@app.task(
+    name="emails.send_notification_batch",
+    autoretry_for=(Exception,),
+    retry_kwargs={"max_retries": 3, "countdown": 60},
+)
+def send_notification_batch_task(notification_data: List[Dict]) -> Dict[str, Any]:
+    """Send a batch of in-app-notification emails.
+
+    Replaces the prior pattern in `notification_service.create_notification`
+    where `asyncio.create_task(_send_email_notifications(db, ...))` ran the
+    sync `requests.post` SendGrid call on the API event loop and reused the
+    request-scoped DB session in a fire-and-forget task. Both were
+    catastrophic under fan-out (notify_project_created → every org member +
+    every superadmin); see 2026-05-18 postmortem.
+
+    Owns its own DB session. Failures per-recipient are logged and swallowed
+    so one bad email doesn't tank the whole batch; the task-level retry is
+    reserved for total failures (e.g. SessionLocal unreachable).
+    """
+    if not notification_data:
+        return {"sent": 0, "failed": 0, "skipped": 0}
+
+    sent = failed = skipped = 0
+    db = SessionLocal()
+    try:
+        from email_service import email_service
+        from models import Notification, User
+        try:
+            from email_validation import is_valid_email
+        except ImportError:
+            def is_valid_email(e: str) -> bool:
+                return "@" in (e or "") and "." in (e or "")
+
+        for notif_dict in notification_data:
+            try:
+                user = db.query(User).filter(User.id == notif_dict["user_id"]).first()
+                if not user or not user.email:
+                    skipped += 1
+                    continue
+
+                if not is_valid_email(user.email):
+                    logger.warning(
+                        f"Skipping notification for user {user.id} — invalid email: {user.email}"
+                    )
+                    skipped += 1
+                    continue
+
+                if HAS_NOTIFICATION_SERVICE and not NotificationService._user_wants_channel(
+                    db, user.id, notif_dict["type"], "email"
+                ):
+                    skipped += 1
+                    continue
+
+                # Hydrate a minimal Notification ORM object — only the
+                # attributes the template path reads. We pass an unattached
+                # instance, never add it to the session.
+                notif = Notification(
+                    id=notif_dict.get("id"),
+                    user_id=notif_dict["user_id"],
+                    type=notif_dict["type"],
+                    title=notif_dict.get("title", ""),
+                    message=notif_dict.get("message", ""),
+                    data=notif_dict.get("data") or {},
+                )
+
+                # `send_notification_email` is `async` but the underlying
+                # SendGrid call is sync. Run via asyncio.run on the worker
+                # process — Celery doesn't have an event loop by default.
+                import asyncio as _aio
+                ok = _aio.run(
+                    email_service.send_notification_email(
+                        user_email=user.email,
+                        notification=notif,
+                        context={"user_name": getattr(user, "name", None)},
+                    )
+                )
+                if ok:
+                    sent += 1
+                else:
+                    failed += 1
+            except Exception as e:
+                logger.error(
+                    f"Notification email failed for {notif_dict.get('user_id')}: {e}"
+                )
+                failed += 1
+    finally:
+        db.close()
+
+    logger.info(
+        f"📬 send_notification_batch: {sent} sent, {failed} failed, {skipped} skipped"
+    )
+    return {"sent": sent, "failed": failed, "skipped": skipped, "total": len(notification_data)}
+
+
 # Label Studio tasks removed - using native annotation system
 
 # NOTE: Label Studio sync function removed - using native annotation system


### PR DESCRIPTION
## Summary

Root-causes the 2026-05-18 prod incident — single API replica was wedged for 22 min by a project-create + invite fan-out, then OOMKilled on a bulk-export retry. Three independent latent bugs collided; this PR fixes them all together rather than band-aiding.

**The cascade we observed:**

1. **WS session leak (latent for 13d)** — `routers/evaluations/ws.py` (added in #94's wake) held a `Depends(get_db)` session across `await asyncio.sleep(2)` for the WebSocket lifetime, leaving the connection IDLE IN TRANSACTION between polls. Unauthenticated, so any browser tab could drain pool slots.
2. **Trigger — sync SendGrid on the event loop** — project create fans `notify_project_created` out to every org member + superadmin, then `asyncio.create_task(_send_email_notifications(db, ...))` ran synchronous `requests.post()` per recipient *on the API event loop*, blocking it for seconds. While blocked, WS handlers couldn't yield/close, auth handlers couldn't progress, `/health` (Redis-dependent) timed out → kubelet SIGKILL.
3. **Bulk-export OOM** — `routers/projects/tasks.py:bulk_export_tasks` loaded every task / annotation / generation / evaluation row into Python and `json.dumps(..., indent=2)`-ed the lot as one string. For "zjs fälle" (581 tasks, 8k generations, 57k task_evals) that blew the 1.5 GiB container limit.

**What this PR ships:**

- **Per-iteration DB sessions** in `evaluations/ws.py`, `generation.py` (polling fallback), `evaluations/status.py` (SSE). Reference pattern: `notifications.py:317-331`.
- **WS auth before `accept()`** via new `verify_token_for_websocket` (cookie-first, Bearer fallback). Same-origin browser handshakes send cookies automatically — no frontend WS-URL change. Frontend reconnect loops now bail on close code 4401/4403.
- **Notification emails → Celery** (`emails.send_notification_batch`). Stop sharing the request session with fire-and-forget tasks; SendGrid runs sync on the worker, where it belongs. `requests.post` now has `timeout=(5, 15)` defensively.
- **Engine hardening** (`database.py`): pool 10/20, `pool_timeout=5`, `connect_args` with `statement_timeout=15s`, `idle_in_transaction_session_timeout=30s`, `application_name='benger-api'` (forensics; we couldn't tell API vs worker sessions during the incident).
- **Alembic advisory lock** in `lifespan()` (`pg_advisory_lock(0xBE9E70)`). Unblocks `api.workers > 1` and `replicaCount > 1` — the previous `workers: 1 # multiple workers hang on startup` comment was hiding this race.
- **Capacity** (`values.yaml`): `replicaCount: 1 → 2` (kills SPOF), `api.workers: 1 → 4`. Effective pool budget: 2×4×(10+20) = 240 slots. Postgres has the headroom (we were at 25 total).
- **Liveness probe**: `/health` → `/healthz` (dependency-free). A Redis blip should pull the pod from the LB (readiness), not SIGKILL it (liveness).
- **Bulk-export streaming**: sync `def` handler + `StreamingResponse` + `yield_per(50)` + compact JSON. Peak memory bounded regardless of project size.
- **Tests updated** to match: mocks now target `get_celery_app`; bulk-export tests use a StreamingResponse-aware collector; WS test sets the access_token cookie.

## Out of scope (filed separately)

- Workers OOM (`benger-workers`, 48 restarts in 15h, sitting at 7.8 GiB on semantic-eval load). Confirmed unrelated to the API auth path.
- Replace evaluation WS polling with Redis pub/sub (the architecturally-right answer, but per-iteration sessions already eliminate the pool-drain class; the remaining inefficiency is just query load).
- Move to asyncpg + AsyncSession.

## Test plan
- [x] `make test-api` — 1632 passed pre-rebase; 10 failures all in the bulk-export and WS tests touched by this PR (fixtures + auth-cookie updates landed; CI is the source of truth for the final count)
- [ ] CI green on this PR
- [ ] After merge, watch `kubectl logs deployment/benger-api -n benger -f` for 1 hour — expect zero QueuePool timeouts and zero liveness restarts
- [ ] Spot-check `pg_stat_activity` shows `application_name='benger-api'` and no sessions older than minutes
- [ ] Re-attempt the "zjs fälle" bulk-export end-to-end
- [ ] Trigger a project-create + invite as a non-superadmin in an org with several members and confirm the API event loop never stalls