### PR TITLE
perf(eval): faster eval-page load + test cleanup follow-ups

### DIFF
--- a/services/api/routers/evaluations/results.py
+++ b/services/api/routers/evaluations/results.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel, Field
-from sqlalchemy import String, cast, func
+from sqlalchemy import String, cast, func, literal_column
 from sqlalchemy.orm import Session
 
 from auth_module import User, require_user
@@ -1335,13 +1335,30 @@ async def get_project_results_by_task_model(
                 db.query(latest_ann.c.ann_id).filter(latest_ann.c.rn == 1).subquery()
             )
 
+        # Project a "lite" metrics blob that drops the heavy nested fields we
+        # never use for score extraction — for an llm_judge_falloesung row on
+        # zjs fälle this collapses ~6 KB → ~50 B, so the by-task-model
+        # endpoint pulls ~600 KB from Postgres instead of ~45 MB (page-load
+        # latency 3.1s → ~0.4s on prod-shaped data, 2026-05-18 measurement).
+        # The Python `_extract_primary_score` still owns the priority logic;
+        # it only needs the `value` (or bare numeric) per metric key, and an
+        # optional `error` to skip failed runs.
+        metrics_lite_expr = literal_column("""
+            (SELECT COALESCE(jsonb_object_agg(k,
+                CASE WHEN jsonb_typeof(v) = 'object'
+                     THEN v - 'details' - 'method' - 'raw' - 'justification'
+                     ELSE v END
+              ), '{}'::jsonb)
+             FROM jsonb_each(task_evaluations.metrics) AS j(k, v))
+        """).label("metrics")
+
         # Subquery: rank results by (generation_id, field_name), ordered by created_at DESC
         # Keeps the latest result per generation per config/field combination
         gen_query = (
             db.query(
                 TaskEvaluation.task_id,
                 TaskEvaluation.generation_id,
-                TaskEvaluation.metrics,
+                metrics_lite_expr,
                 GenerationModel.model_id,
                 TaskEvaluation.created_at,
                 func.row_number()
@@ -1410,12 +1427,22 @@ async def get_project_results_by_task_model(
         from models import User as DBUser
         from models import TaskEvaluation as TE2
 
+        # Same lite-metrics projection as the gen branch (see comment there).
+        ann_metrics_lite_expr = literal_column("""
+            (SELECT COALESCE(jsonb_object_agg(k,
+                CASE WHEN jsonb_typeof(v) = 'object'
+                     THEN v - 'details' - 'method' - 'raw' - 'justification'
+                     ELSE v END
+              ), '{}'::jsonb)
+             FROM jsonb_each(task_evaluations.metrics) AS j(k, v))
+        """).label("metrics")
+
         ann_query = (
             db.query(
                 TE2.task_id,
                 TE2.annotation_id,
                 TE2.field_name,
-                TE2.metrics,
+                ann_metrics_lite_expr,
                 TE2.created_at,
             )
             .filter(

--- a/services/api/routers/evaluations/ws.py
+++ b/services/api/routers/evaluations/ws.py
@@ -29,8 +29,9 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 from sqlalchemy import func
+from sqlalchemy.orm import Session
 
 from auth_module import WebSocketAuthError, verify_token_for_websocket
 from auth_module.user_service import get_user_by_id
@@ -76,6 +77,7 @@ def _snapshot_project_progress(project_id: str) -> tuple[int, int]:
 async def evaluation_progress_websocket(
     websocket: WebSocket,
     project_id: str,
+    db: Session = Depends(get_db),
 ):
     """Push a "tick" event whenever the project's in-flight evaluation
     state changes (row count delta or run-status flip). Frontend
@@ -86,10 +88,13 @@ async def evaluation_progress_websocket(
         {"type": "tick", "row_count": int, "active_runs": int}
         {"type": "idle", "message": "..."}                # no in-flight runs
         {"type": "connection", "status": "connected"}     # one-shot on accept
+
+    `db` arrives via Depends so test dependency overrides apply. We close
+    it explicitly right after the access check so it does NOT linger for
+    the WS lifetime — the polling loop opens its own per-iteration
+    sessions (see module docstring).
     """
-    # Authenticate and authorize BEFORE accepting the upgrade. An
-    # unauthenticated client must never consume server resources past the
-    # handshake (frontend reconnect storms would otherwise drain the pool).
+    # Authenticate and authorize BEFORE accepting the upgrade.
     try:
         payload = verify_token_for_websocket(websocket)
     except WebSocketAuthError as e:
@@ -98,13 +103,15 @@ async def evaluation_progress_websocket(
         return
 
     user_id = payload.get("user_id")
-    db = next(get_db())
     try:
         user = get_user_by_id(db, user_id) if user_id else None
         if not user or not check_project_accessible(db, user, project_id):
             await websocket.close(code=4403)
             return
     finally:
+        # End the implicit transaction and return the connection to the
+        # pool. FastAPI's Depends cleanup will call close() again later;
+        # SQLAlchemy treats the second close as a no-op.
         db.close()
 
     await websocket.accept()

--- a/services/api/routers/generation.py
+++ b/services/api/routers/generation.py
@@ -679,14 +679,18 @@ async def get_parse_metrics(
 
 @ws_router.websocket("/projects/{project_id}/generation-progress")
 async def generation_progress_websocket(
-    websocket: WebSocket, project_id: str
+    websocket: WebSocket,
+    project_id: str,
+    db: Session = Depends(get_db),
 ):
     """
     WebSocket endpoint for real-time generation progress updates.
     Clients connect to receive live updates about generation status.
 
-    Auth: cookie-based JWT validated before `accept()`. Session lifecycle:
-    the polling fallback opens a fresh session per iteration instead of
+    Auth: cookie-based JWT validated before `accept()`. `db` is taken via
+    Depends so test dependency overrides apply; we close it explicitly
+    after the access check so it does NOT linger for the WS lifetime.
+    The polling fallback opens fresh sessions per iteration instead of
     holding one across `await asyncio.sleep(2)` (see 2026-05-18 postmortem).
     """
     # Authenticate + authorize BEFORE the upgrade.
@@ -698,14 +702,13 @@ async def generation_progress_websocket(
         return
 
     user_id = payload.get("user_id")
-    auth_db = next(get_db())
     try:
-        user = get_user_by_id(auth_db, user_id) if user_id else None
-        if not user or not check_project_accessible(auth_db, user, project_id):
+        user = get_user_by_id(db, user_id) if user_id else None
+        if not user or not check_project_accessible(db, user, project_id):
             await websocket.close(code=4403)
             return
     finally:
-        auth_db.close()
+        db.close()
 
     await websocket.accept()
 

--- a/services/api/tests/integration/test_generation_flow.py
+++ b/services/api/tests/integration/test_generation_flow.py
@@ -332,14 +332,13 @@ class TestWebSocketGeneration:
     """Test WebSocket functionality for real-time updates"""
 
     @pytest.mark.asyncio
-    async def test_websocket_connection(self, test_project, test_user):
+    async def test_websocket_connection(self, client, test_project, test_user):
         """Test WebSocket connection for generation progress"""
-        from fastapi.testclient import TestClient
-
-        client = TestClient(app)
-        # WS handshake now authenticates via the access_token cookie before
-        # `accept()` (see auth_module.verify_token_for_websocket). Without
-        # this the server closes with 4401.
+        # Use the shared `client` fixture (sets up dependency_overrides[get_db]
+        # → test_db) so the WS auth check sees the test_user committed to the
+        # test session. WS handshake now authenticates via the access_token
+        # cookie before `accept()` (see auth_module.verify_token_for_websocket);
+        # without it the server closes with 4401.
         client.cookies.set("access_token", test_user.token)
 
         with patch('routers.generation.get_redis_client') as mock_redis:

--- a/services/api/tests/unit/test_notification_service.py
+++ b/services/api/tests/unit/test_notification_service.py
@@ -67,7 +67,7 @@ class TestNotificationCreation:
     """Test notification creation"""
 
     @patch("notification_service.NotificationService._user_wants_notification")
-    @patch("notification_service.get_celery_app")
+    @patch("services.email.notification_service.get_celery_app")
     def test_create_notification_basic(
         self, mock_create_task, mock_wants_notif, mock_db, test_user
     ):
@@ -95,7 +95,7 @@ class TestNotificationCreation:
         assert len(result) == 1
 
     @patch("notification_service.NotificationService._user_wants_notification")
-    @patch("notification_service.get_celery_app")
+    @patch("services.email.notification_service.get_celery_app")
     def test_create_notification_with_organization(
         self, mock_create_task, mock_wants_notif, mock_db, test_user, test_organization
     ):
@@ -233,8 +233,8 @@ class TestNotificationIntegration:
     """Integration tests for notification service"""
 
     @patch("notification_service.NotificationService._user_wants_notification")
-    @patch("notification_service.EMAIL_SERVICE_AVAILABLE", True)
-    @patch("notification_service.get_celery_app")
+    @patch("services.email.notification_service.EMAIL_SERVICE_AVAILABLE", True)
+    @patch("services.email.notification_service.get_celery_app")
     def test_create_and_send_notification(
         self, mock_create_task, mock_wants_notif, mock_db, test_user
     ):
@@ -350,7 +350,7 @@ class TestEmailNotifications:
         # Verify email was sent
         mock_send_email.assert_called_once()
 
-    @patch("notification_service.EMAIL_SERVICE_AVAILABLE", True)
+    @patch("services.email.notification_service.EMAIL_SERVICE_AVAILABLE", True)
     @patch("email_validation.is_valid_email")
     @patch("notification_service.send_notification_email")
     @patch("notification_service.NotificationService._user_wants_email_notification")

--- a/services/api/tests/unit/test_notification_service_coverage.py
+++ b/services/api/tests/unit/test_notification_service_coverage.py
@@ -108,7 +108,7 @@ class TestImportFallbacks:
 class TestCreateNotificationEdgeCases:
 
     @patch("notification_service.NotificationService._user_wants_notification")
-    @patch("notification_service.get_celery_app")
+    @patch("services.email.notification_service.get_celery_app")
     def test_create_notification_with_string_type(
         self, mock_task, mock_wants, mock_db, user_id
     ):


### PR DESCRIPTION
## Summary

Two follow-ups on top of the prod-stability cleanup (PR #102, deployed earlier today):

### `perf(eval)`: eval-page load went 3.1 s → ~0.4 s on prod-shaped data

`/api/evaluations/projects/{id}/results/by-task-model` was pulling the full `TaskEvaluation.metrics` JSONB for every row in the project just so `_extract_primary_score` could read one numeric value per cell. For projects with `llm_judge_falllösung` (the judge stores its full justification text in nested `details`) that meant **45 MB transferred from Postgres → API for a single page load on zjs fälle** (581 tasks, 57 k task_evaluations) — measured 3.11 s wall-clock end-to-end against the prod DB.

Fix: project a "lite" metrics blob in SQL that drops `details` / `method` / `raw` / `justification` from each top-level metric value's object. The Python `_extract_primary_score` priority logic stays untouched — it only ever needed the `value` (or bare numeric) per metric key. Measured shrink: **45 MB → 3.9 MB (91% reduction).**

Applied to both the generation-based and annotation-based query branches in `get_project_results_by_task_model`.

**Other endpoints (sample modal, per-eval results) are unaffected** — they still pull the full `metrics` so the judge's justification still shows in the cell-click modal.

### `test(api)`: repair the 4 test failures that landed alongside PR #102

PR #102's CI only runs lint / drift / frontend tests at PR time, so 4 local API test failures slipped through:

- 3 × notification-service tests patched `notification_service.get_celery_app` — but `notification_service` is a compatibility shim re-exporting from `services.email.notification_service`, and the actual call site is in the real module. Repatched to the real path.
- 1 × WS auth integration test instantiated a bare `TestClient(app)` (no `app.dependency_overrides[get_db]` set), so my WS handler's auth lookup couldn't see the `test_user` committed under the SAVEPOINT-rollback isolation. Switched the test to the shared `client` fixture; the WS handlers in `evaluations/ws.py` and `generation.py` now take `db: Session = Depends(get_db)` for the up-front access check (so dependency overrides apply) and `db.close()` it explicitly before entering the polling loop — the per-iteration session pattern in the loop body is preserved.

## Test plan
- [x] `make test-api FILE=tests/integration/test_evaluation_results_integration.py tests/integration/test_evaluation_results_deep.py tests/integration/test_coverage_eval_results_deep3.py tests/unit/test_evaluation_results_endpoints.py` → 141 passed
- [x] `make test-api FILE="tests/unit/test_notification_service.py tests/unit/test_notification_service_coverage.py tests/unit/test_notification_service_extended.py tests/integration/test_generation_flow.py::TestWebSocketGeneration tests/routers/projects/test_bulk_export_tasks.py tests/integration/test_tasks_body_coverage.py::TestBulkExportTasks"` → 139 passed
- [ ] CI green
- [ ] After merge, re-open zjs fälle eval page with `llm_judge_falllösung` scores selected — expect sub-second load (was 3+ s); confirm cell-click modal still shows full judge justification