### PR TITLE
fix(toast): persistence + dual-timer-arming cleanup

### DIFF
--- a/services/frontend/src/components/shared/Toast.tsx
+++ b/services/frontend/src/components/shared/Toast.tsx
@@ -116,44 +116,6 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
     [storeRemove]
   )
 
-  // Subscribe to store changes so progress toasts that flip from
-  // status='running' (persistent, duration=0) to a terminal status get an
-  // auto-dismiss timer attached on the fly. The regular addToast path
-  // arms its own timer; this hook closes the gap for upserts that go
-  // through `upsertProgressToast` directly.
-  useEffect(() => {
-    const unsubscribe = useNotificationStore.subscribe(
-      (state) => state.toasts,
-      (current, prev) => {
-        for (const t of current) {
-          const isTerminal =
-            t.progress && t.progress.status !== 'running'
-          const dur = t.duration ?? DEFAULT_TOAST_DURATION_MS
-          const alreadyScheduled = timeoutsRef.current.has(t.id)
-          if (isTerminal && dur > 0 && !alreadyScheduled) {
-            const handle = setTimeout(() => {
-              storeRemove(t.id)
-              timeoutsRef.current.delete(t.id)
-            }, dur)
-            timeoutsRef.current.set(t.id, handle)
-          }
-        }
-        // Cancel timers for toasts that have been removed externally.
-        const ids = new Set(current.map((t) => t.id))
-        for (const [id, handle] of timeoutsRef.current.entries()) {
-          if (!ids.has(id)) {
-            clearTimeout(handle)
-            timeoutsRef.current.delete(id)
-          }
-        }
-        // `prev` is unused — kept in signature for the subscribeWithSelector
-        // contract.
-        void prev
-      }
-    )
-    return unsubscribe
-  }, [storeRemove])
-
   // Mount: register the module dispatcher and drain any pending flashes
   // (sessionStorage for same-origin reload, URL params for cross-origin
   // redirects). Strip the URL params after dispatch so they don't linger.

--- a/services/frontend/src/contexts/ProgressContext.tsx
+++ b/services/frontend/src/contexts/ProgressContext.tsx
@@ -89,10 +89,10 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
     [toasts]
   )
 
-  // Map of progress-id -> auto-dismiss timer handle. We arm the timer here
-  // (in addition to the ToastProvider subscriber that watches the same
-  // store) so consumers that render only ProgressProvider in isolation
-  // — tests, narrow embeds — still get the same dismiss behavior.
+  // Map of progress-id -> auto-dismiss timer handle. ProgressProvider is
+  // the single owner of the progress-toast lifecycle — it arms the timer
+  // when `completeProgress` flips status off 'running' and clears it on
+  // restart or manual remove.
   const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
     new Map()
   )
@@ -170,9 +170,7 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
       // stay until done, then behave like regular toasts (10 s default).
       // Applies to BOTH success AND error — error toasts used to be
       // sticky-forever in the old self-rolled overlay, but the unification
-      // brings them under the standard toast lifecycle. The ToastProvider's
-      // subscriber would also arm a timer for the same transition; its
-      // `alreadyScheduled` guard keeps the two paths idempotent.
+      // brings them under the standard toast lifecycle.
       clearTimer(id)
       const handle = setTimeout(() => {
         remove(id)

--- a/services/frontend/src/stores/notificationStore.ts
+++ b/services/frontend/src/stores/notificationStore.ts
@@ -241,9 +241,14 @@ export const useNotificationStore = create<NotificationStore>()(
         // createdAt timestamp; on rehydrate, ToastProvider computes the
         // remaining auto-dismiss window (duration - elapsed) and either
         // evicts the toast or re-arms a setTimeout for the remainder.
-        // Persistent toasts (duration === 0) survive indefinitely.
+        // Persistent toasts (duration === 0) survive indefinitely — but
+        // PROGRESS toasts must not. Their producer (an in-flight export,
+        // upload, etc.) is gone with the page; persisting them would
+        // (a) leave a zombie bar forever since nothing will call
+        // completeProgress, and (b) drop the `onCancel` callback (functions
+        // don't survive JSON). Strip them at the serialization boundary.
         partialize: (state) => ({
-          toasts: state.toasts,
+          toasts: state.toasts.filter((t) => t.progress === undefined),
           pendingFlashes: state.pendingFlashes,
         }),
       }


### PR DESCRIPTION
## Summary

Audit follow-ups on the toast unification (PR #104, just merged):

### 1. Progress toasts could leak into sessionStorage and become zombies on reload
The `partialize` config in `notificationStore` was serializing all toasts including progress ones. Two consequences:
- `onCancel` is a function — doesn't survive JSON → becomes `undefined` on rehydrate.
- A `running` progress toast (duration=0, persistent) with no producer left → static bar forever after a page reload, since nothing alive will ever call `completeProgress`.

Strip `t.progress !== undefined` toasts at the serialization boundary. Regular toasts still survive a same-origin reload as before.

### 2. Dual timer arming on progress completion
PR #104 had both `ProgressProvider.completeProgress` AND a `ToastProvider` store-subscriber arm an auto-dismiss timer on the same state transition. Both fired after 10 s; the second was a no-op but it was redundant. Drop the subscriber — `ProgressProvider` is now the single owner of the progress-toast timer lifecycle.

## Test plan
- [x] `npx jest --testPathPatterns="components/shared|contexts/__tests__|stores"` → 2 525 passed
- [ ] CI green