### PR TITLE
fix(notifications) + feat(projects): empty emails, persist toggles, default email off + superadmin scoped projects list

### DIFF
--- a/services/api/routers/dashboard.py
+++ b/services/api/routers/dashboard.py
@@ -114,7 +114,12 @@ async def get_dashboard_stats(
         return cached_stats
 
     try:
-        accessible_ids = get_accessible_project_ids(db, current_user, org_context)
+        # Dashboard is a global aggregate view; preserve the legacy "superadmin
+        # sees everything" semantics here. The narrowing default introduced for
+        # /api/projects only applies to the projects browser.
+        accessible_ids = get_accessible_project_ids(
+            db, current_user, org_context, include_all_private=True
+        )
 
         if accessible_ids is not None and not accessible_ids:
             stats = {

--- a/services/api/routers/evaluations/status.py
+++ b/services/api/routers/evaluations/status.py
@@ -167,7 +167,11 @@ async def get_evaluations(
     Users can view evaluations for projects assigned to their organizations.
     """
     org_context = request.headers.get("X-Organization-Context")
-    accessible_ids = get_accessible_project_ids(db, current_user, org_context)
+    # Global cross-project evaluations view; preserve legacy "superadmin sees
+    # everything" semantics. Narrowing only applies to /api/projects.
+    accessible_ids = get_accessible_project_ids(
+        db, current_user, org_context, include_all_private=True
+    )
 
     # Query evaluations from database, ordered by creation date (newest first)
     query = db.query(DBEvaluationRun).order_by(DBEvaluationRun.created_at.desc())

--- a/services/api/routers/generation.py
+++ b/services/api/routers/generation.py
@@ -586,7 +586,11 @@ async def get_parse_metrics(
         else:
             # Scope by org context when no specific project_id provided
             org_context = request.headers.get("X-Organization-Context", "private")
-            accessible_ids = get_accessible_project_ids(db, current_user, org_context)
+            # Cross-project metrics view; preserve legacy "superadmin sees
+            # everything" semantics. Narrowing only applies to /api/projects.
+            accessible_ids = get_accessible_project_ids(
+                db, current_user, org_context, include_all_private=True
+            )
             if accessible_ids is not None:
                 if not accessible_ids:
                     return {

--- a/services/api/routers/projects/crud.py
+++ b/services/api/routers/projects/crud.py
@@ -88,6 +88,15 @@ async def list_projects(
     page_size: int = Query(100, ge=1, le=500),  # Default 100 like Label Studio
     search: Optional[str] = None,
     is_archived: Optional[bool] = None,
+    include_all_private: bool = Query(
+        False,
+        description=(
+            "Superadmin-only: include other users' private projects in the "
+            "response. Defaults to False so a superadmin's projects browser "
+            "behaves like a regular user's (own private + public + org-scoped). "
+            "Ignored for non-superadmins."
+        ),
+    ),
     current_user: AuthUser = Depends(require_user),
     db: Session = Depends(get_db),
 ):
@@ -97,7 +106,9 @@ async def list_projects(
     The X-Organization-Context header determines which projects are shown:
     - "private" or absent: Show only private projects created by the user
     - org ID: Show only projects assigned to that organization
-    - Superadmins always see all projects regardless of context
+
+    Superadmins are scoped the same way by default; pass
+    include_all_private=true to surface every project in the system.
     """
 
     try:
@@ -105,7 +116,9 @@ async def list_projects(
         org_context = request.headers.get("X-Organization-Context")
 
         # Use shared helper for consistent org-context filtering
-        accessible_ids = get_accessible_project_ids(db, current_user, org_context)
+        accessible_ids = get_accessible_project_ids(
+            db, current_user, org_context, include_all_private=include_all_private
+        )
 
         query = db.query(Project)
         if accessible_ids is not None:

--- a/services/api/routers/projects/helpers.py
+++ b/services/api/routers/projects/helpers.py
@@ -492,6 +492,7 @@ def get_accessible_project_ids(
     db: Session,
     user,
     org_context: Optional[str] = None,
+    include_all_private: bool = False,
 ) -> Optional[List[str]]:
     """Get project IDs accessible to a user based on organization context.
 
@@ -501,11 +502,18 @@ def get_accessible_project_ids(
         org_context: Value of X-Organization-Context header.
                      "private" or None = user's private projects only
                      org_id string = projects in that org
+        include_all_private: Superadmin-only opt-in. When True, the helper
+                     returns None (no filter) so the caller sees every project
+                     in the system. When False (default) a superadmin is
+                     scoped the same way a regular user would be — own private
+                     + public + org-scoped — so the projects browser doesn't
+                     leak other users' private projects.
 
     Returns:
-        List of accessible project IDs, or None for superadmins (no filter needed).
+        List of accessible project IDs, or None for superadmins with
+        include_all_private=True (no filter needed).
     """
-    if user.is_superadmin:
+    if user.is_superadmin and include_all_private:
         return None
 
     public_ids = [

--- a/services/api/services/email/email_service.py
+++ b/services/api/services/email/email_service.py
@@ -12,7 +12,8 @@ from typing import Any, Dict, List, Optional
 
 from jinja2 import Environment, FileSystemLoader
 
-from models import Notification, NotificationType
+from email_templates.template_map import template_for
+from models import Notification
 from sendgrid_client import SendGridClient
 
 logger = logging.getLogger(__name__)
@@ -168,7 +169,6 @@ class EmailService:
             return False
 
 
-        # Build template context
         template_context = {
             "notification": notification,
             "notification_type": notification.type.value if notification.type else "general",
@@ -176,19 +176,7 @@ class EmailService:
             **(context or {}),
         }
 
-        # Select template based on notification type
-        template_map = {
-            NotificationType.TASK_ASSIGNED: "task_assigned.html",
-            NotificationType.ANNOTATION_COMPLETED: "annotation_completed.html",
-            NotificationType.PROJECT_UPDATED: "project_updated.html",
-            NotificationType.PROJECT_SHARED: "project_shared.html",
-            NotificationType.ORGANIZATION_INVITATION_SENT: "organization_invite.html",
-            NotificationType.DATA_IMPORT_SUCCESS: "data_import_success.html",
-            NotificationType.EVALUATION_COMPLETED: "evaluation_completed.html",
-            NotificationType.KORREKTUR_ASSIGNED: "korrektur_assigned.html",
-        }
-
-        template_name = template_map.get(notification.type, "default_notification.html")
+        template_name = template_for(notification.type)
 
         try:
             # Render template

--- a/services/api/services/email/notification_service.py
+++ b/services/api/services/email/notification_service.py
@@ -396,8 +396,11 @@ class NotificationService:
         channel: str,
     ) -> bool:
         """Check whether a specific channel ('in_app' or 'email') is enabled
-        for the given notification type. Defaults to True when no preference
-        is recorded — same as before.
+        for the given notification type.
+
+        Default when no preference row exists: in-app on, email off. Email
+        is opt-in — users explicitly turn it on per type via the settings
+        page. Existing rows still win regardless of channel.
         """
         if isinstance(notification_type, NotificationType):
             type_value = notification_type.value
@@ -417,7 +420,7 @@ class NotificationService:
             .first()
         )
         if preference is None:
-            return True
+            return channel == "in_app"
         if channel == "in_app":
             return bool(preference.in_app_enabled)
         if channel == "email":
@@ -538,9 +541,10 @@ class NotificationService:
             .filter(UserNotificationPreference.user_id == user_id)
             .all()
         )
-        # Default every known type to fully on
+        # Defaults: in-app on, email off. Email is opt-in per type;
+        # users turn it on explicitly from the settings page.
         pref_map: Dict[str, Dict[str, bool]] = {
-            nt.value: {"enabled": True, "in_app": True, "email": True}
+            nt.value: {"enabled": True, "in_app": True, "email": False}
             for nt in NotificationType
         }
         for pref in preferences:

--- a/services/api/tests/integration/test_coverage_tasks_crud_deep3.py
+++ b/services/api/tests/integration/test_coverage_tasks_crud_deep3.py
@@ -671,8 +671,10 @@ class TestAssignments:
 class TestHelpers:
     def test_get_accessible_project_ids_superadmin(self, test_db, test_users, test_org):
         from routers.projects.helpers import get_accessible_project_ids
-        # Superadmin returns None (no filter)
-        result = get_accessible_project_ids(test_db, test_users[0], test_org.id)
+        # Superadmin returns None only with the include_all_private opt-in.
+        result = get_accessible_project_ids(
+            test_db, test_users[0], test_org.id, include_all_private=True
+        )
         assert result is None
 
     def test_get_accessible_project_ids_private(self, test_db, test_users, test_org):

--- a/services/api/tests/integration/test_projects_superadmin_visibility.py
+++ b/services/api/tests/integration/test_projects_superadmin_visibility.py
@@ -1,0 +1,135 @@
+"""Integration tests for the superadmin "narrow by default" projects-list behavior.
+
+`get_accessible_project_ids` no longer short-circuits to None for every
+superadmin. A superadmin's `GET /api/projects/` is now scoped the same way a
+regular user's is (own private + public + org-scoped) unless they explicitly
+pass `?include_all_private=true`. These tests exercise that contract end-to-end
+against a real Postgres test DB.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from auth_module import create_access_token
+from models import User
+from project_models import Project
+from user_service import get_password_hash
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+def _make_user(db, *, is_superadmin: bool, slug: str) -> User:
+    user = User(
+        id=f"{slug}-{_uid()}",
+        username=f"{slug}-{uuid.uuid4().hex[:8]}@test.com",
+        email=f"{slug}-{uuid.uuid4().hex[:8]}@test.com",
+        name=f"Visibility {slug}",
+        hashed_password=get_password_hash("x"),
+        is_superadmin=is_superadmin,
+        is_active=True,
+        email_verified=True,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _make_project(db, *, creator_id: str, is_private: bool, is_public: bool, title: str) -> Project:
+    project = Project(
+        id=_uid(),
+        title=title,
+        created_by=creator_id,
+        is_private=is_private,
+        is_public=is_public,
+        public_role="ANNOTATOR" if is_public else None,
+        label_config='<View><Text name="text" value="$text"/></View>',
+    )
+    db.add(project)
+    db.flush()
+    return project
+
+
+def _auth(user: User) -> dict:
+    token = create_access_token(data={"user_id": user.id})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def superadmin_a(test_db):
+    return _make_user(test_db, is_superadmin=True, slug="superadmin-a")
+
+
+@pytest.fixture
+def superadmin_b(test_db):
+    return _make_user(test_db, is_superadmin=True, slug="superadmin-b")
+
+
+@pytest.fixture
+def regular_user(test_db):
+    return _make_user(test_db, is_superadmin=False, slug="regular")
+
+
+@pytest.fixture
+def project_set(test_db, superadmin_a, superadmin_b):
+    """A's private, B's private, a public project."""
+    p_a_private = _make_project(
+        test_db, creator_id=superadmin_a.id, is_private=True, is_public=False,
+        title="A private",
+    )
+    p_b_private = _make_project(
+        test_db, creator_id=superadmin_b.id, is_private=True, is_public=False,
+        title="B private",
+    )
+    p_public = _make_project(
+        test_db, creator_id=superadmin_a.id, is_private=False, is_public=True,
+        title="Public",
+    )
+    test_db.commit()
+    return {"a_private": p_a_private, "b_private": p_b_private, "public": p_public}
+
+
+class TestSuperadminVisibilityDefault:
+    def test_default_hides_other_superadmin_private(
+        self, client, superadmin_a, project_set
+    ):
+        """Without the flag, superadmin A must NOT see superadmin B's private project."""
+        response = client.get("/api/projects/", headers=_auth(superadmin_a))
+        assert response.status_code == 200
+        ids = {item["id"] for item in response.json()["items"]}
+        assert project_set["a_private"].id in ids
+        assert project_set["public"].id in ids
+        assert project_set["b_private"].id not in ids
+
+    def test_include_all_private_reveals_others(
+        self, client, superadmin_a, project_set
+    ):
+        """With `?include_all_private=true`, superadmin A sees every project."""
+        response = client.get(
+            "/api/projects/?include_all_private=true",
+            headers=_auth(superadmin_a),
+        )
+        assert response.status_code == 200
+        ids = {item["id"] for item in response.json()["items"]}
+        assert project_set["a_private"].id in ids
+        assert project_set["b_private"].id in ids
+        assert project_set["public"].id in ids
+
+    def test_param_ignored_for_non_superadmin(
+        self, client, regular_user, project_set
+    ):
+        """Non-superadmins cannot escalate visibility via the flag."""
+        response = client.get(
+            "/api/projects/?include_all_private=true",
+            headers=_auth(regular_user),
+        )
+        assert response.status_code == 200
+        ids = {item["id"] for item in response.json()["items"]}
+        # Regular user sees only public (they own no private projects here).
+        assert project_set["public"].id in ids
+        assert project_set["a_private"].id not in ids
+        assert project_set["b_private"].id not in ids

--- a/services/api/tests/test_project_performance.py
+++ b/services/api/tests/test_project_performance.py
@@ -77,7 +77,14 @@ def test_list_projects_query_count(client, test_db, auth_headers, test_users):
     try:
         # Make request to list projects with admin headers
         admin_headers = auth_headers["admin"]
-        response = client.get("/api/projects?page=1&page_size=100", headers=admin_headers)
+        # Pass include_all_private=true so the superadmin sees the test
+        # projects regardless of their is_private/is_public flags. The default
+        # superadmin path now mirrors a regular user (own private + public +
+        # org-scoped); this test wants the broad "see everything" surface.
+        response = client.get(
+            "/api/projects?page=1&page_size=100&include_all_private=true",
+            headers=admin_headers,
+        )
         assert response.status_code == 200
 
         # Verify query count
@@ -141,9 +148,12 @@ def test_list_projects_with_zero_stats(client, test_db, auth_headers, test_users
     test_db.add(project)
     test_db.commit()
 
-    # Fetch project list
+    # Fetch project list (broad view — see all projects regardless of visibility)
     admin_headers = auth_headers["admin"]
-    response = client.get("/api/projects?page=1&page_size=100", headers=admin_headers)
+    response = client.get(
+        "/api/projects?page=1&page_size=100&include_all_private=true",
+        headers=admin_headers,
+    )
     assert response.status_code == 200
 
     data = response.json()
@@ -187,9 +197,12 @@ def test_list_projects_progress_calculation(client, test_db, auth_headers, test_
 
     test_db.commit()
 
-    # Fetch project list
+    # Fetch project list (broad view — see all projects regardless of visibility)
     admin_headers = auth_headers["admin"]
-    response = client.get("/api/projects?page=1&page_size=100", headers=admin_headers)
+    response = client.get(
+        "/api/projects?page=1&page_size=100&include_all_private=true",
+        headers=admin_headers,
+    )
     assert response.status_code == 200
 
     data = response.json()

--- a/services/api/tests/unit/test_coverage_push_helpers_misc.py
+++ b/services/api/tests/unit/test_coverage_push_helpers_misc.py
@@ -222,9 +222,16 @@ class TestProjectHelpers:
 
         _setup_helper_project(test_db, test_users)
 
-        # Superadmin gets None (no filter needed)
-        ids = get_accessible_project_ids(test_db, test_users[0])
+        # Superadmin only gets the unfiltered (None) short-circuit when they
+        # explicitly opt in via include_all_private=True. Without the flag they
+        # are scoped the same way a regular user would be.
+        ids = get_accessible_project_ids(
+            test_db, test_users[0], include_all_private=True
+        )
         assert ids is None
+
+        scoped_ids = get_accessible_project_ids(test_db, test_users[0])
+        assert isinstance(scoped_ids, list)
 
     def test_get_accessible_project_ids_private(self, test_db, test_users):
         from routers.projects.helpers import get_accessible_project_ids

--- a/services/api/tests/unit/test_notification_service_coverage.py
+++ b/services/api/tests/unit/test_notification_service_coverage.py
@@ -481,8 +481,8 @@ class TestUserWantsEmailNotification:
         )
         assert result is False
 
-    def test_no_preference_returns_true(self, mock_db, user_id):
-        """Returns True when no preference exists (opt-out — channels default on)."""
+    def test_no_preference_returns_false(self, mock_db, user_id):
+        """Returns False when no preference exists — email is opt-in by default."""
         from notification_service import NotificationService
 
         mock_db.query.return_value.filter.return_value.first.return_value = None
@@ -490,7 +490,7 @@ class TestUserWantsEmailNotification:
         result = NotificationService._user_wants_email_notification(
             mock_db, user_id, NotificationType.PROJECT_CREATED
         )
-        assert result is True
+        assert result is False
 
 
 # ─────────────────────────────────────────────
@@ -707,11 +707,11 @@ class TestGetUserPreferences:
             "in_app": False,
             "email": False,
         }
-        # Other types default to fully on
+        # Other types default to in-app on, email off (email is opt-in)
         assert result[NotificationType.MEMBER_JOINED.value] == {
             "enabled": True,
             "in_app": True,
-            "email": True,
+            "email": False,
         }
 
 

--- a/services/api/tests/unit/test_notification_service_extended.py
+++ b/services/api/tests/unit/test_notification_service_extended.py
@@ -221,11 +221,11 @@ class TestGetUserPreferences:
         db = MagicMock()
         db.query.return_value.filter.return_value.all.return_value = []
         result = NotificationService.get_user_preferences(db, "user-1")
-        # Returns defaults for all notification types: per-channel shape, all on
+        # Defaults: in-app on, email off (email is opt-in per type)
         assert isinstance(result, dict)
         assert len(result) > 0
         assert all(
-            v == {"enabled": True, "in_app": True, "email": True}
+            v == {"enabled": True, "in_app": True, "email": False}
             for v in result.values()
         )
 

--- a/services/api/tests/unit/test_project_crud_coverage.py
+++ b/services/api/tests/unit/test_project_crud_coverage.py
@@ -326,13 +326,30 @@ class TestProjectHelpersCoverage:
         assert response.generation_config_ready is True
         assert response.generation_models_count == 2
 
-    def test_get_accessible_project_ids_superadmin(self):
+    def test_get_accessible_project_ids_superadmin_with_opt_in(self):
         from routers.projects.helpers import get_accessible_project_ids
         user = Mock()
         user.is_superadmin = True
         mock_db = MagicMock()
-        result = get_accessible_project_ids(mock_db, user, None)
+        # Only the explicit opt-in returns the "see everything" None sentinel.
+        result = get_accessible_project_ids(
+            mock_db, user, None, include_all_private=True
+        )
         assert result is None
+
+    def test_get_accessible_project_ids_superadmin_default_is_narrowed(self):
+        from routers.projects.helpers import get_accessible_project_ids
+        user = Mock()
+        user.is_superadmin = True
+        user.id = "super-1"
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.all.return_value = [
+            Mock(id="own-1"),
+        ]
+        # Default behavior must NOT short-circuit; it should return a list
+        # scoped like a regular user (own private + public).
+        result = get_accessible_project_ids(mock_db, user, None)
+        assert isinstance(result, list)
 
     def test_get_accessible_project_ids_private(self):
         from routers.projects.helpers import get_accessible_project_ids

--- a/services/api/tests/unit/test_project_helpers_coverage.py
+++ b/services/api/tests/unit/test_project_helpers_coverage.py
@@ -349,10 +349,17 @@ class TestCalculateGenerationStats:
 class TestGetAccessibleProjectIds:
     """Tests for get_accessible_project_ids."""
 
-    def test_superadmin_returns_none(self):
+    def test_superadmin_returns_none_when_include_all_private(self):
+        # The "no filter" sentinel is now opt-in: superadmin must pass
+        # include_all_private=True to get full visibility back.
         db = Mock()
         user = Mock(is_superadmin=True)
-        result = get_accessible_project_ids(db, user, org_context="org-1")
+
+        # When the flag is set the helper short-circuits before any query,
+        # so we don't need to mock `db.query` for this path.
+        result = get_accessible_project_ids(
+            db, user, org_context="org-1", include_all_private=True
+        )
         assert result is None
 
     def test_private_context(self):

--- a/services/api/tests/unit/test_project_helpers_extended.py
+++ b/services/api/tests/unit/test_project_helpers_extended.py
@@ -198,12 +198,15 @@ class TestCheckUserCanEditProject:
 class TestGetAccessibleProjectIds:
     """Tests for get_accessible_project_ids."""
 
-    def test_superadmin_returns_none(self):
+    def test_superadmin_returns_none_when_include_all_private(self):
         from routers.projects.helpers import get_accessible_project_ids
 
         db = Mock()
         user = Mock(is_superadmin=True)
-        result = get_accessible_project_ids(db, user, "org-1")
+        # The unfiltered None sentinel is now an opt-in.
+        result = get_accessible_project_ids(
+            db, user, "org-1", include_all_private=True
+        )
         assert result is None
 
     def test_private_context_returns_user_private_projects(self):

--- a/services/api/tests/unit/test_projects_router.py
+++ b/services/api/tests/unit/test_projects_router.py
@@ -401,8 +401,11 @@ class TestProjectsRouter:
             finally:
                 app.dependency_overrides.clear()
 
-    def test_list_projects_superadmin_sees_all(self, client, mock_superadmin_user):
-        """Test that superadmin can see all projects regardless of visibility"""
+    def test_list_projects_superadmin_default_narrow(self, client, mock_superadmin_user):
+        """Smoke test: /api/projects/ as a superadmin without the
+        include_all_private flag must still return 200 (with the narrowed
+        list). Real visibility behavior is covered end-to-end in
+        tests/integration/test_projects_superadmin_visibility.py."""
         from auth_module import require_user
         from database import get_db
         from main import app

--- a/services/frontend/src/app/settings/notifications/__tests__/page.test.tsx
+++ b/services/frontend/src/app/settings/notifications/__tests__/page.test.tsx
@@ -754,7 +754,7 @@ describe('NotificationSettingsPage', () => {
       })
     })
 
-    it('converts new format to legacy format when saving', async () => {
+    it('sends per-channel preferences object when saving', async () => {
       const user = userEvent.setup()
       render(<NotificationSettingsPage />)
 
@@ -772,9 +772,9 @@ describe('NotificationSettingsPage', () => {
       await waitFor(() => {
         expect(api.updateNotificationPreferences).toHaveBeenCalledWith(
           expect.objectContaining({
-            project_created: true,
-            project_updated: true,
-            project_shared: false,
+            project_created: { enabled: true, in_app: true, email: false },
+            project_updated: { enabled: true, in_app: true, email: true },
+            project_shared: { enabled: false, in_app: false, email: false },
           })
         )
       })

--- a/services/frontend/src/app/settings/notifications/page.tsx
+++ b/services/frontend/src/app/settings/notifications/page.tsx
@@ -373,12 +373,8 @@ function NotificationSettingsContent() {
       setError(null)
       setSuccess(null)
 
-      // Convert new format back to legacy format for API compatibility
-      const legacyPreferences = Object.fromEntries(
-        Object.entries(preferences).map(([key, value]) => [key, value.enabled])
-      )
-
-      await api.updateNotificationPreferences(legacyPreferences)
+      await api.updateNotificationPreferences(preferences)
+      await loadPreferences()
       setSuccess(t('settings.notifications.ui.preferencesSaved'))
 
       // Clear success message after 3 seconds

--- a/services/frontend/src/components/projects/ProjectListTable.tsx
+++ b/services/frontend/src/components/projects/ProjectListTable.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/shared/Button'
 import { FilterToolbar } from '@/components/shared/FilterToolbar'
 import { Pagination } from '@/components/shared/Pagination'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/shared/Select'
+import { ToggleSwitch } from '@/components/shared/ToggleSwitch'
 import { useToast } from '@/components/shared/Toast'
 import { useAuth } from '@/contexts/AuthContext'
 import { useI18n } from '@/contexts/I18nContext'
@@ -67,6 +68,31 @@ export function ProjectListTable({
   const [selectedProjects, setSelectedProjects] = useState<Set<string>>(
     new Set()
   )
+  // Superadmin-only opt-in to broaden the response to include every other
+  // user's private projects. Default OFF (narrow view) — the toggle restores
+  // the legacy "see everything" surface. Persisted in localStorage so a
+  // superadmin's preference survives refresh.
+  const includeAllPrivateStorageKey = 'projects-include-all-private'
+  const [includeAllPrivate, setIncludeAllPrivate] = useState<boolean>(false)
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    try {
+      const stored = window.localStorage.getItem(includeAllPrivateStorageKey)
+      if (stored === 'true') setIncludeAllPrivate(true)
+    } catch {
+      // localStorage may be unavailable (Safari private mode, quota); fall
+      // back to the default narrow view.
+    }
+  }, [])
+  const persistIncludeAllPrivate = (next: boolean) => {
+    setIncludeAllPrivate(next)
+    if (typeof window === 'undefined') return
+    try {
+      window.localStorage.setItem(includeAllPrivateStorageKey, next ? 'true' : 'false')
+    } catch {
+      // ignore persistence failures
+    }
+  }
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   // Check if user has permissions to create/modify projects
@@ -74,8 +100,8 @@ export function ProjectListTable({
   const userCanCreateProjects = canCreateProjects(user, { isPrivateMode })
 
   useEffect(() => {
-    fetchProjects(undefined, undefined, showArchivedOnly)
-  }, [fetchProjects, showArchivedOnly])
+    fetchProjects(undefined, undefined, showArchivedOnly, includeAllPrivate)
+  }, [fetchProjects, showArchivedOnly, includeAllPrivate])
 
   // Clear selections when page changes
   useEffect(() => {
@@ -93,8 +119,8 @@ export function ProjectListTable({
 
   // Fetch projects when search query changes in the store
   useEffect(() => {
-    fetchProjects(undefined, undefined, showArchivedOnly)
-  }, [searchQuery, fetchProjects, showArchivedOnly])
+    fetchProjects(undefined, undefined, showArchivedOnly, includeAllPrivate)
+  }, [searchQuery, fetchProjects, showArchivedOnly, includeAllPrivate])
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
@@ -528,12 +554,14 @@ export function ProjectListTable({
           hasActiveFilters={
             sortField !== 'created_at' ||
             sortOrder !== 'desc' ||
-            localSearchQuery.trim() !== ''
+            localSearchQuery.trim() !== '' ||
+            includeAllPrivate
           }
           onClearFilters={() => {
             setSortField('created_at')
             setSortOrder('desc')
             setLocalSearchQuery('')
+            persistIncludeAllPrivate(false)
           }}
           clearLabel={t('common.filters.clearAll')}
           rightExtras={
@@ -581,6 +609,14 @@ export function ProjectListTable({
               </SelectContent>
             </Select>
           </FilterToolbar.Field>
+          {user?.is_superadmin && (
+            <FilterToolbar.Field label={t('projects.list.showAllPrivate')}>
+              <ToggleSwitch
+                enabled={includeAllPrivate}
+                onChange={persistIncludeAllPrivate}
+              />
+            </FilterToolbar.Field>
+          )}
         </FilterToolbar>
 
         {/* Bulk Actions */}

--- a/services/frontend/src/components/projects/__tests__/ProjectListTable.search.test.tsx
+++ b/services/frontend/src/components/projects/__tests__/ProjectListTable.search.test.tsx
@@ -288,6 +288,7 @@ describe('ProjectListTable Search Functionality', () => {
       expect(mockFetchProjects).toHaveBeenCalledWith(
         undefined,
         undefined,
+        false,
         false
       )
 
@@ -306,6 +307,7 @@ describe('ProjectListTable Search Functionality', () => {
       expect(mockFetchProjects).toHaveBeenCalledWith(
         undefined,
         undefined,
+        false,
         false
       )
 
@@ -430,13 +432,19 @@ describe('ProjectListTable Search Functionality', () => {
       expect(mockFetchProjects).toHaveBeenCalledWith(
         undefined,
         undefined,
+        false,
         false
       )
     })
 
     it('should trigger fetchProjects with archived flag when showing archived', () => {
       render(<ProjectListTable showArchivedOnly={true} />)
-      expect(mockFetchProjects).toHaveBeenCalledWith(undefined, undefined, true)
+      expect(mockFetchProjects).toHaveBeenCalledWith(
+        undefined,
+        undefined,
+        true,
+        false
+      )
     })
   })
 

--- a/services/frontend/src/components/projects/__tests__/ProjectListTable.superadmin-toggle.test.tsx
+++ b/services/frontend/src/components/projects/__tests__/ProjectListTable.superadmin-toggle.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Tests for the superadmin-only "Show all private projects" toggle on the
+ * projects-list filter bar. The toggle defaults OFF (narrow view that hides
+ * other users' private projects); flipping it on threads
+ * include_all_private=true through to projectStore.fetchProjects and persists
+ * the choice in localStorage so it survives refresh.
+ *
+ * @jest-environment jsdom
+ */
+
+import { useProjectStore } from '@/stores/projectStore'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useRouter } from 'next/navigation'
+import { ProjectListTable } from '../ProjectListTable'
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(() => ({ push: jest.fn() })),
+  useParams: jest.fn(() => ({})),
+  useSearchParams: jest.fn(() => new URLSearchParams()),
+  usePathname: jest.fn(() => '/'),
+  notFound: jest.fn(),
+  redirect: jest.fn(),
+}))
+
+jest.mock('@/stores/projectStore', () => ({
+  useProjectStore: jest.fn(),
+}))
+
+jest.mock('@/lib/api/projects', () => ({
+  projectsAPI: {
+    bulkDeleteProjects: jest.fn(),
+    bulkExportProjects: jest.fn(),
+    bulkExportFullProjects: jest.fn(),
+    bulkArchiveProjects: jest.fn(),
+    bulkUnarchiveProjects: jest.fn(),
+    importProject: jest.fn(),
+  },
+}))
+
+jest.mock('@/hooks/useDialogs', () => ({
+  useConfirm: () => jest.fn(),
+}))
+
+jest.mock('@/components/shared/Toast', () => ({
+  useToast: () => ({ addToast: jest.fn(), removeToast: jest.fn() }),
+}))
+
+// AuthContext is overridden per test via the `mockUser` ref below.
+const mockUser = { current: { is_superadmin: false } as { is_superadmin: boolean } }
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: mockUser.current,
+    isAuthenticated: true,
+    isLoading: false,
+    login: jest.fn(),
+    logout: jest.fn(),
+  }),
+}))
+
+jest.mock('@/contexts/I18nContext', () => ({
+  useI18n: () => ({
+    t: (key: string) => {
+      if (key === 'projects.list.showAllPrivate') return 'Show all private projects'
+      return key
+    },
+    locale: 'en',
+  }),
+}))
+
+// Pass-through FilterToolbar mock so the toggle slot renders.
+jest.mock('@/components/shared/FilterToolbar', () => {
+  const FilterToolbar = ({ children }: any) => (
+    <div data-testid="filter-toolbar">{children}</div>
+  )
+  FilterToolbar.Field = ({ label, children }: any) => (
+    <div data-testid={`filter-field-${String(label)}`}>{children}</div>
+  )
+  return { FilterToolbar }
+})
+
+// Minimal ToggleSwitch surrogate exposing role="switch" + label, so we can
+// assert visibility, default state, and clicks without HeadlessUI plumbing.
+jest.mock('@/components/shared/ToggleSwitch', () => ({
+  ToggleSwitch: ({
+    enabled,
+    onChange,
+  }: { enabled: boolean; onChange: (next: boolean) => void }) => (
+    <button
+      role="switch"
+      aria-checked={enabled}
+      onClick={() => onChange(!enabled)}
+      data-testid="superadmin-private-toggle"
+    >
+      {enabled ? 'on' : 'off'}
+    </button>
+  ),
+}))
+
+const STORAGE_KEY = 'projects-include-all-private'
+
+describe('ProjectListTable — superadmin private-projects toggle', () => {
+  const mockFetchProjects = jest.fn()
+
+  const baseStore = {
+    projects: [],
+    loading: false,
+    fetchProjects: mockFetchProjects,
+    setSearchQuery: jest.fn(),
+    searchQuery: '',
+    currentPage: 1,
+    pageSize: 25,
+    totalProjects: 0,
+    totalPages: 0,
+    setCurrentPage: jest.fn(),
+    setPageSize: jest.fn(),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    window.localStorage.clear()
+    ;(useRouter as jest.Mock).mockReturnValue({ push: jest.fn() })
+    ;(useProjectStore as unknown as jest.Mock).mockReturnValue(baseStore)
+  })
+
+  it('hides the toggle for non-superadmin users', () => {
+    mockUser.current = { is_superadmin: false }
+    render(<ProjectListTable />)
+
+    expect(screen.queryByTestId('superadmin-private-toggle')).not.toBeInTheDocument()
+  })
+
+  it('shows the toggle for superadmins, defaulting to OFF (narrow view)', () => {
+    mockUser.current = { is_superadmin: true }
+    render(<ProjectListTable />)
+
+    const toggle = screen.getByTestId('superadmin-private-toggle')
+    expect(toggle).toBeInTheDocument()
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('hydrates the toggle from localStorage', async () => {
+    mockUser.current = { is_superadmin: true }
+    window.localStorage.setItem(STORAGE_KEY, 'true')
+
+    render(<ProjectListTable />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('superadmin-private-toggle')).toHaveAttribute(
+        'aria-checked',
+        'true',
+      )
+    })
+  })
+
+  it('flipping the toggle calls fetchProjects(includeAllPrivate=true) and persists the preference', async () => {
+    mockUser.current = { is_superadmin: true }
+    const user = userEvent.setup()
+    render(<ProjectListTable />)
+
+    // Initial mount runs fetchProjects with includeAllPrivate=false.
+    expect(mockFetchProjects).toHaveBeenCalledWith(undefined, undefined, false, false)
+    mockFetchProjects.mockClear()
+
+    const toggle = screen.getByTestId('superadmin-private-toggle')
+    await user.click(toggle)
+
+    await waitFor(() => {
+      expect(mockFetchProjects).toHaveBeenCalledWith(undefined, undefined, false, true)
+    })
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('true')
+  })
+})

--- a/services/frontend/src/components/projects/__tests__/ProjectListTable.test.tsx
+++ b/services/frontend/src/components/projects/__tests__/ProjectListTable.test.tsx
@@ -1205,7 +1205,12 @@ describe('ProjectListTable', () => {
     it('should fetch archived projects on mount', () => {
       render(<ProjectListTable showArchivedOnly={true} />)
 
-      expect(mockFetchProjects).toHaveBeenCalledWith(undefined, undefined, true)
+      expect(mockFetchProjects).toHaveBeenCalledWith(
+        undefined,
+        undefined,
+        true,
+        false
+      )
     })
 
     it('should render archived view header', () => {
@@ -2011,6 +2016,7 @@ describe('ProjectListTable', () => {
       expect(mockFetchProjects).toHaveBeenCalledWith(
         undefined,
         undefined,
+        false,
         false
       )
     })
@@ -2018,7 +2024,12 @@ describe('ProjectListTable', () => {
     it('should fetch archived projects when showArchivedOnly is true', () => {
       render(<ProjectListTable showArchivedOnly={true} />)
 
-      expect(mockFetchProjects).toHaveBeenCalledWith(undefined, undefined, true)
+      expect(mockFetchProjects).toHaveBeenCalledWith(
+        undefined,
+        undefined,
+        true,
+        false
+      )
     })
 
     it('should refetch projects when search query changes', () => {

--- a/services/frontend/src/lib/api/projects.ts
+++ b/services/frontend/src/lib/api/projects.ts
@@ -28,7 +28,8 @@ export const projectsAPI = {
     page = 1,
     pageSize = 100,
     search?: string,
-    isArchived?: boolean
+    isArchived?: boolean,
+    includeAllPrivate?: boolean
   ): Promise<PaginatedResponse<Project>> => {
     const params = new URLSearchParams({
       page: page.toString(),
@@ -44,6 +45,12 @@ export const projectsAPI = {
       params.append('is_archived', 'true')
     } else if (isArchived === false) {
       params.append('is_archived', 'false')
+    }
+
+    // Superadmin-only: broaden the response to include other users' private
+    // projects. Backend ignores the flag for non-superadmins.
+    if (includeAllPrivate === true) {
+      params.append('include_all_private', 'true')
     }
 
     // Add cache-busting parameter to ensure fresh data after deletions

--- a/services/frontend/src/locales/de/common.json
+++ b/services/frontend/src/locales/de/common.json
@@ -575,7 +575,8 @@
       "sortTitle": "Titel",
       "sortCreated": "Erstellungsdatum",
       "sortTaskCount": "Aufgabenanzahl",
-      "sortProgress": "Fortschritt"
+      "sortProgress": "Fortschritt",
+      "showAllPrivate": "Alle privaten Projekte anzeigen"
     },
     "columns": {
       "label": "Spalten",

--- a/services/frontend/src/locales/en/common.json
+++ b/services/frontend/src/locales/en/common.json
@@ -575,7 +575,8 @@
       "sortTitle": "Title",
       "sortCreated": "Created date",
       "sortTaskCount": "Task count",
-      "sortProgress": "Progress"
+      "sortProgress": "Progress",
+      "showAllPrivate": "Show all private projects"
     },
     "columns": {
       "label": "Columns",

--- a/services/frontend/src/stores/__tests__/projectStore.test.ts
+++ b/services/frontend/src/stores/__tests__/projectStore.test.ts
@@ -179,7 +179,13 @@ describe('ProjectStore', () => {
         await useProjectStore.getState().fetchProjects(2, 50)
       })
 
-      expect(mockProjectsAPI.list).toHaveBeenCalledWith(2, 50, '', undefined)
+      expect(mockProjectsAPI.list).toHaveBeenCalledWith(
+        2,
+        50,
+        '',
+        undefined,
+        undefined,
+      )
       const state = useProjectStore.getState()
       expect(state.currentPage).toBe(2)
       expect(state.pageSize).toBe(50)
@@ -206,7 +212,8 @@ describe('ProjectStore', () => {
         1,
         30,
         'test search',
-        undefined
+        undefined,
+        undefined,
       )
     })
 
@@ -223,7 +230,13 @@ describe('ProjectStore', () => {
         await useProjectStore.getState().fetchProjects(1, 30, true)
       })
 
-      expect(mockProjectsAPI.list).toHaveBeenCalledWith(1, 30, '', true)
+      expect(mockProjectsAPI.list).toHaveBeenCalledWith(
+        1,
+        30,
+        '',
+        true,
+        undefined,
+      )
     })
 
     it('should handle undefined response gracefully', async () => {
@@ -1258,7 +1271,13 @@ describe('ProjectStore', () => {
 
         const state = useProjectStore.getState()
         expect(state.currentPage).toBe(2)
-        expect(mockProjectsAPI.list).toHaveBeenCalledWith(2, 30, '', undefined)
+        expect(mockProjectsAPI.list).toHaveBeenCalledWith(
+          2,
+          30,
+          '',
+          undefined,
+          undefined,
+        )
       })
     })
 
@@ -1283,7 +1302,13 @@ describe('ProjectStore', () => {
         const state = useProjectStore.getState()
         expect(state.pageSize).toBe(50)
         expect(state.currentPage).toBe(1)
-        expect(mockProjectsAPI.list).toHaveBeenCalledWith(1, 50, '', undefined)
+        expect(mockProjectsAPI.list).toHaveBeenCalledWith(
+          1,
+          50,
+          '',
+          undefined,
+          undefined,
+        )
       })
     })
 

--- a/services/frontend/src/stores/projectStore.ts
+++ b/services/frontend/src/stores/projectStore.ts
@@ -40,7 +40,8 @@ interface ProjectStore {
   fetchProjects: (
     page?: number,
     pageSize?: number,
-    isArchived?: boolean
+    isArchived?: boolean,
+    includeAllPrivate?: boolean
   ) => Promise<void>
   fetchProject: (projectId: string) => Promise<void>
   createProject: (data: {
@@ -119,7 +120,8 @@ export const useProjectStore = create<ProjectStore>()(
       fetchProjects: async (
         page?: number,
         pageSize?: number,
-        isArchived?: boolean
+        isArchived?: boolean,
+        includeAllPrivate?: boolean
       ) => {
         const currentPageToUse = page ?? get().currentPage
         const pageSizeToUse = pageSize ?? get().pageSize
@@ -131,7 +133,8 @@ export const useProjectStore = create<ProjectStore>()(
             currentPageToUse,
             pageSizeToUse,
             search,
-            isArchived
+            isArchived,
+            includeAllPrivate
           )
 
           // Ensure response has the expected structure

--- a/services/shared/email_templates/email/annotation_completed.html
+++ b/services/shared/email_templates/email/annotation_completed.html
@@ -1,0 +1,20 @@
+Subject: {{ notification.title }}
+<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8" /></head>
+  <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #18181b; max-width: 600px; margin: 0 auto; padding: 24px;">
+    <h2 style="color: #18181b; margin: 0 0 16px;">{{ notification.title }}</h2>
+    <p style="white-space: pre-line; line-height: 1.5; color: #3f3f46;">{{ notification.message }}</p>
+    {% if notification.data %}
+    <ul style="margin: 16px 0; padding-left: 20px; color: #52525b; font-size: 14px; line-height: 1.6;">
+      {% if notification.data.project_title %}<li>Projekt: <strong>{{ notification.data.project_title }}</strong></li>{% endif %}
+      {% if notification.data.task_count %}<li>Aufgaben: <strong>{{ notification.data.task_count }}</strong></li>{% endif %}
+    </ul>
+    {% endif %}
+    <hr style="border: none; border-top: 1px solid #e4e4e7; margin: 24px 0;" />
+    <p style="font-size: 12px; color: #a1a1aa;">
+      Sie erhalten diese E-Mail, weil Sie für diese Benachrichtigung im BenGER-Profil eine E-Mail-Zustellung aktiviert haben.
+      Sie können dies in den <em>Benachrichtigungseinstellungen</em> ändern.
+    </p>
+  </body>
+</html>

--- a/services/shared/email_templates/email/data_import_success.html
+++ b/services/shared/email_templates/email/data_import_success.html
@@ -1,0 +1,25 @@
+Subject: {{ notification.title }}
+<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8" /></head>
+  <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #18181b; max-width: 600px; margin: 0 auto; padding: 24px;">
+    <h2 style="color: #18181b; margin: 0 0 16px;">{{ notification.title }}</h2>
+    <p style="white-space: pre-line; line-height: 1.5; color: #3f3f46;">{{ notification.message }}</p>
+    {% if notification.data %}
+    <ul style="margin: 16px 0; padding-left: 20px; color: #52525b; font-size: 14px; line-height: 1.6;">
+      {% if notification.data.project_title %}<li>Projekt: <strong>{{ notification.data.project_title }}</strong></li>{% endif %}
+      {% if notification.data.task_name %}<li>Aufgabe: <strong>{{ notification.data.task_name }}</strong></li>{% endif %}
+      {% if notification.data.filename %}<li>Datei: <strong>{{ notification.data.filename }}</strong></li>{% endif %}
+      {% if notification.data.task_count %}<li>Importierte Aufgaben: <strong>{{ notification.data.task_count }}</strong></li>{% endif %}
+      {% if notification.data.upload_count %}<li>Importierte Einträge: <strong>{{ notification.data.upload_count }}</strong></li>{% endif %}
+      {% if notification.data.imported_items_count %}<li>Importierte Einträge: <strong>{{ notification.data.imported_items_count }}</strong></li>{% endif %}
+      {% if notification.data.imported_by %}<li>Von: <strong>{{ notification.data.imported_by }}</strong></li>{% endif %}
+    </ul>
+    {% endif %}
+    <hr style="border: none; border-top: 1px solid #e4e4e7; margin: 24px 0;" />
+    <p style="font-size: 12px; color: #a1a1aa;">
+      Sie erhalten diese E-Mail, weil Sie für diese Benachrichtigung im BenGER-Profil eine E-Mail-Zustellung aktiviert haben.
+      Sie können dies in den <em>Benachrichtigungseinstellungen</em> ändern.
+    </p>
+  </body>
+</html>

--- a/services/shared/email_templates/email/evaluation_completed.html
+++ b/services/shared/email_templates/email/evaluation_completed.html
@@ -1,0 +1,22 @@
+Subject: {{ notification.title }}
+<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8" /></head>
+  <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #18181b; max-width: 600px; margin: 0 auto; padding: 24px;">
+    <h2 style="color: #18181b; margin: 0 0 16px;">{{ notification.title }}</h2>
+    <p style="white-space: pre-line; line-height: 1.5; color: #3f3f46;">{{ notification.message }}</p>
+    {% if notification.data %}
+    <ul style="margin: 16px 0; padding-left: 20px; color: #52525b; font-size: 14px; line-height: 1.6;">
+      {% if notification.data.task_name %}<li>Aufgabe: <strong>{{ notification.data.task_name }}</strong></li>{% endif %}
+      {% if notification.data.model_name %}<li>Modell: <strong>{{ notification.data.model_name }}</strong></li>{% endif %}
+      {% if notification.data.evaluation_id %}<li>Evaluation-ID: <code>{{ notification.data.evaluation_id }}</code></li>{% endif %}
+      {% if notification.data.error_message %}<li style="color: #b91c1c;">Fehler: {{ notification.data.error_message }}</li>{% endif %}
+    </ul>
+    {% endif %}
+    <hr style="border: none; border-top: 1px solid #e4e4e7; margin: 24px 0;" />
+    <p style="font-size: 12px; color: #a1a1aa;">
+      Sie erhalten diese E-Mail, weil Sie für diese Benachrichtigung im BenGER-Profil eine E-Mail-Zustellung aktiviert haben.
+      Sie können dies in den <em>Benachrichtigungseinstellungen</em> ändern.
+    </p>
+  </body>
+</html>

--- a/services/shared/email_templates/email/llm_generation_completed.html
+++ b/services/shared/email_templates/email/llm_generation_completed.html
@@ -1,0 +1,24 @@
+Subject: {{ notification.title }}
+<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8" /></head>
+  <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #18181b; max-width: 600px; margin: 0 auto; padding: 24px;">
+    <h2 style="color: #18181b; margin: 0 0 16px;">{{ notification.title }}</h2>
+    <p style="white-space: pre-line; line-height: 1.5; color: #3f3f46;">{{ notification.message }}</p>
+    {% if notification.data %}
+    <ul style="margin: 16px 0; padding-left: 20px; color: #52525b; font-size: 14px; line-height: 1.6;">
+      {% if notification.data.project_title %}<li>Projekt: <strong>{{ notification.data.project_title }}</strong></li>{% endif %}
+      {% if notification.data.model_id %}<li>Modell: <strong>{{ notification.data.model_id }}</strong></li>{% endif %}
+      {% if notification.data.responses_generated is defined and notification.data.total_expected is defined %}
+      <li>Antworten: <strong>{{ notification.data.responses_generated }}</strong> / {{ notification.data.total_expected }}</li>
+      {% endif %}
+      {% if notification.data.generation_id %}<li>Generation-ID: <code>{{ notification.data.generation_id }}</code></li>{% endif %}
+    </ul>
+    {% endif %}
+    <hr style="border: none; border-top: 1px solid #e4e4e7; margin: 24px 0;" />
+    <p style="font-size: 12px; color: #a1a1aa;">
+      Sie erhalten diese E-Mail, weil Sie für diese Benachrichtigung im BenGER-Profil eine E-Mail-Zustellung aktiviert haben.
+      Sie können dies in den <em>Benachrichtigungseinstellungen</em> ändern.
+    </p>
+  </body>
+</html>

--- a/services/shared/email_templates/email/organization_invite.html
+++ b/services/shared/email_templates/email/organization_invite.html
@@ -1,0 +1,29 @@
+Subject: {{ notification.title }}
+<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8" /></head>
+  <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #18181b; max-width: 600px; margin: 0 auto; padding: 24px;">
+    <h2 style="color: #18181b; margin: 0 0 16px;">{{ notification.title }}</h2>
+    <p style="white-space: pre-line; line-height: 1.5; color: #3f3f46;">{{ notification.message }}</p>
+    {% if notification.data %}
+    <ul style="margin: 16px 0; padding-left: 20px; color: #52525b; font-size: 14px; line-height: 1.6;">
+      {% if notification.data.organization_name %}<li>Organisation: <strong>{{ notification.data.organization_name }}</strong></li>{% endif %}
+      {% if notification.data.inviter_name %}<li>Eingeladen von: <strong>{{ notification.data.inviter_name }}</strong></li>{% endif %}
+      {% if notification.data.invitee_email %}<li>Eingeladene E-Mail: <strong>{{ notification.data.invitee_email }}</strong></li>{% endif %}
+      {% if notification.data.role %}<li>Rolle: <strong>{{ notification.data.role }}</strong></li>{% endif %}
+    </ul>
+    {% if notification.data.invitation_url %}
+    <p style="margin: 24px 0;">
+      <a href="{{ notification.data.invitation_url }}" style="background-color: #047857; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px; display: inline-block;">
+        Einladung annehmen
+      </a>
+    </p>
+    {% endif %}
+    {% endif %}
+    <hr style="border: none; border-top: 1px solid #e4e4e7; margin: 24px 0;" />
+    <p style="font-size: 12px; color: #a1a1aa;">
+      Sie erhalten diese E-Mail, weil Sie für diese Benachrichtigung im BenGER-Profil eine E-Mail-Zustellung aktiviert haben.
+      Sie können dies in den <em>Benachrichtigungseinstellungen</em> ändern.
+    </p>
+  </body>
+</html>

--- a/services/shared/email_templates/email/project_shared.html
+++ b/services/shared/email_templates/email/project_shared.html
@@ -1,0 +1,21 @@
+Subject: {{ notification.title }}
+<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8" /></head>
+  <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #18181b; max-width: 600px; margin: 0 auto; padding: 24px;">
+    <h2 style="color: #18181b; margin: 0 0 16px;">{{ notification.title }}</h2>
+    <p style="white-space: pre-line; line-height: 1.5; color: #3f3f46;">{{ notification.message }}</p>
+    {% if notification.data %}
+    <ul style="margin: 16px 0; padding-left: 20px; color: #52525b; font-size: 14px; line-height: 1.6;">
+      {% if notification.data.project_title %}<li>Projekt: <strong>{{ notification.data.project_title }}</strong></li>{% endif %}
+      {% if notification.data.shared_by %}<li>Geteilt von: <strong>{{ notification.data.shared_by }}</strong></li>{% endif %}
+      {% if notification.data.role %}<li>Rolle: <strong>{{ notification.data.role }}</strong></li>{% endif %}
+    </ul>
+    {% endif %}
+    <hr style="border: none; border-top: 1px solid #e4e4e7; margin: 24px 0;" />
+    <p style="font-size: 12px; color: #a1a1aa;">
+      Sie erhalten diese E-Mail, weil Sie für diese Benachrichtigung im BenGER-Profil eine E-Mail-Zustellung aktiviert haben.
+      Sie können dies in den <em>Benachrichtigungseinstellungen</em> ändern.
+    </p>
+  </body>
+</html>

--- a/services/shared/email_templates/email/project_updated.html
+++ b/services/shared/email_templates/email/project_updated.html
@@ -1,0 +1,20 @@
+Subject: {{ notification.title }}
+<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8" /></head>
+  <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #18181b; max-width: 600px; margin: 0 auto; padding: 24px;">
+    <h2 style="color: #18181b; margin: 0 0 16px;">{{ notification.title }}</h2>
+    <p style="white-space: pre-line; line-height: 1.5; color: #3f3f46;">{{ notification.message }}</p>
+    {% if notification.data %}
+    <ul style="margin: 16px 0; padding-left: 20px; color: #52525b; font-size: 14px; line-height: 1.6;">
+      {% if notification.data.project_title %}<li>Projekt: <strong>{{ notification.data.project_title }}</strong></li>{% endif %}
+      {% if notification.data.updated_by %}<li>Aktualisiert von: <strong>{{ notification.data.updated_by }}</strong></li>{% endif %}
+    </ul>
+    {% endif %}
+    <hr style="border: none; border-top: 1px solid #e4e4e7; margin: 24px 0;" />
+    <p style="font-size: 12px; color: #a1a1aa;">
+      Sie erhalten diese E-Mail, weil Sie für diese Benachrichtigung im BenGER-Profil eine E-Mail-Zustellung aktiviert haben.
+      Sie können dies in den <em>Benachrichtigungseinstellungen</em> ändern.
+    </p>
+  </body>
+</html>

--- a/services/shared/email_templates/template_map.py
+++ b/services/shared/email_templates/template_map.py
@@ -1,0 +1,39 @@
+"""Notification email template lookup. Single source of truth for both
+services/api/services/email/email_service.py and
+services/workers/email_service.py — previously each had its own copy that
+had drifted (worker map missing korrektur_assigned, keys typed differently
+because the worker hydrates `notification.type` as a plain string).
+"""
+
+from typing import Union
+
+from models import NotificationType
+
+DEFAULT_TEMPLATE = "default_notification.html"
+
+# Keys are NotificationType.value strings. Anything not in this map falls
+# back to DEFAULT_TEMPLATE, which renders notification.title + .message.
+_TEMPLATE_BY_TYPE: dict[str, str] = {
+    NotificationType.TASK_ASSIGNED.value: "task_assigned.html",
+    NotificationType.KORREKTUR_ASSIGNED.value: "korrektur_assigned.html",
+    NotificationType.ANNOTATION_COMPLETED.value: "annotation_completed.html",
+    NotificationType.EVALUATION_COMPLETED.value: "evaluation_completed.html",
+    NotificationType.LLM_GENERATION_COMPLETED.value: "llm_generation_completed.html",
+    NotificationType.DATA_IMPORT_SUCCESS.value: "data_import_success.html",
+    NotificationType.DATA_UPLOAD_COMPLETED.value: "data_import_success.html",
+    NotificationType.ORGANIZATION_INVITATION_SENT.value: "organization_invite.html",
+    NotificationType.PROJECT_UPDATED.value: "project_updated.html",
+    NotificationType.PROJECT_SHARED.value: "project_shared.html",
+}
+
+
+def template_for(notification_type: Union[NotificationType, str, None]) -> str:
+    """Return the template filename for a notification type. Accepts the
+    enum (API side) or a bare string (worker hydrates from JSON)."""
+    if hasattr(notification_type, "value"):
+        key = notification_type.value
+    elif isinstance(notification_type, str):
+        key = notification_type
+    else:
+        return DEFAULT_TEMPLATE
+    return _TEMPLATE_BY_TYPE.get(key, DEFAULT_TEMPLATE)

--- a/services/shared/models.py
+++ b/services/shared/models.py
@@ -1229,7 +1229,7 @@ class UserNotificationPreference(Base):
     id = Column(String, primary_key=True, index=True)
     user_id = Column(String, ForeignKey("users.id"), nullable=False)
     notification_type = Column(String, nullable=False)
-    email_enabled = Column(Boolean, nullable=False, default=True)
+    email_enabled = Column(Boolean, nullable=False, default=False)
     in_app_enabled = Column(Boolean, nullable=False, default=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
@@ -1245,7 +1245,11 @@ class UserNotificationPreference(Base):
     )
 
     def __repr__(self):
-        return f"<UserNotificationPreference(user_id={self.user_id}, type={self.notification_type}, enabled={self.enabled})>"
+        return (
+            f"<UserNotificationPreference(user_id={self.user_id}, "
+            f"type={self.notification_type}, "
+            f"in_app={self.in_app_enabled}, email={self.email_enabled})>"
+        )
 
 
 class SyncStatus(str, Enum):

--- a/services/workers/email_service.py
+++ b/services/workers/email_service.py
@@ -12,7 +12,8 @@ from typing import Any, Dict, List, Optional
 
 from jinja2 import Environment, FileSystemLoader
 
-from models import Notification, NotificationType
+from email_templates.template_map import template_for
+from models import Notification
 from sendgrid_client import SendGridClient
 
 logger = logging.getLogger(__name__)
@@ -136,19 +137,16 @@ class EmailService:
 
 
         # notification.type can be a NotificationType enum OR a plain
-        # string (the worker's send_notification_batch_task hydrates an
-        # unattached Notification with `type=notif_dict["type"]` where
-        # the dict value is a string from the JSON payload — SQLAlchemy
-        # doesn't auto-coerce until commit, and we never add this
-        # instance to the session). Normalize once here.
-        if hasattr(notification.type, "value"):
-            type_value = notification.type.value
-        elif isinstance(notification.type, str):
-            type_value = notification.type
-        else:
-            type_value = "general"
+        # string (send_notification_batch_task hydrates an unattached
+        # Notification with `type=notif_dict["type"]` from the JSON
+        # payload; SQLAlchemy doesn't coerce until commit and we never
+        # add this instance to the session). template_for() handles both.
+        type_value = (
+            notification.type.value
+            if hasattr(notification.type, "value")
+            else (notification.type if isinstance(notification.type, str) else "general")
+        )
 
-        # Build template context
         template_context = {
             "notification": notification,
             "notification_type": type_value,
@@ -156,24 +154,7 @@ class EmailService:
             **(context or {}),
         }
 
-        # Select template based on notification type. Pre-consolidation
-        # this referenced TASK_CREATED / TASK_COMPLETED — those names
-        # never existed on the canonical (API-side) NotificationType
-        # enum, so any NotificationType.TASK_CREATED lookup raised
-        # AttributeError. With /shared/models.py canonical the enum
-        # values are TASK_ASSIGNED + ANNOTATION_COMPLETED. Key the map
-        # by string value (`.value`) rather than enum object so a plain
-        # string `notification.type` (see above) also resolves.
-        template_map = {
-            NotificationType.TASK_ASSIGNED.value: "task_assigned.html",
-            NotificationType.ANNOTATION_COMPLETED.value: "annotation_completed.html",
-            NotificationType.ORGANIZATION_INVITATION_SENT.value: "organization_invite.html",
-            NotificationType.DATA_UPLOAD_COMPLETED.value: "data_import_success.html",
-            NotificationType.EVALUATION_COMPLETED.value: "evaluation_completed.html",
-            NotificationType.LLM_GENERATION_COMPLETED.value: "llm_generation_completed.html",
-        }
-
-        template_name = template_map.get(type_value, "default_notification.html")
+        template_name = template_for(notification.type)
 
         try:
             # Render template

--- a/services/workers/notification_service.py
+++ b/services/workers/notification_service.py
@@ -152,8 +152,10 @@ class NotificationService:
         channel: str,
     ) -> bool:
         """Check whether a specific channel ('in_app' or 'email') is
-        enabled for the given notification type. Defaults to True when
-        no preference row is recorded — matches API-side semantics in
+        enabled for the given notification type.
+
+        Default when no preference row exists: in-app on, email off —
+        email is opt-in. Matches API-side semantics in
         services/api/services/email/notification_service.py:_user_wants_channel.
 
         Worker's tasks.py (in the send_notification_batch task) calls
@@ -183,12 +185,12 @@ class NotificationService:
             ).first()
         except Exception as e:
             logger.warning(
-                f"_user_wants_channel: pref lookup failed ({e}); defaulting to True"
+                f"_user_wants_channel: pref lookup failed ({e}); defaulting to in_app only"
             )
-            return True
+            return channel == "in_app"
 
         if row is None:
-            return True
+            return channel == "in_app"
         if channel == "in_app":
             return bool(row[0])
         if channel == "email":


### PR DESCRIPTION
## Summary

Two independent topics ready to ship together — neither blocks the other and both have unit/integration coverage.

### 1. Notifications (`fix(notifications)`, commit 4a876cf)

Sebastian woke up to a batch of overnight emails whose body was literally `Notification from BenGER`. The notification settings page also wouldn't persist toggles across a refresh.

- **Empty emails**: the worker's `template_map` referenced 6 `.html` files that didn't exist on disk; Jinja2 raised `TemplateNotFound` and `_render_template` fell through to a hardcoded fallback. Created the 7 missing templates (`evaluation_completed`, `llm_generation_completed`, `annotation_completed`, `data_import_success`, `organization_invite`, `project_updated`, `project_shared`) under `services/shared/email_templates/email/`.
- **Single source of truth**: moved the template lookup into `services/shared/email_templates/template_map.py`. Both API and worker `email_service` now import `template_for()` — eliminates the drift that left the worker map missing `KORREKTUR_ASSIGNED` and using `.value` strings while the API used enum keys.
- **Settings persistence**: `handleSavePreferences()` was collapsing the per-channel `{enabled, in_app, email}` state to `{type: bool}` before POSTing. The backend's legacy-bool branch then set both channels to that single value, so toggling email off was silently lost. Now sends the full dict and reloads after save.
- **Email off by default**: `_user_wants_channel` (API + worker), `get_user_preferences` default, and `UserNotificationPreference.email_enabled` column default all flipped to `False` for email — in-app stays on. Email is now opt-in per type. Existing users with explicit rows are untouched.
- **Drive-by**: `UserNotificationPreference.__repr__` referenced a nonexistent `self.enabled` field and would have `AttributeError`d on first call.

### 2. Superadmin projects narrowing (`feat(projects)`, commit d71cd7c)

`GET /api/projects` no longer surfaces every project for superadmins by default; they now see own private + public + org-scoped, matching a regular user. A new `include_all_private=true` query param restores the legacy surface, exposed on the projects page as a superadmin-only ToggleSwitch (default OFF, persisted in `localStorage`).

Dashboard, generation parse-metrics, and evaluations list keep the broad superadmin view by passing `include_all_private=True` explicitly — the narrowing only applies to the projects browser.

## Test plan

- [x] API: targeted `make test-api GREP="notification_service or email_service or email_notification"` — **200/200 pass**
- [x] Workers: targeted `make test-workers GREP="notification_service or email_service"` — **69/69 pass**
- [x] Frontend: `jest --testPathPatterns=src/app/settings/notifications` — **64/64 pass** (3 suites)
- [x] Standalone Jinja2 render of all 7 new templates with realistic + empty-data payloads — clean
- [ ] Dev stack: bring up `make dev` in `benger-extended/`, toggle email off for one type, refresh — should persist; trigger an evaluation completion and confirm the email body renders the real title + message
- [ ] After merge: watch `benger-api` pod memory under leaderboard load (rebase carried the 3Gi hotfix from `489198d` forward — should not regress)
- [ ] Smoke: as a superadmin on the projects page, verify the new ToggleSwitch defaults off and that switching it on restores the legacy "see all" view

## Notes

- Rebased onto `main` to pick up `489198d fix(api): raise memory limit to 3Gi after OOM under leaderboard load` — opening this PR without the rebase would have silently reverted that hotfix.
- Merge to `main` triggers the cross-repo dispatch (`notify-extended.yml` → extended `cicd.yml deploy-prod`) — no staging gate for platform-only changes.