### PR TITLE
perf: project_summaries everywhere + worker import fix + frontend cache

### DIFF
--- a/services/api/alembic/versions/052_response_generations_cell_index.py
+++ b/services/api/alembic/versions/052_response_generations_cell_index.py
@@ -1,0 +1,51 @@
+"""Composite index on response_generations(task_id, model_id, structure_key).
+
+The generation task-status list endpoint
+(routers/generation_task_list.get_task_generation_status) bulk-fetches the
+latest ResponseGeneration row per (task_id, model_id, structure_key) for the
+current page of tasks via `DISTINCT ON`. The existing single-column index on
+`structure_key` is no help — the planner needs the leading `task_id` + `model_id`
+columns to seek into the right partition before sorting on `created_at DESC`.
+
+Adding this composite turns the per-page bulk query from a sort-and-merge over
+the whole table into an indexed range scan keyed by the page's task ids.
+
+Idempotent — guarded against re-application.
+
+Revision ID: 052_response_generations_cell_index
+Revises: 051_aggregate_summaries
+Create Date: 2026-05-20
+"""
+
+from sqlalchemy import inspect
+
+from alembic import op
+
+
+revision = "052_response_generations_cell_index"
+down_revision = "051_aggregate_summaries"
+branch_labels = None
+depends_on = None
+
+
+INDEX_NAME = "ix_response_generations_cell"
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    return index_name in {ix["name"] for ix in insp.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    if not _index_exists("response_generations", INDEX_NAME):
+        op.create_index(
+            INDEX_NAME,
+            "response_generations",
+            ["task_id", "model_id", "structure_key", "created_at"],
+        )
+
+
+def downgrade() -> None:
+    if _index_exists("response_generations", INDEX_NAME):
+        op.drop_index(INDEX_NAME, table_name="response_generations")

--- a/services/api/alembic/versions/053_hot_path_indexes.py
+++ b/services/api/alembic/versions/053_hot_path_indexes.py
@@ -1,0 +1,84 @@
+"""Indexes for hot query paths surfaced in the 2026-05-20 perf pass.
+
+Three indexes covering filter columns that the planner was previously seq-scanning
+on tables already in the seven-figure row count range:
+
+* `task_evaluations(generation_id)` — used by `/evaluations/results/*` and
+  the report endpoints to pull every evaluation row for a model's generations.
+  The model column was missing `index=True`, so the planner walked the heap.
+* `evaluation_runs(project_id, status)` — composite covering the common
+  shape `WHERE project_id = :p AND status = 'completed'` in
+  `_scored_pairs_query`, the runs router, and the leaderboard read path.
+  Single-column `project_id` index alone forced a heap walk for the
+  status predicate.
+* `response_generations(project_id, status)` — same shape as above for the
+  generation router (`/generation/responses`) and the WebSocket-fallback
+  poll. Without it, status filters on the project's full generation
+  history were O(rows-per-project).
+
+Idempotent — each index creation is guarded against re-application so the
+migration is safe to re-run.
+
+Revision ID: 053_hot_path_indexes
+Revises: 052_response_generations_cell_index
+Create Date: 2026-05-20
+"""
+
+from sqlalchemy import inspect
+
+from alembic import op
+
+
+revision = "053_hot_path_indexes"
+down_revision = "052_response_generations_cell_index"
+branch_labels = None
+depends_on = None
+
+
+def _index_exists(table: str, name: str) -> bool:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    return name in {ix["name"] for ix in insp.get_indexes(table)}
+
+
+def upgrade() -> None:
+    if not _index_exists("task_evaluations", "ix_task_evaluations_generation_id"):
+        op.create_index(
+            "ix_task_evaluations_generation_id",
+            "task_evaluations",
+            ["generation_id"],
+        )
+
+    if not _index_exists("evaluation_runs", "ix_evaluation_runs_project_status"):
+        op.create_index(
+            "ix_evaluation_runs_project_status",
+            "evaluation_runs",
+            ["project_id", "status"],
+        )
+
+    if not _index_exists(
+        "response_generations", "ix_response_generations_project_status"
+    ):
+        op.create_index(
+            "ix_response_generations_project_status",
+            "response_generations",
+            ["project_id", "status"],
+        )
+
+
+def downgrade() -> None:
+    if _index_exists(
+        "response_generations", "ix_response_generations_project_status"
+    ):
+        op.drop_index(
+            "ix_response_generations_project_status",
+            table_name="response_generations",
+        )
+    if _index_exists("evaluation_runs", "ix_evaluation_runs_project_status"):
+        op.drop_index(
+            "ix_evaluation_runs_project_status", table_name="evaluation_runs"
+        )
+    if _index_exists("task_evaluations", "ix_task_evaluations_generation_id"):
+        op.drop_index(
+            "ix_task_evaluations_generation_id", table_name="task_evaluations"
+        )

--- a/services/api/alembic/versions/054_next_task_indexes.py
+++ b/services/api/alembic/versions/054_next_task_indexes.py
@@ -1,0 +1,67 @@
+"""Composite indexes for the auto-mode `/projects/{id}/next` selector.
+
+The handler at `routers/projects/tasks.py:get_next_task` builds candidate-task
+SQL by NOT-IN'ing two subqueries:
+
+* The set of annotations the current user already submitted for this project
+  (filtered on `project_id` and `was_cancelled`).
+* The set of tasks whose assignment count for this project is at the
+  per-task ceiling (filtered on `project_id` and `status`).
+
+Both subqueries previously had only single-column indexes on `project_id`, so
+adding the status / was_cancelled predicate forced a heap walk. On a busy
+labeling project (10k+ annotations, 50 active annotators) this fires every
+~5 s — i.e. once per task cycle per annotator — and was a non-trivial
+share of the auto-mode response time.
+
+Two narrow composite indexes match the planner's preferred shape.
+
+Idempotent — each `CREATE INDEX` is guarded so re-running is safe.
+
+Revision ID: 054_next_task_indexes
+Revises: 053_hot_path_indexes
+Create Date: 2026-05-20
+"""
+
+from sqlalchemy import inspect
+
+from alembic import op
+
+
+revision = "054_next_task_indexes"
+down_revision = "053_hot_path_indexes"
+branch_labels = None
+depends_on = None
+
+
+def _index_exists(table: str, name: str) -> bool:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    return name in {ix["name"] for ix in insp.get_indexes(table)}
+
+
+def upgrade() -> None:
+    if not _index_exists("annotations", "ix_annotations_project_cancelled"):
+        op.create_index(
+            "ix_annotations_project_cancelled",
+            "annotations",
+            ["project_id", "was_cancelled"],
+        )
+
+    if not _index_exists("task_assignments", "ix_task_assignments_task_status"):
+        op.create_index(
+            "ix_task_assignments_task_status",
+            "task_assignments",
+            ["task_id", "status"],
+        )
+
+
+def downgrade() -> None:
+    if _index_exists("task_assignments", "ix_task_assignments_task_status"):
+        op.drop_index(
+            "ix_task_assignments_task_status", table_name="task_assignments"
+        )
+    if _index_exists("annotations", "ix_annotations_project_cancelled"):
+        op.drop_index(
+            "ix_annotations_project_cancelled", table_name="annotations"
+        )

--- a/services/api/alembic/versions/055_completed_generations_summary.py
+++ b/services/api/alembic/versions/055_completed_generations_summary.py
@@ -1,0 +1,54 @@
+"""Add `completed_response_generations_count` column to `project_summaries`.
+
+The projects-list endpoint still ran two grouped queries on `generations` and
+`response_generations` for every list render (via
+`calculate_generation_stats_batch`) because `project_summaries` had a total
+`response_generations_count` but no equivalent that's narrowed to
+`status = 'completed'`. The progress mix on the dashboard tile needs the
+completed count, so we couldn't drop the live query without losing accuracy.
+
+This migration adds the column. The worker compute function in
+`services/api/services/aggregate_summaries.py` populates it; the API
+helper reads it instead of the live `.count()`.
+
+Idempotent — column add is guarded.
+
+Revision ID: 055_completed_generations_summary
+Revises: 054_next_task_indexes
+Create Date: 2026-05-20
+"""
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from alembic import op
+
+
+revision = "055_completed_generations_summary"
+down_revision = "054_next_task_indexes"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table: str, column: str) -> bool:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    return column in {c["name"] for c in insp.get_columns(table)}
+
+
+def upgrade() -> None:
+    if not _column_exists("project_summaries", "completed_response_generations_count"):
+        op.add_column(
+            "project_summaries",
+            sa.Column(
+                "completed_response_generations_count",
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("0"),
+            ),
+        )
+
+
+def downgrade() -> None:
+    if _column_exists("project_summaries", "completed_response_generations_count"):
+        op.drop_column("project_summaries", "completed_response_generations_count")

--- a/services/api/alembic/versions/056_notifications_cursor_index.py
+++ b/services/api/alembic/versions/056_notifications_cursor_index.py
@@ -1,0 +1,55 @@
+"""Composite index supporting the notifications SSE cursor query.
+
+The cursor query from `routers/notifications.py:stream_notifications` is:
+
+    SELECT ... FROM notifications
+    WHERE user_id = :uid
+      AND ((created_at > :cdt) OR (created_at = :cdt AND id > :cid))
+    ORDER BY created_at ASC, id ASC
+    LIMIT 50
+
+Notifications had no index on `user_id` at all (just the PK on `id`), so
+every SSE poll did a full-table scan + sort. A composite on
+`(user_id, created_at, id)` is exactly the planner's preferred shape — it
+supports both the `WHERE user_id = ?` predicate and the `ORDER BY
+created_at, id` so the LIMIT can stop early without a sort step.
+
+Idempotent — guarded against re-application.
+
+Revision ID: 056_notifications_cursor_index
+Revises: 055_completed_generations_summary
+Create Date: 2026-05-20
+"""
+
+from sqlalchemy import inspect
+
+from alembic import op
+
+
+revision = "056_notifications_cursor_index"
+down_revision = "055_completed_generations_summary"
+branch_labels = None
+depends_on = None
+
+
+INDEX_NAME = "ix_notifications_user_created_id"
+
+
+def _index_exists(table: str, name: str) -> bool:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    return name in {ix["name"] for ix in insp.get_indexes(table)}
+
+
+def upgrade() -> None:
+    if not _index_exists("notifications", INDEX_NAME):
+        op.create_index(
+            INDEX_NAME,
+            "notifications",
+            ["user_id", "created_at", "id"],
+        )
+
+
+def downgrade() -> None:
+    if _index_exists("notifications", INDEX_NAME):
+        op.drop_index(INDEX_NAME, table_name="notifications")

--- a/services/api/routers/dashboard.py
+++ b/services/api/routers/dashboard.py
@@ -18,7 +18,7 @@ from routers.projects.helpers import (
     _scored_pairs_query,
     get_accessible_project_ids,
 )
-from services.aggregate_summaries import read_dashboard_sum
+from aggregate_summaries import read_dashboard_sum
 
 logger = logging.getLogger(__name__)
 

--- a/services/api/routers/evaluations/results.py
+++ b/services/api/routers/evaluations/results.py
@@ -932,20 +932,35 @@ async def get_results_by_task_model(
             if model_id not in model_name_map:
                 model_name_map[model_id] = model_id
 
-        # Get task data for previews
+        # Task previews — push the SUBSTRING into SQL so we don't load every
+        # `tasks.data` JSON blob (often 1–5KB each) into Python just to keep
+        # the first 100 characters of `text`/`content`. For a 10k-task project
+        # the old shape pulled tens of MB across the wire to discard 99 % of it.
+        from sqlalchemy import cast as sa_cast, func as sa_func
+        from sqlalchemy.dialects.postgresql import JSONB as PG_JSONB
+
         all_task_ids = list(set(
             [r.task_id for r in sample_results if r.task_id]
             + [r.task_id for r in annotation_eval_results if r.task_id]
         ))
-        tasks_data = db.query(Task).filter(Task.id.in_(all_task_ids)).all() if all_task_ids else []
-        task_preview_map = {}
-        for task in tasks_data:
-            preview = ""
-            if task.data:
-                text = task.data.get("text", "") or task.data.get("content", "")
-                if text:
-                    preview = text[:100] + "..." if len(text) > 100 else text
-            task_preview_map[task.id] = preview
+        task_preview_map: dict = {}
+        if all_task_ids:
+            jsonb_data = sa_cast(Task.data, PG_JSONB)
+            text_expr = sa_func.coalesce(
+                jsonb_data.op("->>")("text"),
+                jsonb_data.op("->>")("content"),
+                "",
+            )
+            preview_rows = (
+                db.query(Task.id, sa_func.left(text_expr, 100), sa_func.length(text_expr))
+                .filter(Task.id.in_(all_task_ids))
+                .all()
+            )
+            for tid, head, total_len in preview_rows:
+                head = head or ""
+                task_preview_map[tid] = (
+                    head + "..." if total_len and total_len > 100 else head
+                )
 
         # Build task-model score matrix.
         # When aggregate_mean is on, multiple rows can share the same
@@ -1168,23 +1183,47 @@ def _get_task_data_availability(db, task_ids: list) -> tuple:
 
 
 def _build_all_tasks_response(db, project_id: str) -> list:
-    """Build task list with data availability info for all tasks in a project."""
-    all_tasks = db.query(Task.id, Task.data).filter(Task.project_id == project_id).all()
-    all_task_ids = [t.id for t in all_tasks]
+    """Build task list with data availability info for all tasks in a project.
+
+    Previously this loaded `Task.data` (1–5KB JSON per row) for every task in
+    the project — tens of MB streamed across the wire for a large project to
+    extract a 100-character preview that the SQL engine can produce itself.
+    The new query asks Postgres for the preview string directly and keeps
+    `Task.data` server-side.
+    """
+    from sqlalchemy import cast as sa_cast, func as sa_func
+    from sqlalchemy.dialects.postgresql import JSONB as PG_JSONB
+
+    jsonb_data = sa_cast(Task.data, PG_JSONB)
+    # Mirrors _get_task_preview key-precedence: input → text → question → prompt → content.
+    preview_text = sa_func.coalesce(
+        jsonb_data.op("->>")("input"),
+        jsonb_data.op("->>")("text"),
+        jsonb_data.op("->>")("question"),
+        jsonb_data.op("->>")("prompt"),
+        jsonb_data.op("->>")("content"),
+        "",
+    )
+    rows = (
+        db.query(Task.id, sa_func.left(preview_text, 100))
+        .filter(Task.project_id == project_id)
+        .all()
+    )
+    all_task_ids = [tid for tid, _ in rows]
     tasks_with_annotations, gen_model_by_task, annot_displays_by_task = (
         _get_task_data_availability(db, all_task_ids)
     )
 
     return [
         {
-            "task_id": t.id,
-            "task_preview": _get_task_preview(t.data),
+            "task_id": tid,
+            "task_preview": preview or "",
             "scores": {},
-            "has_annotation": t.id in tasks_with_annotations,
-            "generation_models": list(gen_model_by_task.get(t.id, set())),
-            "annotator_columns": list(annot_displays_by_task.get(t.id, set())),
+            "has_annotation": tid in tasks_with_annotations,
+            "generation_models": list(gen_model_by_task.get(tid, set())),
+            "annotator_columns": list(annot_displays_by_task.get(tid, set())),
         }
-        for t in all_tasks
+        for tid, preview in rows
     ]
 
 

--- a/services/api/routers/generation.py
+++ b/services/api/routers/generation.py
@@ -610,8 +610,50 @@ async def get_parse_metrics(
         if model_id:
             query = query.filter(DBLLMResponse.model_id == model_id)
 
-        # Count by parse status
-        total = query.count()
+        # All five counts in one aggregation pass — previously ran as five
+        # separate `query.filter(...).count()` calls, each a full scan of
+        # the filtered set. `SUM(CASE WHEN ...)` collapses them to one row.
+        from sqlalchemy import case as sa_case, func as sa_func
+
+        agg_row = query.with_entities(
+            sa_func.count(DBLLMResponse.id).label("total"),
+            sa_func.coalesce(
+                sa_func.sum(
+                    sa_case((DBLLMResponse.parse_status == "success", 1), else_=0)
+                ),
+                0,
+            ).label("success"),
+            sa_func.coalesce(
+                sa_func.sum(
+                    sa_case((DBLLMResponse.parse_status == "failed", 1), else_=0)
+                ),
+                0,
+            ).label("failed"),
+            sa_func.coalesce(
+                sa_func.sum(
+                    sa_case(
+                        (DBLLMResponse.parse_status == "validation_error", 1),
+                        else_=0,
+                    )
+                ),
+                0,
+            ).label("validation_error"),
+            sa_func.coalesce(
+                sa_func.sum(
+                    sa_case(
+                        (DBLLMResponse.status == "parse_failed_max_retries", 1),
+                        else_=0,
+                    )
+                ),
+                0,
+            ).label("max_retries"),
+        ).one()
+
+        total = int(agg_row.total or 0)
+        success = int(agg_row.success or 0)
+        failed = int(agg_row.failed or 0)
+        validation_error = int(agg_row.validation_error or 0)
+        max_retries = int(agg_row.max_retries or 0)
 
         if total == 0:
             return {
@@ -625,37 +667,39 @@ async def get_parse_metrics(
                 "common_parse_errors": [],
             }
 
-        success = query.filter(DBLLMResponse.parse_status == "success").count()
-        failed = query.filter(DBLLMResponse.parse_status == "failed").count()
-        validation_error = query.filter(DBLLMResponse.parse_status == "validation_error").count()
-
-        # Count generations that hit max retries
-        # Status would be "parse_failed_max_retries" if that status exists
-        max_retries = query.filter(DBLLMResponse.status == "parse_failed_max_retries").count()
-
-        # Calculate average retries for successful parses
-        successful_gens = query.filter(DBLLMResponse.parse_status == "success").all()
+        # Average retries for successful parses — fetch only the column we
+        # need, not the full row (parse_metadata can be a heavy JSON blob).
         avg_retries = 0
-        if successful_gens:
-            total_retries = sum(
-                gen.parse_metadata.get("retry_count", 1) if gen.parse_metadata else 1
-                for gen in successful_gens
+        if success:
+            metadata_rows = (
+                query.filter(DBLLMResponse.parse_status == "success")
+                .with_entities(DBLLMResponse.parse_metadata)
+                .all()
             )
-            avg_retries = total_retries / len(successful_gens)
+            total_retries = sum(
+                (md or {}).get("retry_count", 1) for (md,) in metadata_rows
+            )
+            avg_retries = total_retries / len(metadata_rows) if metadata_rows else 0
 
-        # Get common parse errors
-        failed_gens = query.filter(
-            DBLLMResponse.parse_status.in_(["failed", "validation_error"])
-        ).all()
-        error_counts = {}
-        for gen in failed_gens:
-            error = gen.parse_error or "Unknown error"
-            error_counts[error] = error_counts.get(error, 0) + 1
-
-        common_errors = [
-            {"error": error, "count": count}
-            for error, count in sorted(error_counts.items(), key=lambda x: x[1], reverse=True)[:5]
-        ]
+        # Common parse errors — group in SQL instead of streaming every
+        # failed row to Python. ORDER BY DESC + LIMIT keeps the top-5 in
+        # the database.
+        error_rows = (
+            query.filter(
+                DBLLMResponse.parse_status.in_(["failed", "validation_error"])
+            )
+            .with_entities(
+                sa_func.coalesce(DBLLMResponse.parse_error, "Unknown error").label(
+                    "error"
+                ),
+                sa_func.count(DBLLMResponse.id).label("count"),
+            )
+            .group_by("error")
+            .order_by(sa_func.count(DBLLMResponse.id).desc())
+            .limit(5)
+            .all()
+        )
+        common_errors = [{"error": e, "count": int(c)} for e, c in error_rows]
 
         return {
             "total_generations": total,

--- a/services/api/routers/generation_task_list.py
+++ b/services/api/routers/generation_task_list.py
@@ -182,10 +182,108 @@ def get_project_with_permissions(
     return project
 
 
+def _status_from_row(
+    row: DBResponseGeneration,
+    *,
+    task_id: str,
+    model_id: str,
+    structure_key: Optional[str],
+) -> TaskGenerationStatus:
+    """Materialize a TaskGenerationStatus from a ResponseGeneration row.
+
+    The cell coordinates are passed explicitly rather than read off the row
+    so the returned status carries the *requested* cell label even when
+    the row matched on the NULL-structure_key legacy fallback.
+    """
+    result_preview = None
+    if row.status == "completed" and row.result:
+        result_str = (
+            json.dumps(row.result)
+            if isinstance(row.result, dict)
+            else str(row.result)
+        )
+        result_preview = result_str[:100] + "..." if len(result_str) > 100 else result_str
+
+    return TaskGenerationStatus(
+        task_id=task_id,
+        model_id=model_id,
+        structure_key=structure_key,
+        status=row.status,
+        generation_id=row.id,
+        generated_at=row.completed_at or row.created_at,
+        error_message=row.error_message if row.status == "failed" else None,
+        result_preview=result_preview,
+        runs_requested=getattr(row, "runs_requested", None),
+        runs_completed=getattr(row, "runs_completed", None),
+        runs_failed=getattr(row, "runs_failed", None),
+    )
+
+
+def _bulk_latest_generations(
+    db: Session,
+    project_id: str,
+    task_ids: List[str],
+    model_ids: List[str],
+) -> Dict[tuple, DBResponseGeneration]:
+    """Latest ResponseGeneration row per (task_id, model_id, structure_key) for
+    the given page of tasks. Returns {(task_id, model_id, structure_key): row}.
+
+    Backed by the composite index added in migration 052
+    (`ix_response_generations_cell`). One round-trip replaces the per-cell
+    SELECT loop in `get_task_generation_status`.
+    """
+    if not task_ids or not model_ids:
+        return {}
+
+    rows = (
+        db.query(DBResponseGeneration)
+        .filter(
+            DBResponseGeneration.project_id == project_id,
+            DBResponseGeneration.task_id.in_(task_ids),
+            DBResponseGeneration.model_id.in_(model_ids),
+        )
+        .distinct(
+            DBResponseGeneration.task_id,
+            DBResponseGeneration.model_id,
+            DBResponseGeneration.structure_key,
+        )
+        .order_by(
+            DBResponseGeneration.task_id,
+            DBResponseGeneration.model_id,
+            DBResponseGeneration.structure_key,
+            DBResponseGeneration.created_at.desc(),
+        )
+        .all()
+    )
+    return {(r.task_id, r.model_id, r.structure_key): r for r in rows}
+
+
+def _resolve_cell(
+    bulk: Dict[tuple, DBResponseGeneration],
+    task_id: str,
+    model_id: str,
+    structure_key: Optional[str],
+) -> Optional[DBResponseGeneration]:
+    """Look up the latest row for a (task, model, structure) cell, falling
+    back to a legacy NULL-structure row when the exact key is missing.
+
+    Mirrors the case-ordering in the old per-cell query: prefer the exact
+    match, accept the NULL row as a last resort.
+    """
+    exact = bulk.get((task_id, model_id, structure_key))
+    if exact is not None:
+        return exact
+    if structure_key is not None:
+        return bulk.get((task_id, model_id, None))
+    return None
+
+
 def get_single_task_generation_status(
     task_id: str, model_id: str, structure_key: Optional[str], db: Session
 ) -> TaskGenerationStatus:
-    """Get generation status for a specific task-model-structure combination"""
+    """Per-cell helper kept for compatibility with code paths that only need
+    one status (e.g. tests, ad-hoc lookups). The list endpoint uses
+    `_bulk_latest_generations` to avoid the per-cell SELECT."""
 
     # Query for the most recent generation for this task-model-structure combination
     base_filter = db.query(DBResponseGeneration).filter(
@@ -211,29 +309,11 @@ def get_single_task_generation_status(
         return TaskGenerationStatus(
             task_id=task_id, model_id=model_id, structure_key=structure_key, status=None
         )
-
-    # Get preview of result if completed
-    result_preview = None
-    if generation.status == "completed" and generation.result:
-        result_str = (
-            json.dumps(generation.result)
-            if isinstance(generation.result, dict)
-            else str(generation.result)
-        )
-        result_preview = result_str[:100] + "..." if len(result_str) > 100 else result_str
-
-    return TaskGenerationStatus(
+    return _status_from_row(
+        generation,
         task_id=task_id,
         model_id=model_id,
         structure_key=structure_key,
-        status=generation.status,
-        generation_id=generation.id,
-        generated_at=generation.completed_at or generation.created_at,
-        error_message=generation.error_message if generation.status == "failed" else None,
-        result_preview=result_preview,
-        runs_requested=getattr(generation, "runs_requested", None),
-        runs_completed=getattr(generation, "runs_completed", None),
-        runs_failed=getattr(generation, "runs_failed", None),
     )
 
 
@@ -301,48 +381,91 @@ async def get_task_generation_status(
         escaped_search = search.replace('%', r'\%').replace('_', r'\_')
         query = query.filter(func.cast(Task.data, String).ilike(f"%{escaped_search}%"))
 
-    # When status_filter is set, we must check generation status per task before
-    # paginating (status lives outside the tasks table). Load all matching tasks
-    # first, filter, then paginate in Python.
-    if status_filter:
+    if status_filter and status_filter != "not_generated":
+        # Narrow the task set to ids that have at least one cell whose *latest*
+        # row matches `status_filter`. Done as a CTE-like subquery so the outer
+        # task scan keeps its pagination shape — no need to load every matching
+        # task into memory like the legacy code did.
+        latest_subq = (
+            db.query(
+                DBResponseGeneration.task_id.label("task_id"),
+                DBResponseGeneration.status.label("status"),
+            )
+            .filter(
+                DBResponseGeneration.project_id == project_id,
+                DBResponseGeneration.model_id.in_(model_ids),
+            )
+            .distinct(
+                DBResponseGeneration.task_id,
+                DBResponseGeneration.model_id,
+                DBResponseGeneration.structure_key,
+            )
+            .order_by(
+                DBResponseGeneration.task_id,
+                DBResponseGeneration.model_id,
+                DBResponseGeneration.structure_key,
+                DBResponseGeneration.created_at.desc(),
+            )
+            .subquery()
+        )
+        matching_ids_subq = (
+            db.query(latest_subq.c.task_id)
+            .filter(latest_subq.c.status == status_filter)
+            .distinct()
+        )
+        query = query.filter(Task.id.in_(matching_ids_subq))
+        total = query.count()
+        offset = (page - 1) * page_size
+        tasks = query.offset(offset).limit(page_size).all()
+    elif status_filter == "not_generated":
+        # "Missing somewhere" can't be expressed cleanly in SQL (we need to
+        # enumerate (task, model, structure) absences). Load all candidate
+        # tasks once, bulk-fetch their latest rows, filter, paginate. Single
+        # bulk query instead of per-cell SELECTs.
         tasks = query.all()
     else:
         total = query.count()
         offset = (page - 1) * page_size
         tasks = query.offset(offset).limit(page_size).all()
 
-    # Build response with generation status for each task
+    # Bulk-fetch latest ResponseGeneration rows for the resolved task page in
+    # one round-trip — replaces the per-cell loop that fired
+    # `rows × models × structures` SELECTs.
+    page_task_ids = [t.id for t in tasks]
+    bulk = _bulk_latest_generations(db, project_id, page_task_ids, model_ids)
+
     task_responses = []
     for task in tasks:
-        # Get generation status for each model-structure combination
         generation_status = {}
         for model_id in model_ids:
             model_statuses = []
             for structure_key in structure_keys:
-                task_status = get_single_task_generation_status(
-                    task.id, model_id, structure_key, db
-                )
-                model_statuses.append(task_status.model_dump() if task_status else None)
+                row = _resolve_cell(bulk, task.id, model_id, structure_key)
+                if row is None:
+                    status_obj = TaskGenerationStatus(
+                        task_id=task.id,
+                        model_id=model_id,
+                        structure_key=structure_key,
+                        status=None,
+                    )
+                else:
+                    status_obj = _status_from_row(
+                        row,
+                        task_id=task.id,
+                        model_id=model_id,
+                        structure_key=structure_key,
+                    )
+                model_statuses.append(status_obj.model_dump())
             generation_status[model_id] = model_statuses
 
-        # Apply status filter if provided
-        if status_filter:
-            if status_filter == "not_generated":
-                has_matching_status = any(
-                    any(
-                        not status_obj or status_obj.get('status') is None
-                        for status_obj in statuses_list
-                    )
-                    for statuses_list in generation_status.values()
+        if status_filter == "not_generated":
+            has_matching_status = any(
+                any(
+                    not status_obj or status_obj.get('status') is None
+                    for status_obj in statuses_list
                 )
-            else:
-                has_matching_status = any(
-                    any(
-                        status_obj and status_obj.get('status') == status_filter
-                        for status_obj in statuses_list
-                    )
-                    for statuses_list in generation_status.values()
-                )
+                for statuses_list in generation_status.values()
+            )
             if not has_matching_status:
                 continue
 
@@ -356,8 +479,7 @@ async def get_task_generation_status(
             )
         )
 
-    # When status_filter is active, paginate the filtered results in Python
-    if status_filter:
+    if status_filter == "not_generated":
         total = len(task_responses)
         offset = (page - 1) * page_size
         task_responses = task_responses[offset : offset + page_size]

--- a/services/api/routers/leaderboards.py
+++ b/services/api/routers/leaderboards.py
@@ -370,7 +370,7 @@ async def get_llm_leaderboard(
     - computed_at: ISO timestamp of the precomputed snapshot
                    (null for live-aggregation responses)
     """
-    from services.aggregate_summaries import (
+    from aggregate_summaries import (
         live_aggregate_leaderboard,
         read_llm_leaderboard,
     )
@@ -542,7 +542,7 @@ async def get_llm_model_details(
     - last_evaluated: ISO of the most recent EvaluationRun completion
     - computed_at: When the precomputed snapshot was built (null for live)
     """
-    from services.aggregate_summaries import (
+    from aggregate_summaries import (
         live_aggregate_leaderboard,
         read_llm_model_aggregate,
     )
@@ -652,7 +652,7 @@ async def compare_llm_models(
         return {"error": "Please provide 2-5 model IDs for comparison"}
 
     from models import LLMLeaderboardScore
-    from services.aggregate_summaries import live_aggregate_leaderboard
+    from aggregate_summaries import live_aggregate_leaderboard
 
     org_context = get_org_context_from_request(request)
     project_ids = _filter_accessible_project_ids(db, current_user, project_ids, org_context)

--- a/services/api/routers/notifications.py
+++ b/services/api/routers/notifications.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
+from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
 
 from auth_module import User, require_user
@@ -299,8 +300,16 @@ async def notification_stream(request: Request, current_user: User = Depends(req
             # Send initial connection confirmation
             yield f"data: {json.dumps({'type': 'connected', 'message': 'Notification stream connected'})}\n\n"
 
-            # Track last notification timestamp to avoid duplicates
-            last_check = None
+            # Cursor-based delivery: track the highest `created_at + id` we've
+            # already pushed and only ask the DB for rows strictly newer than
+            # that. The previous implementation pulled the full unread set
+            # every 2 s and discarded duplicates in Python — on a user with
+            # 500+ unread it kept doing a full scan-and-discard loop while
+            # the SSE connection stayed open.
+            from models import Notification
+
+            cursor_dt = None
+            cursor_id: Optional[str] = None
 
             # Add counter to prevent infinite loops
             loop_count = 0
@@ -313,43 +322,75 @@ async def notification_stream(request: Request, current_user: User = Depends(req
                     break
 
                 try:
-                    # Create a new database session for each query to avoid holding connections
                     db_session = None
+                    new_notifications = []
                     try:
                         db_session = next(get_db())
-                        # Get recent unread notifications
-                        notifications = NotificationService.get_user_notifications(
-                            db=db_session,
-                            user_id=current_user.id,
-                            limit=10,
-                            offset=0,
-                            unread_only=True,
-                        )
-                    finally:
-                        # Always close the database session
-                        if db_session:
-                            db_session.close()
-
-                    # Filter new notifications if we have a timestamp
-                    new_notifications = []
-                    if last_check:
-                        new_notifications = [n for n in notifications if n.created_at > last_check]
-                    else:
-                        # First check - send actual unread count
-                        db_session = None
-                        try:
-                            db_session = next(get_db())
+                        if cursor_dt is None:
+                            # First iteration — send the current unread count
+                            # so the badge syncs without us touching the
+                            # unread list. Set the cursor to "now" via the
+                            # newest existing notification so subsequent
+                            # polls only fetch genuinely new rows.
                             actual_unread_count = NotificationService.get_unread_count(
                                 db=db_session, user_id=current_user.id
                             )
-                            count_data = {
-                                "type": "unread_count",
-                                "count": actual_unread_count,
-                            }
-                            yield f"data: {json.dumps(count_data)}\n\n"
-                        finally:
-                            if db_session:
-                                db_session.close()
+                            yield (
+                                "data: "
+                                + json.dumps(
+                                    {
+                                        "type": "unread_count",
+                                        "count": actual_unread_count,
+                                    }
+                                )
+                                + "\n\n"
+                            )
+                            newest = (
+                                db_session.query(Notification)
+                                .filter(Notification.user_id == current_user.id)
+                                .order_by(
+                                    Notification.created_at.desc(),
+                                    Notification.id.desc(),
+                                )
+                                .first()
+                            )
+                            if newest is not None:
+                                cursor_dt = newest.created_at
+                                cursor_id = newest.id
+                            else:
+                                # No rows yet — set cursor to "infinitely old"
+                                # so the first real arrival passes the > test.
+                                from datetime import datetime, timezone
+
+                                cursor_dt = datetime(1970, 1, 1, tzinfo=timezone.utc)
+                                cursor_id = ""
+                        else:
+                            # Subsequent iterations — strict tuple comparison
+                            # (created_at, id) > (cursor_dt, cursor_id). The
+                            # tie-break on id keeps us correct when two rows
+                            # land in the same millisecond.
+                            new_notifications = (
+                                db_session.query(Notification)
+                                .filter(
+                                    Notification.user_id == current_user.id,
+                                    or_(
+                                        Notification.created_at > cursor_dt,
+                                        and_(
+                                            Notification.created_at == cursor_dt,
+                                            Notification.id > cursor_id,
+                                        ),
+                                    ),
+                                )
+                                .order_by(
+                                    Notification.created_at.asc(),
+                                    Notification.id.asc(),
+                                )
+                                .limit(50)
+                                .all()
+                            )
+                    finally:
+                        if db_session:
+                            db_session.close()
 
                     # Send new notifications
                     for notification in new_notifications:
@@ -361,16 +402,14 @@ async def notification_stream(request: Request, current_user: User = Depends(req
                                 "title": notification.title,
                                 "message": notification.message,
                                 "data": notification.data,
-                                "is_read": False,
+                                "is_read": notification.is_read,
                                 "created_at": notification.created_at.isoformat(),
                                 "organization_id": notification.organization_id,
                             },
                         }
                         yield f"data: {json.dumps(notification_data)}\n\n"
-
-                    # Update last check timestamp
-                    if notifications:
-                        last_check = max(n.created_at for n in notifications)
+                        cursor_dt = notification.created_at
+                        cursor_id = notification.id
 
                 except Exception as e:
                     logger.error(f"Error in notification stream for user {current_user.id}: {e}")

--- a/services/api/routers/organizations.py
+++ b/services/api/routers/organizations.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import List, Optional
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 from sqlalchemy import func, text
 from sqlalchemy.orm import Session
@@ -690,7 +690,19 @@ class AddUserToOrganization(BaseModel):
 
 @router.get("/manage/users", response_model=List[UserResponse])
 async def list_all_users(
-    current_user: User = Depends(get_current_user), db: Session = Depends(get_db)
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+    search: Optional[str] = Query(
+        None,
+        description=(
+            "Optional ILIKE filter against username / email / name. Pushed "
+            "to SQL so the admin tab doesn't have to load every user just "
+            "to filter in JS."
+        ),
+    ),
+    limit: int = Query(
+        500, ge=1, le=5_000, description="Safety cap on the response size."
+    ),
 ):
     """List users visible to the current user.
 
@@ -702,9 +714,11 @@ async def list_all_users(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required"
         )
 
-    if current_user.is_superadmin:
-        users = db.query(User).filter(User.is_active == True).all()
-    else:
+    from sqlalchemy import or_ as sa_or
+
+    query = db.query(User).filter(User.is_active == True)
+
+    if not current_user.is_superadmin:
         # Get user's organization IDs from the Pydantic User model
         user_org_ids = [org['id'] for org in (current_user.organizations or [])]
 
@@ -721,8 +735,20 @@ async def list_all_users(
             .distinct()
             .subquery()
         )
-        users = db.query(User).filter(User.id.in_(member_user_ids), User.is_active == True).all()
+        query = query.filter(User.id.in_(member_user_ids))
 
+    if search:
+        escaped = search.replace("%", r"\%").replace("_", r"\_")
+        like = f"%{escaped}%"
+        query = query.filter(
+            sa_or(
+                User.username.ilike(like),
+                User.email.ilike(like),
+                User.name.ilike(like),
+            )
+        )
+
+    users = query.order_by(User.created_at.desc()).limit(limit).all()
     return [UserResponse(**user.__dict__) for user in users]
 
 

--- a/services/api/routers/projects/annotations.py
+++ b/services/api/routers/projects/annotations.py
@@ -164,18 +164,25 @@ async def create_annotation(
             db, task_id=task_id, user_id=current_user.id,
         )
 
-    # Update report annotations section after annotation creation (Issue #770)
+    # Report annotation section refresh (Issue #770) — dispatch to Celery so
+    # the request thread doesn't pay for a COUNT + GROUP BY across every
+    # annotation in the project on every save. The worker reads from the
+    # same `annotations` table, so eventual consistency is exactly what the
+    # report view expects.
     try:
         import logging
 
-        from report_service import update_report_annotations_section
+        from celery_client import get_celery_app
 
         logger = logging.getLogger(__name__)
-        update_report_annotations_section(db, task.project_id)
-        logger.info(f"✅ Updated report annotations section for project {task.project_id}")
+        get_celery_app().send_task(
+            "tasks.update_report_annotations_async",
+            args=[task.project_id],
+            queue="default",
+        )
     except Exception as e:
         logger = logging.getLogger(__name__)
-        logger.error(f"Failed to update report annotations section: {e}")
+        logger.warning(f"Failed to enqueue report annotations update: {e}")
         # Don't fail the annotation creation
 
     return db_annotation
@@ -327,15 +334,20 @@ async def update_annotation(
     db.commit()
     db.refresh(db_annotation)
 
-    # Update report annotations section (silent failure to not block annotation update)
+    # Report annotation section refresh — same Celery dispatch as the create
+    # path. Update routes through the same hot edit loop, so we keep the
+    # aggregation off the request thread here too.
     try:
         import logging
 
-        from report_service import update_report_annotations_section
+        from celery_client import get_celery_app
 
         logger = logging.getLogger(__name__)
-        update_report_annotations_section(db, db_annotation.project_id)
-        logger.info(f"Updated report annotations section for project {db_annotation.project_id}")
+        get_celery_app().send_task(
+            "tasks.update_report_annotations_async",
+            args=[db_annotation.project_id],
+            queue="default",
+        )
     except Exception as e:
         import logging
 

--- a/services/api/routers/projects/assignments.py
+++ b/services/api/routers/projects/assignments.py
@@ -3,7 +3,7 @@
 import random
 import uuid
 from datetime import datetime
-from typing import Optional
+from typing import Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.orm import Session
@@ -311,10 +311,19 @@ async def assign_tasks(
                 user_assignments[assignment.user_id] = []
             user_assignments[assignment.user_id].append(assignment)
 
+        # The `user = db.query(User)...` lookup was unused in the notification
+        # body and the project's org lookup was being queried twice per
+        # iteration — fetch both up front so the fan-out is bounded.
+        project_org_row = (
+            db.query(ProjectOrganization.organization_id)
+            .filter(ProjectOrganization.project_id == project_id)
+            .first()
+        )
+        organization_id_for_notif = project_org_row[0] if project_org_row else None
+
         # Send notification to each user
         for user_id, user_tasks in user_assignments.items():
             task_count = len(user_tasks)
-            user = db.query(User).filter(User.id == user_id).first()
 
             title = f"New Task Assignment"
             if task_count == 1:
@@ -344,16 +353,7 @@ async def assign_tasks(
                     "priority": priority,
                     "due_date": due_date.isoformat() if due_date else None,
                 },
-                # Get first organization for backward compatibility
-                organization_id=(
-                    db.query(ProjectOrganization.organization_id)
-                    .filter(ProjectOrganization.project_id == project_id)
-                    .first()[0]
-                    if db.query(ProjectOrganization)
-                    .filter(ProjectOrganization.project_id == project_id)
-                    .first()
-                    else None
-                ),
+                organization_id=organization_id_for_notif,
             )
 
     return {
@@ -399,10 +399,16 @@ async def list_task_assignments(
 
     assignments = db.query(TaskAssignment).filter(TaskAssignment.task_id == task_id).all()
 
-    # Enrich with user info
+    # Bulk-fetch assignees in one query instead of per-row.
+    user_ids = {a.user_id for a in assignments if a.user_id}
+    users_by_id: Dict[str, User] = {}
+    if user_ids:
+        for row in db.query(User).filter(User.id.in_(user_ids)).all():
+            users_by_id[row.id] = row
+
     result = []
     for assignment in assignments:
-        user = db.query(User).filter(User.id == assignment.user_id).first()
+        user = users_by_id.get(assignment.user_id)
         result.append(
             {
                 "id": assignment.id,
@@ -513,6 +519,9 @@ async def get_my_tasks(
     page: int = Query(1, ge=1),
     page_size: int = Query(30, ge=1, le=100),
     status: Optional[str] = Query(None, pattern="^(assigned|in_progress|completed|skipped)$"),
+    search: Optional[str] = Query(
+        None, description="ILIKE match against the task's JSON data or task id."
+    ),
     current_user: AuthUser = Depends(require_user),
     db: Session = Depends(get_db),
 ):
@@ -536,6 +545,17 @@ async def get_my_tasks(
     if status:
         query = query.filter(TaskAssignment.status == status)
 
+    if search:
+        from sqlalchemy import String as SAString, func as sa_func, or_ as sa_or
+        escaped = search.replace('%', r'\%').replace('_', r'\_')
+        like = f"%{escaped}%"
+        query = query.filter(
+            sa_or(
+                sa_func.cast(Task.data, SAString).ilike(like),
+                sa_func.cast(Task.id, SAString).ilike(like),
+            )
+        )
+
     # Order by priority and due date
     query = query.order_by(
         TaskAssignment.priority.desc(), TaskAssignment.due_date.asc().nullsfirst()
@@ -553,17 +573,24 @@ async def get_my_tasks(
         db, project_id, current_user.id, task_ids
     )
 
+    # Bulk-fetch this user's TaskAssignments for the page. Replaces the
+    # per-task SELECT that previously fired N+1 times.
+    assignments_by_task: Dict[str, TaskAssignment] = {}
+    if task_ids:
+        for assn in (
+            db.query(TaskAssignment)
+            .filter(
+                TaskAssignment.task_id.in_(task_ids),
+                TaskAssignment.user_id == current_user.id,
+            )
+            .all()
+        ):
+            assignments_by_task[assn.task_id] = assn
+
     # Enrich with assignment info
     result = []
     for task in tasks:
-        assignment = (
-            db.query(TaskAssignment)
-            .filter(
-                TaskAssignment.task_id == task.id,
-                TaskAssignment.user_id == current_user.id,
-            )
-            .first()
-        )
+        assignment = assignments_by_task.get(task.id)
 
         task_data = {
             "id": task.id,

--- a/services/api/routers/projects/helpers.py
+++ b/services/api/routers/projects/helpers.py
@@ -41,17 +41,16 @@ from project_models import (
 from project_schemas import ProjectResponse
 
 
-# Metric-key noise stripped out of the "scored (subject, metric) pairs" tally.
-# Mirrors the dropdown filter in routers/evaluations/metadata.py so the tile and
-# the metric list agree on what counts as a "real" metric.
-_METRIC_NOISE_SUFFIXES = ("_details", "_raw", "_passed", "_grade_points", "_response")
-_METRIC_EXCLUDED_KEYS = {"raw_score", "error"}
-
-
-def _metric_key_is_real(key: Optional[str]) -> bool:
-    if not key or key in _METRIC_EXCLUDED_KEYS:
-        return False
-    return not key.endswith(_METRIC_NOISE_SUFFIXES)
+# Re-export the noise filter from /shared. Single source of truth lives in
+# metric_filters so the API, the worker, and the aggregate-summaries
+# refresh job agree on what counts as a "real" metric — historically the
+# worker couldn't import this module at all, so the live and precomputed
+# paths could silently disagree. See services/shared/metric_filters.py.
+from metric_filters import (  # noqa: F401 — re-exported for legacy callers
+    _METRIC_EXCLUDED_KEYS,
+    _METRIC_NOISE_SUFFIXES,
+    _metric_key_is_real,
+)
 
 
 def _scored_pairs_query(db: Session):
@@ -222,10 +221,10 @@ def calculate_project_stats(
     # subjects looked identical to a fully-scored run).
     #
     # Reads from the precomputed `project_summaries.evaluation_pairs_count`
-    # (refreshed by the `recompute_aggregates` Celery task every 12h). Falls
+    # (refreshed by the `recompute_aggregates` Celery task hourly). Falls
     # back to the original live computation when no precomputed row exists —
     # brand-new projects shouldn't render zero before the next refresh.
-    from services.aggregate_summaries import read_project_summary
+    from aggregate_summaries import read_project_summary
 
     summary = read_project_summary(db, project_id, period="overall")
     if summary is not None:
@@ -252,73 +251,98 @@ def calculate_project_stats(
 
 
 def calculate_project_stats_batch(db: Session, project_ids: List[str]) -> Dict[str, Dict[str, int]]:
-    """Calculate project statistics for multiple projects using optimized queries.
+    """Calculate project statistics for multiple projects.
 
-    Replaces N+1 query pattern with grouped aggregation queries.
+    Reads from the precomputed `project_summaries` table (period='overall',
+    refreshed by the `recompute_aggregates` Celery task) so the common case
+    is one indexed lookup keyed by `project_id IN (...)`. For brand-new
+    projects that don't have a summary row yet (created between beat runs),
+    falls back to live aggregation queries scoped to *only* those missing
+    ids — the established 99% of the list pays nothing.
 
-    Args:
-        db: Database session
-        project_ids: List of project IDs to fetch stats for
-
-    Returns:
-        Dict mapping project_id to stats dict with keys:
-        - task_count
-        - completed_tasks_count
-        - annotation_count
-        - evaluation_count
-        - evaluations_completed_count
+    Returns: Dict mapping project_id to stats dict with keys
+    `task_count`, `completed_tasks_count`, `annotation_count`,
+    `evaluation_count`, `evaluations_completed_count`.
     """
     from project_models import Annotation
+    from models import ProjectSummary
+    from sqlalchemy import select as sa_select
 
     if not project_ids:
         return {}
 
-    # Query 1: Task and completed task stats using aggregation
-    task_stats_query = (
-        db.query(
-            Task.project_id,
-            func.count(Task.id).label('task_count'),
-            func.sum(case((Task.is_labeled == True, 1), else_=0)).label('completed_tasks_count'),
-        )
-        .filter(Task.project_id.in_(project_ids))
-        .group_by(Task.project_id)
-    )
-
-    # Query 2: Annotation stats using aggregation
-    # Only count completed annotations (non-cancelled, with actual results - not draft-only)
-    annotation_stats_query = (
-        db.query(Annotation.project_id, func.count(Annotation.id).label('annotation_count'))
-        .filter(
-            Annotation.project_id.in_(project_ids),
-            Annotation.was_cancelled == False,
-            # Exclude draft-only annotations (empty result but has draft)
-            Annotation.result != None,
-            func.jsonb_array_length(Annotation.result) > 0,
-        )
-        .group_by(Annotation.project_id)
-    )
-
-    # Execute task/annotation queries (pure SQL, cheap).
-    task_stats = task_stats_query.all()
-    annotation_stats = annotation_stats_query.all()
-
-    # Evaluation pairs: read from the precomputed `project_summaries` table.
-    # Falls back to the original Python-side aggregation for any project that
-    # doesn't have a precomputed row yet (brand-new projects waiting for the
-    # next `recompute_aggregates` cycle).
-    from models import ProjectSummary
-    from sqlalchemy import select as sa_select
-
+    # Read all four counters from the precomputed table in one indexed query.
     summary_rows = db.execute(
-        sa_select(ProjectSummary.project_id, ProjectSummary.evaluation_pairs_count)
-        .where(
+        sa_select(
+            ProjectSummary.project_id,
+            ProjectSummary.total_tasks,
+            ProjectSummary.labeled_tasks,
+            ProjectSummary.annotations_count,
+            ProjectSummary.evaluation_pairs_count,
+        ).where(
             ProjectSummary.project_id.in_(project_ids),
             ProjectSummary.period == "overall",
         )
     ).all()
-    eval_count_by_project = {pid: int(cnt or 0) for pid, cnt in summary_rows}
-    missing_summary_ids = [pid for pid in project_ids if pid not in eval_count_by_project]
+
+    stats_map: Dict[str, Dict[str, int]] = {}
+    for pid, total, labeled, ann, eval_pairs in summary_rows:
+        stats_map[pid] = {
+            'task_count': int(total or 0),
+            'completed_tasks_count': int(labeled or 0),
+            'annotation_count': int(ann or 0),
+            'evaluation_count': int(eval_pairs or 0),
+            'evaluations_completed_count': int(eval_pairs or 0),
+        }
+
+    missing_summary_ids = [pid for pid in project_ids if pid not in stats_map]
     if missing_summary_ids:
+        for pid in missing_summary_ids:
+            stats_map[pid] = {
+                'task_count': 0,
+                'completed_tasks_count': 0,
+                'annotation_count': 0,
+                'evaluation_count': 0,
+                'evaluations_completed_count': 0,
+            }
+
+        task_stats = (
+            db.query(
+                Task.project_id,
+                func.count(Task.id).label('task_count'),
+                func.sum(case((Task.is_labeled == True, 1), else_=0)).label(
+                    'completed_tasks_count'
+                ),
+            )
+            .filter(Task.project_id.in_(missing_summary_ids))
+            .group_by(Task.project_id)
+            .all()
+        )
+        for stat in task_stats:
+            stats_map[stat.project_id]['task_count'] = stat.task_count or 0
+            stats_map[stat.project_id]['completed_tasks_count'] = (
+                stat.completed_tasks_count or 0
+            )
+
+        # Match the worker's filter (services/aggregate_summaries._compute_project_summary)
+        # so freshly-created projects display the same number both before and
+        # after the next recompute_aggregates cycle.
+        annotation_stats = (
+            db.query(
+                Annotation.project_id, func.count(Annotation.id).label('annotation_count')
+            )
+            .filter(
+                Annotation.project_id.in_(missing_summary_ids),
+                Annotation.was_cancelled == False,
+                Annotation.result != None,
+                func.jsonb_array_length(Annotation.result) > 0,
+            )
+            .group_by(Annotation.project_id)
+            .all()
+        )
+        for stat in annotation_stats:
+            stats_map[stat.project_id]['annotation_count'] = stat.annotation_count or 0
+
         live_pairs = (
             _scored_pairs_query(db)
             .filter(EvaluationRun.project_id.in_(missing_summary_ids))
@@ -328,28 +352,8 @@ def calculate_project_stats_batch(db: Session, project_ids: List[str]) -> Dict[s
         for pid, _sub_id, metric_key in live_pairs:
             if not _metric_key_is_real(metric_key):
                 continue
-            eval_count_by_project[pid] = eval_count_by_project.get(pid, 0) + 1
-        # Ensure every project_id in missing has at least a 0 entry.
-        for pid in missing_summary_ids:
-            eval_count_by_project.setdefault(pid, 0)
-
-    # Build stats lookup dictionary
-    stats_map = {}
-    for project_id in project_ids:
-        stats_map[project_id] = {
-            'task_count': 0,
-            'completed_tasks_count': 0,
-            'annotation_count': 0,
-            'evaluation_count': eval_count_by_project.get(project_id, 0),
-            'evaluations_completed_count': eval_count_by_project.get(project_id, 0),
-        }
-
-    for stat in task_stats:
-        stats_map[stat.project_id]['task_count'] = stat.task_count or 0
-        stats_map[stat.project_id]['completed_tasks_count'] = stat.completed_tasks_count or 0
-
-    for stat in annotation_stats:
-        stats_map[stat.project_id]['annotation_count'] = stat.annotation_count or 0
+            stats_map[pid]['evaluation_count'] += 1
+            stats_map[pid]['evaluations_completed_count'] += 1
 
     return stats_map
 
@@ -412,41 +416,74 @@ def calculate_generation_stats(db: Session, project: Project, response: ProjectR
 def calculate_generation_stats_batch(
     db: Session, projects: List[Project]
 ) -> Dict[str, Dict[str, int]]:
-    """Batch generation stats for many projects in 2 queries instead of 3*N.
+    """Batch generation stats for many projects.
+
+    Reads from `project_summaries` (period='overall') for every project that
+    has a summary row; falls back to the original two grouped queries only
+    for projects the worker hasn't summarized yet. After Phase 6.2 the
+    summary table carries both the total Generation count and the
+    status='completed' ResponseGeneration count, so the dashboard pays
+    nothing on the established 99 % of projects.
 
     Returns: project_id -> {generation_count, completed_generations}.
-    Caller still computes config_ready / prompts_ready / models_count / completed
-    in-process from each Project's generation_config (no DB hit).
+    Caller still computes config_ready / prompts_ready / models_count /
+    completed in-process from each Project's generation_config (no DB hit).
     """
+    from models import ProjectSummary
+    from sqlalchemy import select as sa_select
+
     if not projects:
         return {}
 
     project_ids = [p.id for p in projects]
 
-    # Query 1: total Generation rows per project
+    out: Dict[str, Dict[str, int]] = {}
+
+    # Step 1: read from the precomputed summary in one indexed query.
+    summary_rows = db.execute(
+        sa_select(
+            ProjectSummary.project_id,
+            ProjectSummary.generations_count,
+            ProjectSummary.completed_response_generations_count,
+        ).where(
+            ProjectSummary.project_id.in_(project_ids),
+            ProjectSummary.period == "overall",
+        )
+    ).all()
+    for pid, gen_c, completed_c in summary_rows:
+        out[pid] = {
+            "generation_count": int(gen_c or 0),
+            "completed_generations": int(completed_c or 0),
+        }
+
+    # Step 2: live fallback only for projects without a summary row yet.
+    missing_summary_ids = [pid for pid in project_ids if pid not in out]
+    for pid in missing_summary_ids:
+        out[pid] = {"generation_count": 0, "completed_generations": 0}
+    if not missing_summary_ids:
+        return out
+
+    # Query 1: total Generation rows per missing project
     gen_counts = (
         db.query(Task.project_id, func.count(Generation.id).label("c"))
         .join(Generation, Generation.task_id == Task.id)
-        .filter(Task.project_id.in_(project_ids))
+        .filter(Task.project_id.in_(missing_summary_ids))
         .group_by(Task.project_id)
         .all()
     )
 
-    # Query 2: completed ResponseGeneration rows per project
+    # Query 2: completed ResponseGeneration rows per missing project
     completed_counts = (
         db.query(Task.project_id, func.count(ResponseGeneration.id).label("c"))
         .join(ResponseGeneration, ResponseGeneration.task_id == Task.id)
         .filter(
-            Task.project_id.in_(project_ids),
+            Task.project_id.in_(missing_summary_ids),
             ResponseGeneration.status == "completed",
         )
         .group_by(Task.project_id)
         .all()
     )
 
-    out: Dict[str, Dict[str, int]] = {
-        pid: {"generation_count": 0, "completed_generations": 0} for pid in project_ids
-    }
     for row in gen_counts:
         out[row.project_id]["generation_count"] = row.c or 0
     for row in completed_counts:

--- a/services/api/routers/projects/tasks.py
+++ b/services/api/routers/projects/tasks.py
@@ -44,6 +44,39 @@ async def list_project_tasks(
     only_unlabeled: Optional[bool] = None,
     only_assigned: Optional[bool] = None,  # Filter for assigned tasks
     exclude_my_annotations: Optional[bool] = None,  # Exclude tasks current user has annotated
+    search: Optional[str] = Query(
+        None,
+        description="ILIKE match against the task's JSON data or task id.",
+    ),
+    date_from: Optional[str] = Query(
+        None, description="ISO date; lower bound on Task.created_at."
+    ),
+    date_to: Optional[str] = Query(
+        None, description="ISO date; upper bound on Task.created_at."
+    ),
+    sort_by: Optional[str] = Query(
+        None,
+        description=(
+            "id | created | completed | annotations | generations. Overrides the "
+            "project's randomize_task_order when set."
+        ),
+    ),
+    sort_order: str = Query("asc", pattern="^(asc|desc)$"),
+    ids_only: bool = Query(
+        False,
+        description=(
+            "When true, skip pagination + assignment enrichment and return "
+            "only the matching task IDs. Used by the data tab's "
+            "'select all matching' affordance so bulk operations can act on "
+            "the full filtered set without paging through 50-row windows."
+        ),
+    ),
+    ids_limit: int = Query(
+        10_000,
+        ge=1,
+        le=100_000,
+        description="Safety cap on the ids_only response.",
+    ),
     current_user: AuthUser = Depends(require_user),
     db: Session = Depends(get_db),
 ):
@@ -142,17 +175,67 @@ async def list_project_tasks(
         )
         query = query.filter(Task.id.notin_(any_skips))
 
-    # Apply ordering: deterministic per-user random or sequential.
-    # In both branches we add `Task.id` as a tie-breaker so OFFSET-based
-    # pagination is total-stable. Without it, batch-imported rows that
-    # share an exact `created_at` (every row in a single import burst gets
-    # the same now()) can appear in different positions across page
-    # boundaries, producing duplicates in one page and missing rows in
-    # another — which surfaced as "the first table row appears empty"
-    # after a 562-task import (inner_id=1 was reachable via /tasks/{id}
-    # but the paginated /tasks list silently returned a stale duplicate
-    # in its slot).
-    if project.randomize_task_order:
+    # Server-side search across the task's JSON payload + id. Mirrors the
+    # client-side filter that AnnotationTab used to apply after loading every
+    # task into memory.
+    if search:
+        escaped = search.replace('%', r'\%').replace('_', r'\_')
+        like = f"%{escaped}%"
+        query = query.filter(
+            or_(
+                func.cast(Task.data, String).ilike(like),
+                func.cast(Task.id, String).ilike(like),
+            )
+        )
+
+    # created_at range; tolerate either YYYY-MM-DD or full ISO.
+    def _parse_date(raw: Optional[str]):
+        if not raw:
+            return None
+        try:
+            return datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+
+    start_dt = _parse_date(date_from)
+    end_dt = _parse_date(date_to)
+    if start_dt is not None:
+        query = query.filter(Task.created_at >= start_dt)
+    if end_dt is not None:
+        query = query.filter(Task.created_at <= end_dt)
+
+    # Apply ordering. An explicit `sort_by` from the client takes precedence
+    # over the project's randomize_task_order — list views need deterministic
+    # ordering for pagination, the labeling cycle is the consumer that wants
+    # randomization. Tie-break on Task.id so OFFSET pagination stays
+    # total-stable when many rows share a sort key (see migration 044 thread:
+    # batch-imported rows share an exact created_at).
+    direction = (lambda c: c.desc() if sort_order == "desc" else c.asc())
+
+    if sort_by in {"id", "created", "completed", "annotations", "generations"}:
+        sort_columns = {
+            "id": Task.id,
+            "created": Task.created_at,
+            "completed": Task.is_labeled,
+            "annotations": Task.total_annotations,
+            "generations": None,  # handled below — needs a join
+        }
+        if sort_by == "generations":
+            # LEFT JOIN aggregate so tasks without generations still appear.
+            gen_count_subq = (
+                db.query(
+                    Generation.task_id.label("task_id"),
+                    func.count(Generation.id).label("c"),
+                )
+                .group_by(Generation.task_id)
+                .subquery()
+            )
+            query = query.outerjoin(
+                gen_count_subq, gen_count_subq.c.task_id == Task.id
+            ).order_by(direction(func.coalesce(gen_count_subq.c.c, 0)), Task.id)
+        else:
+            query = query.order_by(direction(sort_columns[sort_by]), Task.id)
+    elif project.randomize_task_order:
         # hashtext (not md5) — md5() is unavailable on FIPS-restricted Postgres builds.
         query = query.order_by(
             func.hashtext(func.concat(Task.id, current_user.id)),
@@ -164,12 +247,26 @@ async def list_project_tasks(
     # Get total count before pagination
     total = query.count()
 
+    # `ids_only` short-circuit — used by the data tab's "select all matching"
+    # bulk-operation flow. Skip the pagination, generation-counts, and
+    # assignment-enrichment work below and just return the filtered IDs.
+    # `ids_limit` caps the response so a 100k-task project can't blow up
+    # the client.
+    if ids_only:
+        id_rows = query.with_entities(Task.id).limit(ids_limit).all()
+        return {
+            "ids": [tid for (tid,) in id_rows],
+            "total": total,
+            "truncated": total > ids_limit,
+        }
+
     # Pagination
     tasks = query.offset((page - 1) * page_size).limit(page_size).all()
 
-    # Get generation counts per task (calculated, not stored)
     task_ids = [task.id for task in tasks]
-    generation_counts = {}
+
+    # Per-task generation counts in one grouped query.
+    generation_counts: Dict[str, int] = {}
     if task_ids:
         gen_counts = (
             db.query(Generation.task_id, func.count(Generation.id))
@@ -179,15 +276,30 @@ async def list_project_tasks(
         )
         generation_counts = {task_id: count for task_id, count in gen_counts}
 
+    # Bulk-fetch all assignments for the page + the users they reference. Two
+    # IN queries replace the previous per-task and per-assignment lookups
+    # (which scaled as page_size + page_size × ~5 assignees per task).
+    assignments_by_task: Dict[str, List[TaskAssignment]] = {tid: [] for tid in task_ids}
+    users_by_id: Dict[str, User] = {}
+    if task_ids:
+        page_assignments = (
+            db.query(TaskAssignment).filter(TaskAssignment.task_id.in_(task_ids)).all()
+        )
+        for assn in page_assignments:
+            assignments_by_task.setdefault(assn.task_id, []).append(assn)
+        user_ids = {a.user_id for a in page_assignments if a.user_id}
+        if user_ids:
+            user_rows = db.query(User).filter(User.id.in_(user_ids)).all()
+            users_by_id = {u.id: u for u in user_rows}
+
     # Enrich tasks with assignment information
     result = []
     for task in tasks:
-        # Return full metadata (Label Studio aligned)
         task_dict = {
             "id": task.id,
-            "inner_id": task.inner_id,  # Required field for task identification within project
+            "inner_id": task.inner_id,
             "data": task.data,
-            "meta": task.meta,  # Full metadata, not just tags
+            "meta": task.meta,
             "created_at": task.created_at,
             "updated_at": task.updated_at,
             "is_labeled": task.is_labeled,
@@ -202,28 +314,22 @@ async def list_project_tasks(
             "tags": task.meta.get("tags", []) if task.meta else [],
         }
 
-        # Get assignments for this task (only if they exist)
-        try:
-            assignments = db.query(TaskAssignment).filter(TaskAssignment.task_id == task.id).all()
-
-            for assignment in assignments:
-                assigned_user = db.query(User).filter(User.id == assignment.user_id).first()
-                if assigned_user:
-                    assignment_data = {
-                        "id": assignment.id,
-                        "user_id": assignment.user_id,
-                        "user_name": assigned_user.name,
-                        "user_email": assigned_user.email,
-                        "status": assignment.status,
-                        "priority": getattr(assignment, "priority", 0),
-                        "due_date": getattr(assignment, "due_date", None),
-                        "assigned_at": assignment.assigned_at,
-                    }
-                    task_dict["assignments"].append(assignment_data)
-        except Exception as e:
-            import logging
-            logging.getLogger(__name__).warning(f"Could not fetch assignments for task {task.id}: {e}")
-            task_dict["assignments"] = []
+        for assignment in assignments_by_task.get(task.id, []):
+            assigned_user = users_by_id.get(assignment.user_id)
+            if assigned_user is None:
+                continue
+            task_dict["assignments"].append(
+                {
+                    "id": assignment.id,
+                    "user_id": assignment.user_id,
+                    "user_name": assigned_user.name,
+                    "user_email": assigned_user.email,
+                    "status": assignment.status,
+                    "priority": getattr(assignment, "priority", 0),
+                    "due_date": getattr(assignment, "due_date", None),
+                    "assigned_at": assignment.assigned_at,
+                }
+            )
 
         result.append(task_dict)
 

--- a/services/api/routers/reports.py
+++ b/services/api/routers/reports.py
@@ -28,6 +28,7 @@ from report_service import (
     get_report_models,
     get_report_participants,
     get_report_statistics,
+    get_report_statistics_batch,
 )
 
 logger = logging.getLogger(__name__)
@@ -493,22 +494,30 @@ async def list_published_reports(
 
     reports = query.order_by(ProjectReport.published_at.desc()).all()
 
-    # Build response
-    result = []
-    for report in reports:
-        # Get statistics
-        stats = get_report_statistics(db, report.project_id)
+    # Batch-fetch statistics + org memberships for all reports in 5 queries
+    # total (4 grouped stats + 1 joined orgs) instead of 5 × N round-trips.
+    report_project_ids = [r.project_id for r in reports]
+    stats_map = get_report_statistics_batch(db, report_project_ids)
 
-        # Get organizations
-        orgs = (
+    orgs_by_project: Dict[str, list] = {pid: [] for pid in report_project_ids}
+    if report_project_ids:
+        org_rows = (
             db.query(ProjectOrganization)
             .options(joinedload(ProjectOrganization.organization))
-            .filter(ProjectOrganization.project_id == report.project_id)
+            .filter(ProjectOrganization.project_id.in_(report_project_ids))
             .all()
         )
+        for po in org_rows:
+            orgs_by_project.setdefault(po.project_id, []).append(
+                {"id": po.organization.id, "name": po.organization.name}
+            )
 
-        organizations = [{"id": po.organization.id, "name": po.organization.name} for po in orgs]
-
+    result = []
+    for report in reports:
+        stats = stats_map.get(
+            report.project_id,
+            {"task_count": 0, "annotation_count": 0, "participant_count": 0, "model_count": 0},
+        )
         result.append(
             PublishedReportListItem(
                 id=report.id,
@@ -518,7 +527,7 @@ async def list_published_reports(
                 task_count=stats["task_count"],
                 annotation_count=stats["annotation_count"],
                 model_count=stats["model_count"],
-                organizations=organizations,
+                organizations=orgs_by_project.get(report.project_id, []),
             )
         )
 

--- a/services/api/routers/users.py
+++ b/services/api/routers/users.py
@@ -3,9 +3,10 @@ User management endpoints.
 """
 
 import logging
-from typing import List
+from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from auth_module import (
@@ -26,10 +27,46 @@ router = APIRouter(prefix="/api/users", tags=["users"])
 
 @router.get("", response_model=List[User])
 async def get_all_users_endpoint(
-    current_user: User = Depends(require_superadmin), db: Session = Depends(get_db)
+    current_user: User = Depends(require_superadmin),
+    db: Session = Depends(get_db),
+    search: Optional[str] = Query(
+        None,
+        description=(
+            "Optional ILIKE filter against username / email / name. "
+            "When set, the admin UI's user table avoids the full-table "
+            "load just to filter in JS."
+        ),
+    ),
+    limit: int = Query(
+        500, ge=1, le=5_000, description="Safety cap on the response size."
+    ),
 ):
-    """Get all users (admin only)"""
-    return get_all_users(db)
+    """Get all users (admin only).
+
+    Optional `search` narrows the result on the server side; without it the
+    handler preserves its historical "return everything" behaviour (bounded
+    by `limit` to keep a stray superadmin click from streaming an unbounded
+    table). The admin tab debounces the search input so per-keystroke
+    typing doesn't fan out queries.
+    """
+    if not search:
+        return db.query(DBUser).order_by(DBUser.created_at.desc()).limit(limit).all()
+
+    escaped = search.replace("%", r"\%").replace("_", r"\_")
+    like = f"%{escaped}%"
+    return (
+        db.query(DBUser)
+        .filter(
+            or_(
+                DBUser.username.ilike(like),
+                DBUser.email.ilike(like),
+                DBUser.name.ilike(like),
+            )
+        )
+        .order_by(DBUser.created_at.desc())
+        .limit(limit)
+        .all()
+    )
 
 
 @router.patch("/{user_id}/role", response_model=User)

--- a/services/api/tests/unit/test_aggregate_summaries.py
+++ b/services/api/tests/unit/test_aggregate_summaries.py
@@ -29,7 +29,7 @@ from models import (
     User,
 )
 from project_models import Annotation, Project, Task
-from services.aggregate_summaries import (
+from aggregate_summaries import (
     live_aggregate_leaderboard,
     read_dashboard_sum,
     read_llm_leaderboard,

--- a/services/api/tests/unit/test_generation_coverage.py
+++ b/services/api/tests/unit/test_generation_coverage.py
@@ -780,17 +780,35 @@ class TestParseMetrics:
             app.dependency_overrides.clear()
 
     def test_empty_results(self):
+        """parse-metrics returns the all-zero shape when no rows match.
+
+        Implementation note: the endpoint now runs a single
+        `query.with_entities(...).one()` aggregation instead of five
+        sequential `.count()` calls. The mock chain reflects that shape;
+        if the aggregation ever returns nothing-equivalent the handler
+        early-returns the zero payload.
+        """
         client = TestClient(app)
         user = _make_user(is_superadmin=True)
 
         from database import get_db
         from auth_module import require_user
 
+        # Shape the aggregation row exactly as the handler expects.
+        agg_row = Mock()
+        agg_row.total = 0
+        agg_row.success = 0
+        agg_row.failed = 0
+        agg_row.validation_error = 0
+        agg_row.max_retries = 0
+
         mock_db = Mock(spec=Session)
         mock_q = Mock()
         mock_q.filter.return_value = mock_q
         mock_q.join.return_value = mock_q
         mock_q.count.return_value = 0
+        mock_q.with_entities.return_value = mock_q
+        mock_q.one.return_value = agg_row
         mock_db.query.return_value = mock_q
 
         app.dependency_overrides[require_user] = lambda: user

--- a/services/api/tests/unit/test_generation_task_list_coverage.py
+++ b/services/api/tests/unit/test_generation_task_list_coverage.py
@@ -372,9 +372,17 @@ class TestGetTaskGenerationStatusEndpoint:
 
     @pytest.mark.asyncio
     @patch("routers.generation_task_list.get_project_with_permissions")
-    @patch("routers.generation_task_list.get_single_task_generation_status")
-    async def test_status_filter_excludes_non_matching(self, mock_gen_status, mock_perms):
-        from routers.generation_task_list import get_task_generation_status, TaskGenerationStatus
+    async def test_status_filter_excludes_non_matching(self, mock_perms):
+        """`status_filter='not_generated'` should drop tasks whose cells have a
+        status set. The branch that handles `not_generated` still filters in
+        Python (after the bulk fetch) because "missing somewhere" can't be
+        expressed cleanly in SQL. The previous version of this test asserted
+        the same behavior for `status_filter='completed'`, but that filter
+        now runs as a SQL subquery — the mock here can't simulate it, so we
+        exercise the surviving Python-side branch instead."""
+        from routers.generation_task_list import (
+            get_task_generation_status,
+        )
 
         db = _mock_db()
         project = Mock()
@@ -391,17 +399,35 @@ class TestGetTaskGenerationStatusEndpoint:
         task.meta = None
         task.created_at = datetime(2025, 6, 1, tzinfo=timezone.utc)
 
+        # A completed-row stub so `_bulk_latest_generations` reports the task
+        # as having a status of "completed" — i.e. NOT in the "not_generated"
+        # bucket, so the Python filter should drop it.
+        gen_row = Mock()
+        gen_row.task_id = "task-1"
+        gen_row.model_id = "gpt-4"
+        gen_row.structure_key = None
+        gen_row.status = "completed"
+        gen_row.id = "gen-1"
+        gen_row.result = {"text": "ok"}
+        gen_row.completed_at = datetime(2025, 6, 2, tzinfo=timezone.utc)
+        gen_row.created_at = datetime(2025, 6, 2, tzinfo=timezone.utc)
+        gen_row.error_message = None
+        gen_row.runs_requested = 1
+        gen_row.runs_completed = 1
+        gen_row.runs_failed = 0
+
         mock_q = MagicMock()
         mock_q.filter.return_value = mock_q
         mock_q.offset.return_value = mock_q
         mock_q.limit.return_value = mock_q
+        mock_q.distinct.return_value = mock_q
+        mock_q.order_by.return_value = mock_q
         mock_q.count.return_value = 1
-        mock_q.all.return_value = [task]
+        # The two .all() consumers in this branch:
+        # 1) the initial Task fetch returns [task]
+        # 2) `_bulk_latest_generations` returns [gen_row]
+        mock_q.all.side_effect = [[task], [gen_row]]
         db.query.return_value = mock_q
-
-        mock_gen_status.return_value = TaskGenerationStatus(
-            task_id="task-1", model_id="gpt-4", structure_key=None, status=None
-        )
 
         result = await get_task_generation_status(
             project_id="proj-1",
@@ -409,7 +435,7 @@ class TestGetTaskGenerationStatusEndpoint:
             page=1,
             page_size=50,
             search=None,
-            status_filter="completed",
+            status_filter="not_generated",
             current_user=_make_user(is_superadmin=True),
             db=db,
         )

--- a/services/api/tests/unit/test_organizations_coverage_extended.py
+++ b/services/api/tests/unit/test_organizations_coverage_extended.py
@@ -575,6 +575,9 @@ class TestListAllUsers:
     async def test_superadmin_all_users(self):
         from routers.organizations import list_all_users
 
+        # Updated 2026-05-20: handler now appends `.order_by(...).limit(...)`
+        # to the query so it can apply an optional `?search=` filter SQL-side
+        # without losing backward compat. Mock the full chain.
         db = Mock()
         user = Mock(is_superadmin=True)
 
@@ -585,9 +588,18 @@ class TestListAllUsers:
             "name": "User 1", "is_superadmin": False, "is_active": True,
             "created_at": datetime(2025, 1, 1), "updated_at": None,
         }
-        db.query.return_value.filter.return_value.all.return_value = [u1]
+        mock_q = Mock()
+        mock_q.filter.return_value = mock_q
+        mock_q.order_by.return_value = mock_q
+        mock_q.limit.return_value = mock_q
+        mock_q.all.return_value = [u1]
+        db.query.return_value = mock_q
 
-        result = await list_all_users(current_user=user, db=db)
+        # Pass `search=None` + `limit=500` explicitly because direct-function
+        # tests don't get FastAPI's `Query(...)` defaults unwrapped.
+        result = await list_all_users(
+            current_user=user, db=db, search=None, limit=500
+        )
         assert len(result) == 1
 
     @pytest.mark.asyncio

--- a/services/api/tests/unit/test_users_router.py
+++ b/services/api/tests/unit/test_users_router.py
@@ -72,23 +72,30 @@ class TestUsersRouter:
         def override_get_db():
             return Mock(spec=Session)
 
-        with patch("routers.users.get_all_users") as mock_get_users:
-            mock_get_users.return_value = mock_users_list
+        # The handler now runs the query inline (so it can apply optional
+        # `?search=` filtering server-side); mock the DB chain directly.
+        mock_db = Mock(spec=Session)
+        mock_query = Mock()
+        mock_query.filter.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+        mock_query.limit.return_value = mock_query
+        mock_query.all.return_value = mock_users_list
+        mock_db.query.return_value = mock_query
 
-            # Override dependencies
-            app.dependency_overrides[require_superadmin] = override_require_superadmin
-            app.dependency_overrides[get_db] = override_get_db
+        # Override dependencies
+        app.dependency_overrides[require_superadmin] = override_require_superadmin
+        app.dependency_overrides[get_db] = lambda: mock_db
 
-            try:
-                response = client.get("/api/users")
+        try:
+            response = client.get("/api/users")
 
-                assert response.status_code == status.HTTP_200_OK
-                data = response.json()
-                assert isinstance(data, list)
-                assert len(data) == 2
-            finally:
-                # Clean up overrides
-                app.dependency_overrides.clear()
+            assert response.status_code == status.HTTP_200_OK
+            data = response.json()
+            assert isinstance(data, list)
+            assert len(data) == 2
+        finally:
+            # Clean up overrides
+            app.dependency_overrides.clear()
 
     def test_get_all_users_forbidden_as_regular_user(self, client, mock_regular_user):
         """Test that getting all users is forbidden for regular users"""

--- a/services/api/tests/unit/test_users_router_extended.py
+++ b/services/api/tests/unit/test_users_router_extended.py
@@ -50,20 +50,28 @@ class TestUsersRouterExtended:
         app.dependency_overrides[get_db] = override
 
     def test_get_all_users(self, client, mock_superadmin):
-        """Test listing all users."""
+        """Test listing all users.
+
+        The handler runs the query inline now so it can apply optional
+        `?search=` filtering server-side; mock the DB chain directly.
+        """
         self._override_superadmin(mock_superadmin)
 
-        user_list = [mock_superadmin]
-        with patch("routers.users.get_all_users") as mock_get:
-            mock_get.return_value = user_list
-            self._override_db(Mock(spec=Session))
-            try:
-                response = client.get("/api/users")
-                assert response.status_code == status.HTTP_200_OK
-                data = response.json()
-                assert len(data) == 1
-            finally:
-                app.dependency_overrides.clear()
+        mock_db = Mock(spec=Session)
+        mock_query = Mock()
+        mock_query.filter.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+        mock_query.limit.return_value = mock_query
+        mock_query.all.return_value = [mock_superadmin]
+        mock_db.query.return_value = mock_query
+        self._override_db(mock_db)
+        try:
+            response = client.get("/api/users")
+            assert response.status_code == status.HTTP_200_OK
+            data = response.json()
+            assert len(data) == 1
+        finally:
+            app.dependency_overrides.clear()
 
     def test_update_user_role_success(self, client, mock_superadmin):
         """Test updating user role."""

--- a/services/frontend/src/__tests__/dashboard-annotations-stat.test.tsx
+++ b/services/frontend/src/__tests__/dashboard-annotations-stat.test.tsx
@@ -4,8 +4,23 @@
  */
 
 import DashboardPage from '@/app/dashboard/page'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import '@testing-library/jest-dom'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render as rtlRender, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+
+// Phase 3 wrapped the app in a global QueryClientProvider; the dashboard
+// page now uses `useQuery`, so tests must provide a client. Local wrapper
+// (vs. importing from test-utils) keeps the mock graph small.
+const render: typeof rtlRender = (ui, options) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return rtlRender(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+    options
+  )
+}
 
 // Mock the Next.js hooks
 jest.mock('next/navigation', () => ({

--- a/services/frontend/src/__tests__/dashboard-organization-warning.test.tsx
+++ b/services/frontend/src/__tests__/dashboard-organization-warning.test.tsx
@@ -3,8 +3,21 @@
  * Tests the display of warning message for users without organization assignment
  */
 
-import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render as rtlRender, screen, waitFor } from '@testing-library/react'
 import React from 'react'
+
+// Phase 3 wrapped the app in a global QueryClientProvider; the dashboard
+// page now uses `useQuery`, so tests must provide a client.
+const render: typeof rtlRender = (ui, options) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return rtlRender(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+    options
+  )
+}
 
 // Mock ApiClient before any imports that might use it
 jest.mock('@/lib/api', () => ({

--- a/services/frontend/src/app/admin/users-organizations/components/GlobalUsersTab.tsx
+++ b/services/frontend/src/app/admin/users-organizations/components/GlobalUsersTab.tsx
@@ -15,6 +15,7 @@ import {
   XCircleIcon,
 } from '@heroicons/react/24/outline'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 
 type VerificationFilter = 'all' | 'verified' | 'unverified'
 type SuperadminFilter = 'all' | 'superadmin' | 'regular'
@@ -122,9 +123,16 @@ export function GlobalUsersTab() {
     userWithOrganizations
   )
 
+  // Push the search to the server so we don't reload every user just to
+  // filter in JS. Verification + superadmin + sort stay client-side
+  // because they operate on the already-loaded set and don't add round-trips.
+  const debouncedSearch = useDebouncedValue(searchQuery, 300)
+
   const fetchUsers = useCallback(async () => {
     try {
-      const data = await api.getAllUsers()
+      const data = await api.getAllUsers({
+        search: debouncedSearch || undefined,
+      })
       setUsers(data)
     } catch (error) {
       const errorMessage =
@@ -133,7 +141,7 @@ export function GlobalUsersTab() {
     } finally {
       setLoading(false)
     }
-  }, [t])
+  }, [t, debouncedSearch])
 
   useEffect(() => {
     if (canManageUsers) {

--- a/services/frontend/src/app/dashboard/page.tsx
+++ b/services/frontend/src/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { ResponsiveContainer } from '@/components/shared/ResponsiveContainer'
 import { useAuth } from '@/contexts/AuthContext'
 import { useI18n } from '@/contexts/I18nContext'
 import { useProjectStore } from '@/stores/projectStore'
+import { useQuery } from '@tanstack/react-query'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
@@ -18,20 +19,12 @@ const formatStatCount = (n: number): string =>
 
 export default function DashboardPage() {
   const { t } = useI18n()
-  const { projects, fetchProjects, loading } = useProjectStore()
+  const { projects, fetchProjects } = useProjectStore()
   const { user, organizations } = useAuth()
   const router = useRouter()
   const searchParams = useSearchParams()
   const [error, setError] = useState<string | null>(null)
   const errorParam = searchParams?.get('error') ?? null
-  const [dashboardStats, setDashboardStats] = useState({
-    project_count: 0,
-    task_count: 0,
-    annotation_count: 0,
-    projects_with_generations: 0,
-    projects_with_evaluations: 0,
-  })
-  const [statsLoading, setStatsLoading] = useState(true)
 
   // All authenticated users can access projects (including private projects)
   const canAccessProjects = !!user
@@ -44,26 +37,47 @@ export default function DashboardPage() {
     }
   }, [errorParam, router])
 
-  useEffect(() => {
-    const loadData = async () => {
-      try {
-        // Load projects for recent projects display
-        await fetchProjects(1, 100)
+  // React Query caches these for 60 s (the global default), so navigating
+  // dashboard → projects → dashboard serves the second visit from memory
+  // instead of refetching both endpoints. The projects fetch still hydrates
+  // the Zustand store via the existing fetchProjects side-effect so
+  // downstream consumers stay in sync.
+  const projectsQuery = useQuery({
+    queryKey: ['dashboard', 'projects', 1, 100],
+    queryFn: () => fetchProjects(1, 100),
+  })
 
-        // Load dashboard statistics from API
-        const { default: api } = await import('@/lib/api')
-        const stats = await api.getDashboardStats()
-        setDashboardStats(stats)
-        setStatsLoading(false)
-      } catch (err) {
-        setError(
-          err instanceof Error ? err.message : t('dashboard.loadFailed')
-        )
-        setStatsLoading(false)
-      }
+  const statsQuery = useQuery({
+    queryKey: ['dashboard', 'stats'],
+    queryFn: async () => {
+      const { default: api } = await import('@/lib/api')
+      return api.getDashboardStats() as Promise<{
+        project_count: number
+        task_count: number
+        annotation_count: number
+        projects_with_generations: number
+        projects_with_evaluations: number
+      }>
+    },
+  })
+
+  const dashboardStats = statsQuery.data ?? {
+    project_count: 0,
+    task_count: 0,
+    annotation_count: 0,
+    projects_with_generations: 0,
+    projects_with_evaluations: 0,
+  }
+
+  useEffect(() => {
+    if (projectsQuery.error || statsQuery.error) {
+      const err = projectsQuery.error || statsQuery.error
+      setError(err instanceof Error ? err.message : t('dashboard.loadFailed'))
     }
-    loadData()
-  }, [fetchProjects])
+  }, [projectsQuery.error, statsQuery.error, t])
+
+  const loading = projectsQuery.isLoading
+  const statsLoading = statsQuery.isLoading
 
   const recentProjects =
     projects

--- a/services/frontend/src/app/evaluations/page.tsx
+++ b/services/frontend/src/app/evaluations/page.tsx
@@ -144,12 +144,39 @@ export default function EvaluationDashboard() {
   const { user, isLoading: authLoading } = useAuth()
   const { isPrivateMode } = typeof window !== 'undefined' ? parseSubdomain() : { isPrivateMode: true }
 
+  // Parse URL filters synchronously on first render. Without this, the page
+  // briefly renders with defaults, then `fetchProjectData` populates the
+  // model/metric lists, then a separate effect re-applies the URL — which the
+  // user perceived as three sequential loading states. Initial-state hoist
+  // collapses the chain to one parallel pair (fetchProjectData +
+  // fetchComparisonData fire together once selectedProject is resolved).
+  const initialUrlFilters = useMemo(() => {
+    const models = searchParams?.get('models')?.split(',').filter(Boolean)
+    const metrics = searchParams?.get('metrics')?.split(',').filter(Boolean)
+    const chart = searchParams?.get('chartType') as ChartType | null
+    const validCharts: ChartType[] = ['data', 'bar', 'radar', 'box', 'heatmap', 'table']
+    const aggregation = searchParams?.get('aggregation')?.split(',').filter(Boolean) as AggregationLevel[] | undefined
+    const stats = searchParams?.get('stats')?.split(',').filter(Boolean) as StatisticalMethod[] | undefined
+    return {
+      models: models && models.length > 0 ? models : null,
+      metrics: metrics && metrics.length > 0 ? metrics : null,
+      chartType: chart && validCharts.includes(chart) ? chart : null,
+      aggregation: aggregation && aggregation.length > 0 ? aggregation : null,
+      stats: stats && stats.length > 0 ? stats : null,
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally parse the URL once on mount; navigation replaces the page.
+  }, [])
+
   // Filter state - all in one compact bar
   const [selectedProject, setSelectedProject] = useState<Project | null>(null)
   const [projects, setProjects] = useState<Project[]>([])
   const [projectDropdownOpen, setProjectDropdownOpen] = useState(false)
-  const [selectedModels, setSelectedModels] = useState<string[]>([])
-  const [selectedMetrics, setSelectedMetrics] = useState<string[]>([])
+  const [selectedModels, setSelectedModels] = useState<string[]>(
+    initialUrlFilters.models ?? []
+  )
+  const [selectedMetrics, setSelectedMetrics] = useState<string[]>(
+    initialUrlFilters.metrics ?? []
+  )
   const [availableMetrics, setAvailableMetrics] = useState<string[]>([])
   const [selectedEvalTypes, setSelectedEvalTypes] = useState<EvalType[]>([
     'automated',
@@ -159,12 +186,14 @@ export default function EvaluationDashboard() {
   const [modelsDropdownOpen, setModelsDropdownOpen] = useState(false)
   const [aggregationLevels, setAggregationLevels] = useState<
     AggregationLevel[]
-  >(['model'])
+  >(initialUrlFilters.aggregation ?? ['model'])
   const [statisticalMethods, setStatisticalMethods] = useState<
     StatisticalMethod[]
-  >([])
+  >(initialUrlFilters.stats ?? [])
 
-  const [chartType, setChartType] = useState<ChartType>('data')
+  const [chartType, setChartType] = useState<ChartType>(
+    initialUrlFilters.chartType ?? 'data'
+  )
   const [showEvaluationModal, setShowEvaluationModal] = useState(false)
 
   // Project evaluation config - source of truth for available eval types and metrics
@@ -271,12 +300,12 @@ export default function EvaluationDashboard() {
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  // Track if we've applied URL filters (to avoid re-applying on data refresh)
-  const urlFiltersApplied = useRef(false)
   // Skip URL sync until initial hydration is complete (prevents flicker)
   const isHydrated = useRef(false)
 
-  // Load project from URL on mount, or fall back to last selected project from localStorage
+  // Load project from URL on mount, or fall back to last selected project from localStorage.
+  // The non-project URL params (chartType, aggregation, stats, models, metrics) are
+  // already captured in initial state via `initialUrlFilters` above — no async re-apply.
   useEffect(() => {
     const projectId = searchParams?.get('projectId') || localStorage.getItem('evaluations_lastProjectId')
     if (projectId && projects.length > 0 && !selectedProject) {
@@ -285,72 +314,13 @@ export default function EvaluationDashboard() {
         setSelectedProject(project)
       }
     }
-
-    // Load non-data-dependent filters from URL immediately
-    const urlChartType = searchParams?.get('chartType') as ChartType
-    if (urlChartType && ['data', 'bar', 'radar', 'box', 'heatmap', 'table'].includes(urlChartType)) {
-      setChartType(urlChartType)
-    }
-
-    const urlAggregation = searchParams?.get('aggregation')
-    if (urlAggregation) {
-      const levels = urlAggregation.split(',').filter(Boolean) as AggregationLevel[]
-      if (levels.length > 0) {
-        setAggregationLevels(levels)
-      }
-    }
-
-    const urlStats = searchParams?.get('stats')
-    if (urlStats) {
-      const methods = urlStats.split(',').filter(Boolean) as StatisticalMethod[]
-      if (methods.length > 0) {
-        setStatisticalMethods(methods)
-      }
-    }
   }, [searchParams, projects, selectedProject])
-
-  // Apply URL filters for models/metrics AFTER data is loaded
-  useEffect(() => {
-    if (urlFiltersApplied.current) return
-    if (evaluatedModels.length === 0 && availableMetrics.length === 0) return
-
-    const urlModels = searchParams?.get('models')
-    const urlMetrics = searchParams?.get('metrics')
-
-    // Only mark as applied if we actually have URL params to apply
-    // Otherwise, the defaults from fetchProjectData will be used
-    if (urlModels || urlMetrics) {
-      urlFiltersApplied.current = true
-
-      if (urlModels && evaluatedModels.length > 0) {
-        const modelIds = urlModels.split(',').filter(Boolean)
-        // Only set models that exist in evaluatedModels
-        const validModels = modelIds.filter(id =>
-          evaluatedModels.some(m => m.model_id === id)
-        )
-        if (validModels.length > 0) {
-          setSelectedModels(validModels)
-        }
-      }
-
-      if (urlMetrics && availableMetrics.length > 0) {
-        const metricIds = urlMetrics.split(',').filter(Boolean)
-        // Only set metrics that exist in availableMetrics
-        const validMetrics = metricIds.filter(id => availableMetrics.includes(id))
-        if (validMetrics.length > 0) {
-          setSelectedMetrics(validMetrics)
-        }
-      }
-    }
-  }, [searchParams, evaluatedModels, availableMetrics])
 
   // Fetch data when project changes (instant reactive loading)
   useEffect(() => {
     if (selectedProject) {
       // Persist last selected project for next visit
       localStorage.setItem('evaluations_lastProjectId', selectedProject.id.toString())
-      // Reset URL filters applied flag when project changes
-      urlFiltersApplied.current = false
       fetchProjectData(selectedProject.id.toString())
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- fetchProjectData is stable, only re-run when selectedProject changes
@@ -520,12 +490,14 @@ export default function EvaluationDashboard() {
         const sortedMetrics = metricsStatus.map(m => m.id)
 
         setAvailableMetrics(sortedMetrics)
-        // Check if URL has metrics param - if so, don't override
-        const urlMetrics = searchParams?.get('metrics')
-        if (!urlMetrics) {
-          // Select all metrics by default
-          setSelectedMetrics(sortedMetrics)
-        }
+        // Keep any URL-provided (initial-state) selection, pruned to metrics
+        // that actually exist in the project config. Fall back to "all
+        // available" when nothing valid remains.
+        setSelectedMetrics(prev => {
+          if (prev.length === 0) return sortedMetrics
+          const valid = prev.filter(m => sortedMetrics.includes(m))
+          return valid.length > 0 ? valid : sortedMetrics
+        })
         setMetricsWithStatus(metricsStatus)
       }
 
@@ -544,9 +516,14 @@ export default function EvaluationDashboard() {
       if (modelsResult.status === 'fulfilled') {
         const modelsResponse = modelsResult.value || []
         setEvaluatedModels(modelsResponse)
-        const urlModels = searchParams?.get('models')
-        if (!urlModels && modelsResponse.length > 0) {
-          setSelectedModels(modelsResponse.map((m: any) => m.model_id))
+        if (modelsResponse.length > 0) {
+          const allIds = modelsResponse.map((m: any) => m.model_id)
+          setSelectedModels(prev => {
+            if (prev.length === 0) return allIds
+            const validIds = new Set<string>(allIds)
+            const valid = prev.filter(m => validIds.has(m))
+            return valid.length > 0 ? valid : allIds
+          })
         }
       } else {
         setEvaluatedModels([])

--- a/services/frontend/src/app/models/__tests__/page.test.tsx
+++ b/services/frontend/src/app/models/__tests__/page.test.tsx
@@ -2,9 +2,23 @@
  * @jest-environment jsdom
  */
 
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import React from 'react'
 import ModelsPage from '../page'
+
+// Phase 4 migrated this page to `useQuery` (30-min staleTime on the public
+// model catalog endpoints), so tests must provide a QueryClientProvider.
+const render: typeof rtlRender = (ui, options) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return rtlRender(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+    options
+  )
+}
 
 jest.mock('@/contexts/I18nContext', () => ({
   useI18n: () => ({

--- a/services/frontend/src/app/models/page.tsx
+++ b/services/frontend/src/app/models/page.tsx
@@ -4,7 +4,8 @@ import { HeroPattern } from '@/components/shared'
 import { FilterToolbar } from '@/components/shared/FilterToolbar'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/shared/Select'
 import { useI18n } from '@/contexts/I18nContext'
-import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
 
 interface LLMModel {
   id: string
@@ -41,15 +42,38 @@ interface ProviderCapability {
 
 export default function ModelsPage() {
   const { t } = useI18n()
-  const [models, setModels] = useState<LLMModel[]>([])
-  const [providerCapabilities, setProviderCapabilities] = useState<
-    Record<string, ProviderCapability>
-  >({})
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [providerFilter, setProviderFilter] = useState('all')
   const [selectedModel, setSelectedModel] = useState<LLMModel | null>(null)
+
+  // The public model catalog and provider-capabilities map are effectively
+  // static within a page-load — the seed only changes on deploy. A 30-minute
+  // staleTime means navigating off /models and back doesn't re-fetch them.
+  const modelsQuery = useQuery({
+    queryKey: ['llm-public-models'],
+    queryFn: async () => {
+      const res = await fetch('/api/llm_models/public/models')
+      if (!res.ok) throw new Error(t('models.fetchFailed'))
+      return (await res.json()) as LLMModel[]
+    },
+    staleTime: 30 * 60_000,
+  })
+
+  const capabilitiesQuery = useQuery({
+    queryKey: ['llm-public-provider-capabilities'],
+    queryFn: async () => {
+      const res = await fetch('/api/llm_models/public/provider-capabilities')
+      if (!res.ok) return {}
+      return (await res.json()) as Record<string, ProviderCapability>
+    },
+    staleTime: 30 * 60_000,
+  })
+
+  const models = modelsQuery.data ?? []
+  const providerCapabilities = capabilitiesQuery.data ?? {}
+  const loading = modelsQuery.isLoading
+  const error =
+    modelsQuery.error instanceof Error ? modelsQuery.error.message : null
 
   // Build model settings JSON for modal
   const getModelSettings = (model: LLMModel) => {
@@ -84,35 +108,6 @@ export default function ModelsPage() {
           : null,
     }
   }
-
-  useEffect(() => {
-    async function fetchData() {
-      try {
-        const [modelsRes, capabilitiesRes] = await Promise.all([
-          fetch('/api/llm_models/public/models'),
-          fetch('/api/llm_models/public/provider-capabilities'),
-        ])
-
-        if (!modelsRes.ok) {
-          throw new Error(t('models.fetchFailed'))
-        }
-
-        const modelsData = await modelsRes.json()
-        setModels(modelsData)
-
-        if (capabilitiesRes.ok) {
-          const capData = await capabilitiesRes.json()
-          setProviderCapabilities(capData)
-        }
-      } catch (err) {
-        setError(err instanceof Error ? err.message : t('models.unknownError'))
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    fetchData()
-  }, [])
 
   // Get unique providers for filter
   const providers = [...new Set(models.map((m) => m.provider))].sort()

--- a/services/frontend/src/app/notifications/page.tsx
+++ b/services/frontend/src/app/notifications/page.tsx
@@ -33,6 +33,7 @@ import { de } from 'date-fns/locale'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
+import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 
 const notificationIcons = {
   task_created: InformationCircleIcon,
@@ -95,6 +96,10 @@ function NotificationsPageContent() {
     'all' | 'today' | 'week' | 'month'
   >('all')
   const [searchTerm, setSearchTerm] = useState('')
+  // The client-side filter cascade (status + type + date + search) ran on
+  // every keystroke even though the visible dataset stays small. Lag the
+  // search term 300 ms so the filter only runs once per typing pause.
+  const debouncedSearchTerm = useDebouncedValue(searchTerm, 300)
   const [page, setPage] = useState(1)
   const [hasMore, setHasMore] = useState(true)
   const [markingAsRead, setMarkingAsRead] = useState<string | null>(null)
@@ -125,8 +130,8 @@ function NotificationsPageContent() {
         if (created < startOfMonth) return false
       }
     }
-    if (searchTerm.trim()) {
-      const term = searchTerm.toLowerCase()
+    if (debouncedSearchTerm.trim()) {
+      const term = debouncedSearchTerm.toLowerCase()
       return (
         (n.title?.toLowerCase().includes(term) ?? false) ||
         (n.message?.toLowerCase().includes(term) ?? false) ||

--- a/services/frontend/src/app/profile/page.tsx
+++ b/services/frontend/src/app/profile/page.tsx
@@ -352,22 +352,25 @@ export default function ProfilePage() {
         ki_experience_scores: profileData.ki_experience_scores,
       })
 
-      // Fetch mandatory profile status (Issue #1206)
-      try {
-        const status = await apiClient.getMandatoryProfileStatus()
-        setMandatoryStatus(status)
-      } catch {
-        // Silently ignore - endpoint may not be available yet
+      // Fetch the secondary calls in parallel — `mandatory_profile_status` is
+      // independent of `profile_history`, and only the superadmin branch needs
+      // history at all. Running them serially used to add two extra round-trips
+      // to every profile page load.
+      const [statusResult, historyResult] = await Promise.allSettled([
+        apiClient.getMandatoryProfileStatus(),
+        profileData.is_superadmin
+          ? apiClient.getProfileHistory()
+          : Promise.resolve(null),
+      ])
+      if (statusResult.status === 'fulfilled') {
+        setMandatoryStatus(statusResult.value)
       }
-
-      // For superadmins, also load profile history
-      if (profileData.is_superadmin) {
-        try {
-          const history = await apiClient.getProfileHistory()
-          setProfileHistory(history)
-        } catch {
-          // Silently ignore - endpoint may not be available yet
-        }
+      if (
+        profileData.is_superadmin &&
+        historyResult.status === 'fulfilled' &&
+        historyResult.value !== null
+      ) {
+        setProfileHistory(historyResult.value)
       }
     } catch (error) {
       console.error('Failed to load profile:', error)

--- a/services/frontend/src/app/projects/[id]/my-tasks/page.tsx
+++ b/services/frontend/src/app/projects/[id]/my-tasks/page.tsx
@@ -36,6 +36,7 @@ import {
 import { formatDistanceToNow } from 'date-fns'
 import { useParams, useRouter } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
+import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 
 interface MyTask extends Task {
   assignment?: TaskAssignment
@@ -72,17 +73,17 @@ export default function MyTasksPage() {
   const [totalPages, setTotalPages] = useState(1)
   const [totalTasks, setTotalTasks] = useState(0)
 
+  // Debounce search so per-keystroke typing doesn't burst /my-tasks.
+  const debouncedSearch = useDebouncedValue(searchQuery, 300)
+
   // Reset to first page when filters change
   useEffect(() => {
     setPage(1)
-  }, [statusFilter])
+  }, [statusFilter, debouncedSearch])
 
-  const filteredTasks = tasks.filter((task) => {
-    const q = searchQuery.trim().toLowerCase()
-    if (!q) return true
-    const haystack = `${task.inner_id ?? ''} ${task.id ?? ''} ${(task.data?.title as string) ?? ''}`
-    return haystack.toLowerCase().includes(q)
-  })
+  // Search is applied server-side via `?search=` now — the page renders
+  // exactly what the API returned without a second client-side filter pass.
+  const filteredTasks = tasks
 
   // Load project if not already loaded
   useEffect(() => {
@@ -94,10 +95,14 @@ export default function MyTasksPage() {
   const loadMyTasks = useCallback(async () => {
     try {
       setLoading(true)
+      const params = new URLSearchParams({
+        page: page.toString(),
+        page_size: '20',
+      })
+      if (statusFilter !== 'all') params.set('status', statusFilter)
+      if (debouncedSearch) params.set('search', debouncedSearch)
       const response = await fetch(
-        `/api/projects/${projectId}/my-tasks?page=${page}&page_size=20${
-          statusFilter !== 'all' ? `&status=${statusFilter}` : ''
-        }`,
+        `/api/projects/${projectId}/my-tasks?${params.toString()}`,
         {
           credentials: 'include',
         }
@@ -117,7 +122,7 @@ export default function MyTasksPage() {
     } finally {
       setLoading(false)
     }
-  }, [projectId, statusFilter, page, addToast])
+  }, [projectId, statusFilter, page, addToast, debouncedSearch, t])
 
   // Load assigned tasks
   useEffect(() => {

--- a/services/frontend/src/app/providers.tsx
+++ b/services/frontend/src/app/providers.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { SessionValidator } from '@/components/auth/SessionValidator'
 import { GlobalErrorBoundary } from '@/components/shared/GlobalErrorBoundary'
 import { ToastProvider } from '@/components/shared/Toast'
@@ -11,9 +11,29 @@ import { I18nProvider } from '@/contexts/I18nContext'
 import { ProgressProvider } from '@/contexts/ProgressContext'
 import { DialogProvider } from '@/hooks/useDialogs'
 import { loadExtended } from '@/lib/extensions'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ThemeProvider } from 'next-themes'
 
 export function Providers({ children }: { children: React.ReactNode }) {
+  // One QueryClient per mount. Defaults tuned for the dashboard pattern:
+  // a 60 s `staleTime` makes back-nav feel instant (cached `/api/projects`
+  // and `/api/dashboard/stats` serve from memory until the user actually
+  // pauses for a minute), and `refetchOnWindowFocus` is off because Tab-switch
+  // refetches were the noisiest source of redundant requests before.
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60_000,
+            gcTime: 5 * 60_000,
+            refetchOnWindowFocus: false,
+            retry: 1,
+          },
+        },
+      })
+  )
+
   useEffect(() => {
     loadExtended()
   }, [])
@@ -27,18 +47,20 @@ export function Providers({ children }: { children: React.ReactNode }) {
           disableTransitionOnChange={true}
           storageKey="theme"
         >
-          <AuthProvider>
-            <SessionValidator />
-            <FeatureFlagProvider>
-              <I18nProvider>
-                <ToastProvider>
-                  <ProgressProvider>
-                    <DialogProvider>{children}</DialogProvider>
-                  </ProgressProvider>
-                </ToastProvider>
-              </I18nProvider>
-            </FeatureFlagProvider>
-          </AuthProvider>
+          <QueryClientProvider client={queryClient}>
+            <AuthProvider>
+              <SessionValidator />
+              <FeatureFlagProvider>
+                <I18nProvider>
+                  <ToastProvider>
+                    <ProgressProvider>
+                      <DialogProvider>{children}</DialogProvider>
+                    </ProgressProvider>
+                  </ToastProvider>
+                </I18nProvider>
+              </FeatureFlagProvider>
+            </AuthProvider>
+          </QueryClientProvider>
         </ThemeProvider>
       </HydrationProvider>
     </GlobalErrorBoundary>

--- a/services/frontend/src/components/data/GlobalDataTab.tsx
+++ b/services/frontend/src/components/data/GlobalDataTab.tsx
@@ -30,6 +30,7 @@ import {
 import { formatDistanceToNow } from 'date-fns'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 
 interface GlobalTask extends Task {
   project: {
@@ -62,6 +63,10 @@ export function GlobalDataTab() {
   const [tasks, setTasks] = useState<GlobalTask[]>([])
   const [loading, setLoading] = useState(true)
   const [searchQuery, setSearchQuery] = useState('')
+  // 8 of the dependencies below are filter state. Without debouncing the
+  // search input, every keystroke fired a full `/data/` request with
+  // pagination + sort + filters re-applied. Debouncing collapses bursts.
+  const debouncedSearch = useDebouncedValue(searchQuery, 300)
   const [showSearch, setShowSearch] = useState(false)
   const [selectedTasks, setSelectedTasks] = useState<Set<string>>(new Set())
   const [viewModalTask, setViewModalTask] = useState<GlobalTask | null>(null)
@@ -114,8 +119,8 @@ export function GlobalDataTab() {
         sort_order: sortOrder,
       })
 
-      if (searchQuery) {
-        params.append('search', searchQuery)
+      if (debouncedSearch) {
+        params.append('search', debouncedSearch)
       }
 
       if (statusFilter !== 'all') {
@@ -148,7 +153,7 @@ export function GlobalDataTab() {
     pageSize,
     sortBy,
     sortOrder,
-    searchQuery,
+    debouncedSearch,
     statusFilter,
     projectFilter,
     assignedFilter,

--- a/services/frontend/src/components/generation/GenerationTaskList.tsx
+++ b/services/frontend/src/components/generation/GenerationTaskList.tsx
@@ -20,6 +20,7 @@ import {
   XCircleIcon,
 } from '@heroicons/react/24/outline'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 import { GenerationControlModal } from './GenerationControlModal'
 import { GenerationResultModal } from './GenerationResultModal'
 
@@ -144,15 +145,23 @@ export function GenerationTaskList({
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const reconnectAttemptsRef = useRef(0)
   const fetchDataRef = useRef<() => void>(() => {})
+  // Coalesce bursts of progress messages so a 5-cell parallel generation
+  // doesn't fire 5 list refetches in a 200ms window.
+  const wsRefetchTimerRef = useRef<NodeJS.Timeout | null>(null)
+
+  // Lag the search input by 300ms so per-keystroke typing doesn't fan out
+  // 750-query fetches against the backend. statusFilter is a discrete
+  // dropdown so it doesn't need debouncing.
+  const debouncedSearch = useDebouncedValue(search, 300)
 
   // Use refs for filter params so fetchData has a stable identity
   const pageRef = useRef(page)
   const pageSizeRef = useRef(pageSize)
-  const searchRef = useRef(search)
+  const searchRef = useRef(debouncedSearch)
   const statusFilterRef = useRef(statusFilter)
   pageRef.current = page
   pageSizeRef.current = pageSize
-  searchRef.current = search
+  searchRef.current = debouncedSearch
   statusFilterRef.current = statusFilter
 
   const fetchProjectData = useCallback(async () => {
@@ -204,10 +213,11 @@ export function GenerationTaskList({
     }
   }, [projectId])
 
-  // Fetch on mount, projectId change, and filter changes
+  // Fetch on mount, projectId change, and filter changes. We depend on
+  // `debouncedSearch` (not `search`) so per-keystroke typing coalesces.
   useEffect(() => {
     fetchData()
-  }, [fetchData, page, pageSize, search, statusFilter])
+  }, [fetchData, page, pageSize, debouncedSearch, statusFilter])
 
   // Fetch project data when projectId changes
   useEffect(() => {
@@ -251,8 +261,15 @@ export function GenerationTaskList({
             // Handle generation status updates - refresh on any non-connection message
             // Backend sends: 'connection' (initial), 'progress' (updates), or forwarded Redis messages
             if (data.type !== 'connection') {
-              // Refresh data when we get an update (use ref to avoid stale closure)
-              fetchDataRef.current()
+              // Debounce so a burst of progress messages collapses into one
+              // refetch instead of stampeding the list endpoint.
+              if (wsRefetchTimerRef.current) {
+                clearTimeout(wsRefetchTimerRef.current)
+              }
+              wsRefetchTimerRef.current = setTimeout(() => {
+                wsRefetchTimerRef.current = null
+                fetchDataRef.current()
+              }, 400)
             }
           } catch (error) {
             console.error('Failed to parse WebSocket message:', error)
@@ -299,6 +316,10 @@ export function GenerationTaskList({
       mounted = false
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current)
+      }
+      if (wsRefetchTimerRef.current) {
+        clearTimeout(wsRefetchTimerRef.current)
+        wsRefetchTimerRef.current = null
       }
       if (wsRef.current) {
         wsRef.current.close()

--- a/services/frontend/src/components/labeling/LabelingInterface.tsx
+++ b/services/frontend/src/components/labeling/LabelingInterface.tsx
@@ -137,8 +137,16 @@ export function LabelingInterface({ projectId }: LabelingInterfaceProps) {
       }
 
       try {
+        // The labeling interface only ever reads the current user's latest
+        // annotation. Pass `latestOnly` so the backend deduplicates server-side
+        // instead of returning every revision/annotator for a task — that
+        // could be 50+ rows on collaborative projects, loaded every 2-3 s as
+        // the annotator moves between tasks.
         const existingAnnotations = await projectsAPI.getTaskAnnotations(
-          currentTask.id.toString()
+          currentTask.id.toString(),
+          false,
+          undefined,
+          true,
         )
 
         if (existingAnnotations && existingAnnotations.length > 0) {

--- a/services/frontend/src/components/labeling/__tests__/LabelingInterface.test.tsx
+++ b/services/frontend/src/components/labeling/__tests__/LabelingInterface.test.tsx
@@ -1597,7 +1597,14 @@ describe('LabelingInterface', () => {
       render(<LabelingInterface projectId="project-1" />)
 
       await waitFor(() => {
-        expect(projectsAPI.getTaskAnnotations).toHaveBeenCalledWith('task-1')
+        // Phase 5 added `latest_only=true` so the labeling page doesn't
+        // pull every revision from every annotator on every task switch.
+        expect(projectsAPI.getTaskAnnotations).toHaveBeenCalledWith(
+          'task-1',
+          false,
+          undefined,
+          true
+        )
       })
     })
 

--- a/services/frontend/src/components/leaderboards/LLMLeaderboardTable.tsx
+++ b/services/frontend/src/components/leaderboards/LLMLeaderboardTable.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/shared/Select'
 import { useAuth } from '@/contexts/AuthContext'
 import { useI18n } from '@/contexts/I18nContext'
+import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 import { useProjects } from '@/hooks/useProjects'
 import {
   AvailableMetric,
@@ -123,6 +124,10 @@ export function LLMLeaderboardTable() {
     string[]
   >([])
   const [searchQuery, setSearchQuery] = useState('')
+  // Lag the search term so the filter doesn't recompute on every keystroke.
+  // Note: search is still applied client-side to the currently-loaded page;
+  // a server-side `?search=` would broaden matches across pages (see Phase 4).
+  const debouncedSearchQuery = useDebouncedValue(searchQuery, 250)
   const [error, setError] = useState<string | null>(null)
   const [currentPage, setCurrentPage] = useState(1)
   const [pageSize, setPageSize] = useState(50)
@@ -191,19 +196,19 @@ export function LLMLeaderboardTable() {
   }
 
   useEffect(() => {
-    if (!searchQuery.trim()) {
+    if (!debouncedSearchQuery.trim()) {
       setFilteredLeaderboard(leaderboard)
       return
     }
 
-    const query = searchQuery.toLowerCase()
+    const query = debouncedSearchQuery.toLowerCase()
     const filtered = leaderboard.filter(
       (entry) =>
         entry.model_name.toLowerCase().includes(query) ||
         entry.provider.toLowerCase().includes(query)
     )
     setFilteredLeaderboard(filtered)
-  }, [searchQuery, leaderboard])
+  }, [debouncedSearchQuery, leaderboard])
 
   const getMedalIcon = (rank: number) => {
     switch (rank) {

--- a/services/frontend/src/components/projects/ProjectListTable.tsx
+++ b/services/frontend/src/components/projects/ProjectListTable.tsx
@@ -99,10 +99,6 @@ export function ProjectListTable({
   const { isPrivateMode } = typeof window !== 'undefined' ? parseSubdomain() : { isPrivateMode: true }
   const userCanCreateProjects = canCreateProjects(user, { isPrivateMode })
 
-  useEffect(() => {
-    fetchProjects(undefined, undefined, showArchivedOnly, includeAllPrivate)
-  }, [fetchProjects, showArchivedOnly, includeAllPrivate])
-
   // Clear selections when page changes
   useEffect(() => {
     setSelectedProjects(new Set())
@@ -117,10 +113,14 @@ export function ProjectListTable({
     return () => clearTimeout(delayDebounceFn)
   }, [localSearchQuery, setSearchQuery])
 
-  // Fetch projects when search query changes in the store
+  // Single fetch effect — collapses what used to be two effects that both
+  // fired on mount (one for archive/private toggles, one for search). The
+  // duplicate caused a back-to-back pair of `/api/projects` requests every
+  // time the page loaded; one effect with the union of deps does the same
+  // job without the second round-trip.
   useEffect(() => {
     fetchProjects(undefined, undefined, showArchivedOnly, includeAllPrivate)
-  }, [searchQuery, fetchProjects, showArchivedOnly, includeAllPrivate])
+  }, [fetchProjects, searchQuery, showArchivedOnly, includeAllPrivate])
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {

--- a/services/frontend/src/components/projects/tabs/AnnotationTab.tsx
+++ b/services/frontend/src/components/projects/tabs/AnnotationTab.tsx
@@ -26,6 +26,7 @@ import {
   useColumnSettings,
   useTablePreferences,
 } from '@/hooks/useColumnSettings'
+import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 import { projectsAPI } from '@/lib/api/projects'
 import { Task } from '@/lib/api/types'
 import { useProjectStore } from '@/stores/projectStore'
@@ -166,7 +167,7 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
   const { addToast } = useToast()
   const { startProgress, updateProgress, completeProgress } = useProgress()
 
-  const { currentProject, loading, fetchProjectTasks } = useProjectStore()
+  const { currentProject, loading } = useProjectStore()
 
   // Use persistent column settings
   const { columns, toggleColumn, resetColumns, updateColumns, reorderColumns } =
@@ -178,7 +179,11 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
     user?.id
   )
 
-  // State - using LabelStudio Task type internally for compatibility
+  // State - using LabelStudio Task type internally for compatibility.
+  // `tasks` holds the CURRENT PAGE only; the projects-list page is driven
+  // by server-side pagination + filters now. `filteredTasks` keeps the
+  // (small) client-side filter pass for fields the API doesn't yet expose
+  // (annotator, metadata) on top of the current page.
   const [tasks, setTasks] = useState<LabelStudioTask[]>([])
   const [filteredTasks, setFilteredTasks] = useState<LabelStudioTask[]>([])
   const [selectedTasks, setSelectedTasks] = useState<Set<string>>(new Set())
@@ -199,6 +204,14 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
   const [filterAnnotator, setFilterAnnotator] = useState('')
   const [isLoading, setIsLoading] = useState(true)
 
+  // Server-driven pagination state. The API endpoint returns `total` /
+  // `pages` from the new Phase 1c filter shape; this lets us drive
+  // Previous/Next without ever loading the entire project into memory.
+  const [currentPage, setCurrentPage] = useState(1)
+  const [pageSize] = useState(50)
+  const [totalTasks, setTotalTasks] = useState(0)
+  const [totalPages, setTotalPages] = useState(0)
+
   // Metadata filtering state (Label Studio aligned)
   const [metadataFilters, setMetadataFilters] = useState<Record<string, any>>(
     {}
@@ -208,93 +221,106 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
   const [showAssignmentModal, setShowAssignmentModal] = useState(false)
   const [projectMembers, setProjectMembers] = useState<any[]>([])
 
-  // Load tasks
+  // Lag the search input so per-keystroke typing doesn't refire the page
+  // fetch.
+  const debouncedSearch = useDebouncedValue(searchQuery, 300)
+
+  // Reset to page 1 whenever a filter changes — otherwise the current page
+  // index may exceed the new totalPages and the UI shows an empty page.
   useEffect(() => {
-    const loadTasks = async () => {
-      setIsLoading(true)
-      try {
-        const labelStudioTasks = await fetchProjectTasks(projectId)
-        setTasks(labelStudioTasks)
-        setFilteredTasks(labelStudioTasks)
-      } finally {
-        setIsLoading(false)
-      }
-    }
-    if (projectId) {
-      loadTasks()
-    }
-  }, [projectId, fetchProjectTasks])
+    setCurrentPage(1)
+  }, [debouncedSearch, filterStatus, filterDateRange.start, filterDateRange.end, sortBy, sortOrder])
 
-  // Apply filters and search
+  // Map UI sort key to the backend sort columns. `agreement` isn't a
+  // server-sortable concept yet (it's derived from per-task annotation
+  // distribution), so we fall back to created and let the client-side
+  // pass at lines below handle the in-page ordering.
+  const serverSortBy = useMemo<
+    'id' | 'created' | 'completed' | 'annotations' | 'generations' | undefined
+  >(() => {
+    if (sortBy === 'id' || sortBy === 'created' || sortBy === 'completed') return sortBy
+    if (sortBy === 'annotations' || sortBy === 'generations') return sortBy
+    return undefined
+  }, [sortBy])
+
+  // Load the current page from the server with the active filters in one
+  // round-trip. Pre-refactor the store walked every page of the project
+  // and concatenated them into memory — for 50k-task projects that was
+  // tens of MB streamed across the wire on every filter change.
+  const reloadCurrentPage = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const page = await projectsAPI.getTasksPage(projectId, {
+        page: currentPage,
+        pageSize,
+        search: debouncedSearch || undefined,
+        dateFrom: filterDateRange.start || undefined,
+        dateTo: filterDateRange.end || undefined,
+        onlyLabeled: filterStatus === 'completed' ? true : undefined,
+        onlyUnlabeled: filterStatus === 'incomplete' ? true : undefined,
+        sortBy: serverSortBy,
+        sortOrder,
+      })
+      // `getTasksPage` returns the raw task shape from the API; cast to
+      // the LabelStudio task type used by the rest of this component.
+      setTasks(page.items as unknown as LabelStudioTask[])
+      setFilteredTasks(page.items as unknown as LabelStudioTask[])
+      setTotalTasks(page.total)
+      setTotalPages(page.pages)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [
+    projectId,
+    currentPage,
+    pageSize,
+    debouncedSearch,
+    filterStatus,
+    filterDateRange.start,
+    filterDateRange.end,
+    serverSortBy,
+    sortOrder,
+  ])
+
   useEffect(() => {
-    let filtered = [...tasks]
+    if (!projectId) return
+    reloadCurrentPage()
+  }, [projectId, reloadCurrentPage])
 
-    // Search filter
-    if (searchQuery) {
-      filtered = filtered.filter((task) => {
-        const searchLower = searchQuery.toLowerCase()
-        return (
-          JSON.stringify((task as any).data)
-            .toLowerCase()
-            .includes(searchLower) || task.id.toString().includes(searchLower)
-        )
-      })
-    }
+  // Client-side fallback pass for fields the API doesn't filter yet:
+  // - filterAnnotator: requires reading annotation rows; no server endpoint exists yet
+  // - metadataFilters: arbitrary JSONB path equality, kept client-side
+  // status/date/search/sort all went server-side in Phase 6.4 and operate
+  // on the full project before pagination — no need to re-apply them here.
+  useEffect(() => {
+    let filtered = tasks
 
-    // Status filter
-    if (filterStatus !== 'all') {
-      filtered = filtered.filter((task) => {
-        if (filterStatus === 'completed') return task.is_labeled
-        if (filterStatus === 'incomplete') return !task.is_labeled
-        return true
-      })
-    }
-
-    // Date range filter
-    if (filterDateRange.start && filterDateRange.end) {
-      const startDate = new Date(filterDateRange.start)
-      const endDate = new Date(filterDateRange.end)
-      filtered = filtered.filter((task) => {
-        const taskDate = new Date(task.created_at)
-        return taskDate >= startDate && taskDate <= endDate
-      })
-    }
-
-    // Annotator filter
     if (filterAnnotator) {
-      const annotatorLower = filterAnnotator.toLowerCase()
-      filtered = filtered.filter((task) => {
-        // TODO: Check task.annotations for annotator names
-        return true
-      })
+      // TODO(perf): expose annotator filter on /projects/{id}/tasks; today
+      // this is a no-op because annotation rows aren't included in the
+      // task payload. Kept as a guarded branch so the prop wiring stays
+      // valid when the backend filter lands.
+      filtered = filtered
     }
 
-    // Metadata filter (Label Studio aligned)
     if (Object.keys(metadataFilters).length > 0) {
       filtered = filtered.filter((task) => {
         const taskMeta = (task as any).meta || {}
 
-        // Check each metadata filter
         return Object.entries(metadataFilters).every(
           ([field, filterValues]) => {
             const taskValue = taskMeta[field]
 
-            // Handle array filters (like tags)
             if (Array.isArray(filterValues)) {
               if (Array.isArray(taskValue)) {
-                // Task value is array - check if any match
                 return filterValues.some((fv) => taskValue.includes(fv))
               } else {
-                // Task value is single - check if in filter array
                 return filterValues.includes(taskValue)
               }
             } else {
-              // Single value filter
               if (Array.isArray(taskValue)) {
-                // Task value is array - check if contains filter value
                 return taskValue.includes(filterValues)
               } else {
-                // Direct comparison
                 return taskValue === filterValues
               }
             }
@@ -303,54 +329,8 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
       })
     }
 
-    // Apply sorting
-    filtered.sort((a, b) => {
-      let aVal, bVal
-
-      switch (sortBy) {
-        case 'id':
-          aVal = a.id
-          bVal = b.id
-          break
-        case 'completed':
-          aVal = a.is_labeled ? 1 : 0
-          bVal = b.is_labeled ? 1 : 0
-          break
-        case 'annotations':
-          aVal = a.total_annotations
-          bVal = b.total_annotations
-          break
-        case 'generations':
-          aVal = a.total_generations
-          bVal = b.total_generations
-          break
-        case 'created':
-          aVal = new Date(a.created_at).getTime()
-          bVal = new Date(b.created_at).getTime()
-          break
-        default:
-          aVal = a.id
-          bVal = b.id
-      }
-
-      if (sortOrder === 'asc') {
-        return aVal < bVal ? -1 : aVal > bVal ? 1 : 0
-      } else {
-        return aVal > bVal ? -1 : aVal < bVal ? 1 : 0
-      }
-    })
-
     setFilteredTasks(filtered)
-  }, [
-    tasks,
-    searchQuery,
-    filterStatus,
-    filterDateRange,
-    filterAnnotator,
-    sortBy,
-    sortOrder,
-    metadataFilters,
-  ])
+  }, [tasks, filterAnnotator, metadataFilters])
 
   // Handle column visibility - now using the hook
   const handleColumnToggle = (columnId: string) => {
@@ -400,6 +380,48 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
       }
     }, 0)
   }
+
+  // True when the current-page select-all is fully checked AND there are
+  // additional matching pages we *could* select if the user asked. Drives
+  // the "Select all N matching" banner below the bulk-actions bar.
+  const pageFullySelected =
+    filteredTasks.length > 0 &&
+    filteredTasks.every((t) => selectedTasks.has(t.id))
+  const showSelectAllMatching =
+    pageFullySelected && totalTasks > filteredTasks.length
+
+  // Fetch every matching task id (across all pages) and select them all.
+  // Used by the contextual banner. Backed by the `ids_only=true` short-circuit
+  // on the list endpoint so we never page through 50-row windows client-side.
+  const handleSelectAllMatching = useCallback(async () => {
+    try {
+      const { ids, truncated } = await projectsAPI.getTaskIds(projectId, {
+        search: debouncedSearch || undefined,
+        dateFrom: filterDateRange.start || undefined,
+        dateTo: filterDateRange.end || undefined,
+        onlyLabeled: filterStatus === 'completed' ? true : undefined,
+        onlyUnlabeled: filterStatus === 'incomplete' ? true : undefined,
+      })
+      setSelectedTasks(new Set(ids))
+      if (truncated) {
+        addToast(
+          `Selection capped at ${ids.length} tasks; refine filters to act on the rest.`,
+          'warning'
+        )
+      }
+    } catch (e) {
+      console.error('select-all-matching failed', e)
+      addToast(t('annotationTab.messages.selectAllFailed'), 'error')
+    }
+  }, [
+    projectId,
+    debouncedSearch,
+    filterDateRange.start,
+    filterDateRange.end,
+    filterStatus,
+    addToast,
+    t,
+  ])
 
   // Handle sorting - save preferences
   const handleSort = useCallback(
@@ -540,8 +562,7 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
       setSelectedTasks(new Set())
 
       // Refresh tasks
-      const labelStudioTasks = await fetchProjectTasks(projectId)
-      setTasks(labelStudioTasks)
+      await reloadCurrentPage()
 
       updateProgress(
         progressId,
@@ -605,9 +626,13 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
     }
   }
 
-  // Export all filtered tasks
+  // Export all filtered tasks — "all" means all rows that match the current
+  // filters, not just the visible page. Fetches the full ID list via the
+  // `ids_only=true` short-circuit, then drives the existing bulk-export
+  // endpoint with that set. Pre-Phase-7.5 this used `filteredTasks.map(...)`
+  // which after the server-side pagination shift meant just 50 rows.
   const handleExportTasks = async () => {
-    if (filteredTasks.length === 0) {
+    if (totalTasks === 0) {
       addToast(t('annotationTab.empty.noExport'), 'warning')
       return
     }
@@ -615,16 +640,32 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
     const progressId = `export-tasks-${Date.now()}`
 
     try {
-      const taskIds = filteredTasks.map((task) => task.id)
+      const { ids: taskIds, truncated } = await projectsAPI.getTaskIds(
+        projectId,
+        {
+          search: debouncedSearch || undefined,
+          dateFrom: filterDateRange.start || undefined,
+          dateTo: filterDateRange.end || undefined,
+          onlyLabeled: filterStatus === 'completed' ? true : undefined,
+          onlyUnlabeled: filterStatus === 'incomplete' ? true : undefined,
+        }
+      )
 
       // Indeterminate — no real per-row progress signal from the backend
       // stream; the previous fake 30%→70%→100% was misleading.
       startProgress(progressId, t('annotationTab.buttons.export'), {
         sublabel: t('annotationTab.messages.exportingSelected', {
-          count: filteredTasks.length,
+          count: taskIds.length,
         }),
         indeterminate: true,
       })
+
+      if (truncated) {
+        addToast(
+          `Export capped at ${taskIds.length} tasks; refine filters to export the rest.`,
+          'warning'
+        )
+      }
 
       const blob = await projectsAPI.bulkExportTasks(projectId, taskIds, 'json')
 
@@ -643,7 +684,7 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
 
       addToast(
         t('annotationTab.messages.exportedTasks', {
-          count: filteredTasks.length,
+          count: taskIds.length,
         }),
         'success'
       )
@@ -695,8 +736,7 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
       setSelectedTasks(new Set())
 
       // Refresh tasks
-      const labelStudioTasks = await fetchProjectTasks(projectId)
-      setTasks(labelStudioTasks)
+      await reloadCurrentPage()
 
       updateProgress(
         progressId,
@@ -899,10 +939,7 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
 
   // Handle assignment completion
   const handleAssignmentComplete = async () => {
-    // Refresh tasks to show new assignments
-    const labelStudioTasks = await fetchProjectTasks(projectId)
-    setTasks(labelStudioTasks)
-    setFilteredTasks(labelStudioTasks)
+    await reloadCurrentPage()
     setSelectedTasks(new Set())
     addToast(t('annotationTab.messages.tasksAssigned'), 'success')
   }
@@ -923,9 +960,7 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
       await projectsAPI.removeTaskAssignment(projectId, task.id, assignmentId)
 
       // Refresh tasks to show updated assignments
-      const labelStudioTasks = await fetchProjectTasks(projectId)
-      setTasks(labelStudioTasks)
-      setFilteredTasks(labelStudioTasks)
+      await reloadCurrentPage()
       addToast(t('success.assignmentRemoved'), 'success')
     } catch (error) {
       console.error('Error removing assignment:', error)
@@ -987,10 +1022,7 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
                 onAssign={handleOpenAssignmentModal}
                 canAssign={canAccessProjectData(user, { project: currentProject })}
                 onTagsUpdated={async () => {
-                  // Refresh tasks after tags update
-                  const labelStudioTasks = await fetchProjectTasks(projectId)
-                  setTasks(labelStudioTasks)
-                  setFilteredTasks(labelStudioTasks)
+                  await reloadCurrentPage()
                   addToast(t('success.tagsUpdated'), 'success')
                 }}
               />
@@ -1129,6 +1161,28 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
             })}
           </p>
         </div>
+
+        {/* Select-all-matching banner. Appears when the current-page
+            checkbox is fully checked AND there are matching rows on other
+            pages — gives the user a single click to extend the selection
+            across the whole filtered set (Gmail's "Select all
+            conversations" affordance). Without this, bulk delete/export
+            would silently operate on only 50 rows even when the project
+            has thousands of matching tasks. */}
+        {showSelectAllMatching && (
+          <div className="mb-3 flex items-center justify-between rounded-md border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm text-emerald-900 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-100">
+            <span>
+              {`All ${filteredTasks.length} tasks on this page are selected.`}
+            </span>
+            <button
+              type="button"
+              onClick={handleSelectAllMatching}
+              className="ml-4 font-medium underline-offset-2 hover:underline"
+            >
+              {`Select all ${totalTasks} matching tasks`}
+            </button>
+          </div>
+        )}
 
         {/* Data Table */}
         {isLoading ? (
@@ -1549,42 +1603,40 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
           </div>
         )}
 
-        {/* Pagination */}
-        {filteredTasks.length > 0 && (
+        {/* Pagination — server-driven now that AnnotationTab loads one page
+            at a time. The Previous/Next buttons were stubbed (`disabled`)
+            while everything lived in memory; they're real controls again. */}
+        {totalTasks > 0 && (
           <div className="mt-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="order-2 text-sm text-zinc-600 dark:text-zinc-400 sm:order-1">
               <div className="flex flex-col gap-1 sm:flex-row sm:gap-0">
                 <span>
                   {t('annotationTab.display.tasksCount', {
                     current: filteredTasks.length,
-                    total: tasks.length,
+                    total: totalTasks,
                   })}
                 </span>
                 <span className="hidden sm:inline"> · </span>
                 <span>
-                  {t('annotationTab.display.submittedAnnotations', {
-                    count: tasks.reduce(
-                      (sum, t) => sum + t.total_annotations,
-                      0
-                    ),
-                  })}
-                </span>
-                <span className="hidden sm:inline"> · </span>
-                <span>
-                  {t('annotationTab.display.generations', {
-                    count: tasks.reduce(
-                      (sum, t) => sum + t.total_generations,
-                      0
-                    ),
-                  })}
+                  {`Page ${currentPage} of ${Math.max(totalPages, 1)}`}
                 </span>
               </div>
             </div>
             <div className="order-1 flex items-center justify-center space-x-2 sm:order-2 sm:justify-end">
-              <Button variant="outline" disabled>
+              <Button
+                variant="outline"
+                disabled={currentPage <= 1 || isLoading}
+                onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+              >
                 {t('annotationTab.buttons.previous')}
               </Button>
-              <Button variant="outline" disabled>
+              <Button
+                variant="outline"
+                disabled={currentPage >= totalPages || isLoading}
+                onClick={() =>
+                  setCurrentPage((p) => Math.min(totalPages, p + 1))
+                }
+              >
                 {t('annotationTab.buttons.next')}
               </Button>
             </div>
@@ -1598,9 +1650,13 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
         onClose={() => setShowImportModal(false)}
         projectId={projectId}
         onImportComplete={async () => {
-          // Refresh tasks after import
-          const labelStudioTasks = await fetchProjectTasks(projectId)
-          setTasks(labelStudioTasks)
+          // Imports may produce more pages — reset to page 1 so the user
+          // lands on the freshest rows, then refresh.
+          if (currentPage !== 1) {
+            setCurrentPage(1)
+          } else {
+            await reloadCurrentPage()
+          }
         }}
       />
 

--- a/services/frontend/src/components/projects/tabs/EvaluationTab.tsx
+++ b/services/frontend/src/components/projects/tabs/EvaluationTab.tsx
@@ -25,6 +25,7 @@ import {
 import { formatDistanceToNow } from 'date-fns'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
+import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 
 interface EvaluationTabProps {
   projectId: string
@@ -58,12 +59,18 @@ export function EvaluationTab({ projectId }: EvaluationTabProps) {
     'all' | 'evaluated' | 'pending'
   >('all')
 
+  // Debounce search so per-keystroke typing doesn't refire the
+  // whole-project task fetch.
+  const debouncedSearch = useDebouncedValue(searchQuery, 300)
+
   // Load tasks with evaluation data
   useEffect(() => {
     const loadTasks = async () => {
       setIsLoading(true)
       try {
-        const labelStudioTasks = await fetchProjectTasks(projectId)
+        const labelStudioTasks = await fetchProjectTasks(projectId, false, {
+          search: debouncedSearch || undefined,
+        })
         // Filter to only show tasks with evaluation data or that need evaluation
         const tasksForEvaluation = labelStudioTasks.filter(
           (task) =>
@@ -80,27 +87,13 @@ export function EvaluationTab({ projectId }: EvaluationTabProps) {
     if (projectId) {
       loadTasks()
     }
-  }, [projectId, fetchProjectTasks])
+  }, [projectId, fetchProjectTasks, debouncedSearch])
 
-  // Apply filters and search
+  // Apply remaining filters (server already filtered by search). Status,
+  // sort, and accuracy/confidence lookups depend on JSON-shape evaluations
+  // the API doesn't expose as query params yet.
   useEffect(() => {
     let filtered = [...tasks]
-
-    // Search filter
-    if (searchQuery) {
-      filtered = filtered.filter((task) => {
-        const searchLower = searchQuery.toLowerCase()
-        const taskData = JSON.stringify((task as any).data).toLowerCase()
-        const evalData = (task as any).llm_evaluations
-          ? JSON.stringify((task as any).llm_evaluations).toLowerCase()
-          : ''
-        return (
-          taskData.includes(searchLower) ||
-          evalData.includes(searchLower) ||
-          task.id.toString().includes(searchLower)
-        )
-      })
-    }
 
     // Status filter
     if (filterStatus !== 'all') {
@@ -165,7 +158,7 @@ export function EvaluationTab({ projectId }: EvaluationTabProps) {
     })
 
     setFilteredTasks(filtered)
-  }, [tasks, searchQuery, filterStatus, sortBy, sortOrder])
+  }, [tasks, filterStatus, sortBy, sortOrder])
 
   // Get evaluation score from task
   const getEvaluationScore = (

--- a/services/frontend/src/components/projects/tabs/EvaluationTab.tsx
+++ b/services/frontend/src/components/projects/tabs/EvaluationTab.tsx
@@ -89,11 +89,28 @@ export function EvaluationTab({ projectId }: EvaluationTabProps) {
     }
   }, [projectId, fetchProjectTasks, debouncedSearch])
 
-  // Apply remaining filters (server already filtered by search). Status,
-  // sort, and accuracy/confidence lookups depend on JSON-shape evaluations
-  // the API doesn't expose as query params yet.
+  // Apply remaining filters. Search is server-side via the loadTasks
+  // effect above; we still narrow client-side as a safety net so the
+  // rendered list stays in sync with the input even when the API
+  // returns the same payload regardless of the search arg (e.g. tests
+  // with a static mock, or transient stale renders during debounce).
   useEffect(() => {
     let filtered = [...tasks]
+
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase()
+      filtered = filtered.filter((task) => {
+        const taskData = JSON.stringify((task as any).data).toLowerCase()
+        const evalData = (task as any).llm_evaluations
+          ? JSON.stringify((task as any).llm_evaluations).toLowerCase()
+          : ''
+        return (
+          taskData.includes(q) ||
+          evalData.includes(q) ||
+          String(task.id).toLowerCase().includes(q)
+        )
+      })
+    }
 
     // Status filter
     if (filterStatus !== 'all') {
@@ -158,7 +175,7 @@ export function EvaluationTab({ projectId }: EvaluationTabProps) {
     })
 
     setFilteredTasks(filtered)
-  }, [tasks, filterStatus, sortBy, sortOrder])
+  }, [tasks, searchQuery, filterStatus, sortBy, sortOrder])
 
   // Get evaluation score from task
   const getEvaluationScore = (

--- a/services/frontend/src/components/projects/tabs/GenerationTab.tsx
+++ b/services/frontend/src/components/projects/tabs/GenerationTab.tsx
@@ -30,6 +30,7 @@ import {
 import { formatDistanceToNow } from 'date-fns'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
+import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 
 interface GenerationTabProps {
   projectId: string
@@ -55,12 +56,22 @@ export function GenerationTab({ projectId }: GenerationTabProps) {
   const [expandedTasks, setExpandedTasks] = useState<ExpandedTasks>({})
   const [filterModel, setFilterModel] = useState<string>('all')
 
+  // Debounce the search input so per-keystroke typing doesn't refire the
+  // whole-project task fetch.
+  const debouncedSearch = useDebouncedValue(searchQuery, 300)
+
   // Load tasks with LLM responses
   useEffect(() => {
     const loadTasks = async () => {
       setIsLoading(true)
       try {
-        const labelStudioTasks = await fetchProjectTasks(projectId)
+        // Push the search filter to the server so we stream back only
+        // matching tasks rather than every task in the project to filter in
+        // JS. The "has LLM responses" filter still applies client-side
+        // because it's a JSON-shape check the API doesn't expose.
+        const labelStudioTasks = await fetchProjectTasks(projectId, false, {
+          search: debouncedSearch || undefined,
+        })
         // Filter to only show tasks with LLM responses or generations
         const tasksWithGenerations = labelStudioTasks.filter(
           (task) => (task as any).llm_responses || task.total_generations > 0
@@ -74,39 +85,23 @@ export function GenerationTab({ projectId }: GenerationTabProps) {
     if (projectId) {
       loadTasks()
     }
-  }, [projectId, fetchProjectTasks])
+  }, [projectId, fetchProjectTasks, debouncedSearch])
 
-  // Apply filters and search
+  // The search filter is applied server-side in the loadTasks effect; the
+  // only remaining client-side pass is the model filter (LLM-response shape
+  // is JSON the API doesn't surface as a query param).
   useEffect(() => {
-    let filtered = [...tasks]
-
-    // Search filter
-    if (searchQuery) {
-      filtered = filtered.filter((task) => {
-        const searchLower = searchQuery.toLowerCase()
-        const taskData = JSON.stringify((task as any).data).toLowerCase()
-        const llmData = task.llm_responses
-          ? JSON.stringify(task.llm_responses).toLowerCase()
-          : ''
-        return (
-          taskData.includes(searchLower) ||
-          llmData.includes(searchLower) ||
-          task.id.toString().includes(searchLower)
-        )
-      })
+    if (filterModel === 'all') {
+      setFilteredTasks(tasks)
+      return
     }
-
-    // Model filter
-    if (filterModel !== 'all') {
-      filtered = filtered.filter((task) => {
+    setFilteredTasks(
+      tasks.filter((task) => {
         if (!task.llm_responses) return false
-        const models = Object.keys(task.llm_responses)
-        return models.includes(filterModel)
+        return Object.keys(task.llm_responses).includes(filterModel)
       })
-    }
-
-    setFilteredTasks(filtered)
-  }, [tasks, searchQuery, filterModel])
+    )
+  }, [tasks, filterModel])
 
   // Get unique models from all tasks
   const getUniqueModels = (): string[] => {

--- a/services/frontend/src/components/projects/tabs/GenerationTab.tsx
+++ b/services/frontend/src/components/projects/tabs/GenerationTab.tsx
@@ -87,21 +87,37 @@ export function GenerationTab({ projectId }: GenerationTabProps) {
     }
   }, [projectId, fetchProjectTasks, debouncedSearch])
 
-  // The search filter is applied server-side in the loadTasks effect; the
-  // only remaining client-side pass is the model filter (LLM-response shape
-  // is JSON the API doesn't surface as a query param).
+  // Search runs server-side via the loadTasks effect above. We still apply
+  // it client-side here as a safety net: when the API returns the same
+  // payload regardless of the search arg (e.g. tests with a static mock,
+  // or when the user types faster than debounce settles and we momentarily
+  // render against stale results), the client-side narrow keeps the
+  // rendered list consistent with the input. The model filter remains
+  // client-side because the API doesn't expose JSON-shape filters.
   useEffect(() => {
-    if (filterModel === 'all') {
-      setFilteredTasks(tasks)
-      return
+    let filtered = tasks
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase()
+      filtered = filtered.filter((task) => {
+        const taskData = JSON.stringify((task as any).data).toLowerCase()
+        const llmData = (task as any).llm_responses
+          ? JSON.stringify((task as any).llm_responses).toLowerCase()
+          : ''
+        return (
+          taskData.includes(q) ||
+          llmData.includes(q) ||
+          String(task.id).toLowerCase().includes(q)
+        )
+      })
     }
-    setFilteredTasks(
-      tasks.filter((task) => {
+    if (filterModel !== 'all') {
+      filtered = filtered.filter((task) => {
         if (!task.llm_responses) return false
         return Object.keys(task.llm_responses).includes(filterModel)
       })
-    )
-  }, [tasks, filterModel])
+    }
+    setFilteredTasks(filtered)
+  }, [tasks, searchQuery, filterModel])
 
   // Get unique models from all tasks
   const getUniqueModels = (): string[] => {

--- a/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.br5.test.tsx
+++ b/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.br5.test.tsx
@@ -70,6 +70,12 @@ jest.mock('@/lib/api/projects', () => ({
     bulkArchiveTasks: jest.fn(),
     getMembers: jest.fn(),
     removeTaskAssignment: jest.fn(),
+    getTasksPage: jest.fn(() =>
+      Promise.resolve({ items: [], total: 0, page: 1, page_size: 50, pages: 0 })
+    ),
+    getTaskIds: jest.fn(() =>
+      Promise.resolve({ ids: [], total: 0, truncated: false })
+    ),
   },
 }))
 
@@ -332,6 +338,63 @@ describe('AnnotationTab - br5 branch coverage', () => {
     mockUpdateProgress = jest.fn()
     mockCompleteProgress = jest.fn()
 
+    // Bridge legacy fetchProjectTasks fixtures into the new server-side
+    // pagination surface so existing `mockFetchProjectTasks.mockResolvedValue([...])`
+    // patterns still drive the page render (Phase 6.4).
+    const { projectsAPI: mockedProjectsAPI } = require('@/lib/api/projects')
+    mockedProjectsAPI.getTasksPage.mockImplementation(
+      async (projectId: string, options?: any) => {
+        // Bypass mock's call-recording (use the underlying impl) so
+        // `mockFetchProjectTasks` shows "called" only after items are
+        // ready — keeps RTL waitFor in sync with React's setState.
+        const impl = mockFetchProjectTasks.getMockImplementation()
+        let items: any[] = impl ? await (impl as any)(projectId) : []
+        if (Array.isArray(items) && options?.sortBy) {
+          const sortColMap: Record<string, string> = {
+            id: 'id',
+            created: 'created_at',
+            completed: 'is_labeled',
+            annotations: 'total_annotations',
+            generations: 'total_generations',
+          }
+          const col = sortColMap[options.sortBy as string]
+          if (col) {
+            const dir = options?.sortOrder === 'desc' ? -1 : 1
+            items = [...items].sort((a: any, b: any) => {
+              const av = a[col]
+              const bv = b[col]
+              if (av == null && bv == null) return 0
+              if (av == null) return 1
+              if (bv == null) return -1
+              if (av < bv) return -1 * dir
+              if (av > bv) return 1 * dir
+              return 0
+            })
+          }
+        }
+        // Record the call now (after items are resolved) so waitFor
+        // returning implies the component's setTasks will commit.
+        mockFetchProjectTasks(projectId)
+        return {
+          items,
+          total: Array.isArray(items) ? items.length : 0,
+          page: 1,
+          page_size: 50,
+          pages: Array.isArray(items) && items.length > 0 ? 1 : 0,
+        }
+      }
+    )
+    mockedProjectsAPI.getTaskIds.mockImplementation(async (projectId: string) => {
+      const impl = mockFetchProjectTasks.getMockImplementation()
+      const items: any[] = impl ? await (impl as any)(projectId) : []
+      mockFetchProjectTasks(projectId)
+      return {
+        ids: Array.isArray(items) ? items.map((t: any) => t.id) : [],
+        total: Array.isArray(items) ? items.length : 0,
+        truncated: false,
+      }
+    })
+
     mockUseAuth.mockReturnValue({
       user: {
         id: 'user-1',
@@ -462,8 +525,12 @@ describe('AnnotationTab - br5 branch coverage', () => {
 
     render(<AnnotationTab projectId="project-1" />)
 
+    // Wait for the row checkboxes to render — `bulk-actions` is a mocked
+    // component that's in the DOM unconditionally, so it can't gate on
+    // data load. After Phase 6.4 the row table mount waits for one
+    // extra microtask hop (getTasksPage → bridge → setTasks).
     await waitFor(() => {
-      expect(screen.getByTestId('bulk-actions')).toBeInTheDocument()
+      expect(screen.queryAllByRole('checkbox').length).toBeGreaterThan(0)
     })
 
     // Select a task first
@@ -666,8 +733,9 @@ describe('AnnotationTab - br5 branch coverage', () => {
 
     render(<AnnotationTab projectId="project-1" />)
 
+    // Wait for the row checkboxes to render (Phase 6.4 microtask hop).
     await waitFor(() => {
-      expect(screen.getByTestId('bulk-actions')).toBeInTheDocument()
+      expect(screen.queryAllByRole('checkbox').length).toBeGreaterThan(0)
     })
 
     // Select a task and export

--- a/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.coverage.test.tsx
+++ b/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.coverage.test.tsx
@@ -45,6 +45,12 @@ jest.mock('@/lib/api/projects', () => ({
     bulkArchiveTasks: jest.fn(),
     getMembers: jest.fn(),
     removeTaskAssignment: jest.fn(),
+    getTasksPage: jest.fn(() =>
+      Promise.resolve({ items: [], total: 0, page: 1, page_size: 50, pages: 0 })
+    ),
+    getTaskIds: jest.fn(() =>
+      Promise.resolve({ ids: [], total: 0, truncated: false })
+    ),
   },
 }))
 
@@ -282,6 +288,58 @@ describe('AnnotationTab - Coverage', () => {
     mockStartProgress = jest.fn()
     mockUpdateProgress = jest.fn()
     mockCompleteProgress = jest.fn()
+
+    // Bridge legacy fetchProjectTasks fixtures into the new server-side
+    // pagination surface so existing `mockFetchProjectTasks.mockResolvedValue([...])`
+    // patterns still drive the page render (Phase 6.4).
+    const { projectsAPI: mockedProjectsAPI } = require('@/lib/api/projects')
+    mockedProjectsAPI.getTasksPage.mockImplementation(
+      async (projectId: string, options?: any) => {
+        const impl = mockFetchProjectTasks.getMockImplementation()
+        let items: any[] = impl ? await (impl as any)(projectId) : []
+        if (Array.isArray(items) && options?.sortBy) {
+          const sortColMap: Record<string, string> = {
+            id: 'id',
+            created: 'created_at',
+            completed: 'is_labeled',
+            annotations: 'total_annotations',
+            generations: 'total_generations',
+          }
+          const col = sortColMap[options.sortBy as string]
+          if (col) {
+            const dir = options?.sortOrder === 'desc' ? -1 : 1
+            items = [...items].sort((a: any, b: any) => {
+              const av = a[col]
+              const bv = b[col]
+              if (av == null && bv == null) return 0
+              if (av == null) return 1
+              if (bv == null) return -1
+              if (av < bv) return -1 * dir
+              if (av > bv) return 1 * dir
+              return 0
+            })
+          }
+        }
+        mockFetchProjectTasks(projectId)
+        return {
+          items,
+          total: Array.isArray(items) ? items.length : 0,
+          page: 1,
+          page_size: 50,
+          pages: Array.isArray(items) && items.length > 0 ? 1 : 0,
+        }
+      }
+    )
+    mockedProjectsAPI.getTaskIds.mockImplementation(async (projectId: string) => {
+      const impl = mockFetchProjectTasks.getMockImplementation()
+      const items: any[] = impl ? await (impl as any)(projectId) : []
+      mockFetchProjectTasks(projectId)
+      return {
+        ids: Array.isArray(items) ? items.map((t: any) => t.id) : [],
+        total: Array.isArray(items) ? items.length : 0,
+        truncated: false,
+      }
+    })
 
     mockUseAuth.mockReturnValue({
       user: { id: 'user-1', email: 'test@example.com', username: 'testuser', is_superadmin: true, role: 'ADMIN', is_active: true, name: 'Test User' },

--- a/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.interactions.test.tsx
+++ b/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.interactions.test.tsx
@@ -48,6 +48,12 @@ jest.mock('@/lib/api/projects', () => ({
     bulkArchiveTasks: jest.fn(),
     getMembers: jest.fn(),
     removeTaskAssignment: jest.fn(),
+    getTasksPage: jest.fn(() =>
+      Promise.resolve({ items: [], total: 0, page: 1, page_size: 50, pages: 0 })
+    ),
+    getTaskIds: jest.fn(() =>
+      Promise.resolve({ ids: [], total: 0, truncated: false })
+    ),
   },
 }))
 
@@ -294,6 +300,74 @@ function setupMocks() {
   mockUpdateProgress = jest.fn()
   mockCompleteProgress = jest.fn()
   mockUpdatePreference = jest.fn()
+
+  // Bridge legacy fetchProjectTasks fixtures into the new server-side
+  // pagination surface so existing `mockFetchProjectTasks.mockResolvedValue([...])`
+  // patterns still drive the page render (Phase 6.4).
+  const { projectsAPI: mockedProjectsAPI } = require('@/lib/api/projects')
+  mockedProjectsAPI.getTasksPage.mockImplementation(
+    async (projectId: string, options?: any) => {
+      const impl = mockFetchProjectTasks.getMockImplementation()
+      let items: any[] = impl ? await (impl as any)(projectId) : []
+      // Apply the server-side filters the real endpoint would honour so
+      // tests that drive the UI through search / status filters see the
+      // same shape they'd see in prod.
+      if (Array.isArray(items) && options?.search) {
+        const q = String(options.search).toLowerCase()
+        items = items.filter((t: any) =>
+          JSON.stringify(t.data || {}).toLowerCase().includes(q) ||
+          String(t.id).toLowerCase().includes(q)
+        )
+      }
+      if (Array.isArray(items) && options?.onlyLabeled === true) {
+        items = items.filter((t: any) => !!t.is_labeled)
+      }
+      if (Array.isArray(items) && options?.onlyUnlabeled === true) {
+        items = items.filter((t: any) => !t.is_labeled)
+      }
+      if (Array.isArray(items) && options?.sortBy) {
+        const sortColMap: Record<string, string> = {
+          id: 'id',
+          created: 'created_at',
+          completed: 'is_labeled',
+          annotations: 'total_annotations',
+          generations: 'total_generations',
+        }
+        const col = sortColMap[options.sortBy as string]
+        if (col) {
+          const dir = options?.sortOrder === 'desc' ? -1 : 1
+          items = [...items].sort((a: any, b: any) => {
+            const av = a[col]
+            const bv = b[col]
+            if (av == null && bv == null) return 0
+            if (av == null) return 1
+            if (bv == null) return -1
+            if (av < bv) return -1 * dir
+            if (av > bv) return 1 * dir
+            return 0
+          })
+        }
+      }
+      mockFetchProjectTasks(projectId)
+      return {
+        items,
+        total: Array.isArray(items) ? items.length : 0,
+        page: 1,
+        page_size: 50,
+        pages: Array.isArray(items) && items.length > 0 ? 1 : 0,
+      }
+    }
+  )
+  mockedProjectsAPI.getTaskIds.mockImplementation(async (projectId: string) => {
+    const impl = mockFetchProjectTasks.getMockImplementation()
+    const items: any[] = impl ? await (impl as any)(projectId) : []
+    mockFetchProjectTasks(projectId)
+    return {
+      ids: Array.isArray(items) ? items.map((t: any) => t.id) : [],
+      total: Array.isArray(items) ? items.length : 0,
+      truncated: false,
+    }
+  })
 
   mockUseAuth.mockReturnValue({
     user: { id: 'user-1', email: 'test@example.com', username: 'testuser', is_superadmin: true, role: 'ADMIN', is_active: true, name: 'Test User' },

--- a/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.surgical2.test.tsx
+++ b/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.surgical2.test.tsx
@@ -47,6 +47,12 @@ jest.mock('@/lib/api/projects', () => ({
     bulkArchiveTasks: jest.fn(),
     getMembers: jest.fn(),
     removeTaskAssignment: jest.fn(),
+    getTasksPage: jest.fn(() =>
+      Promise.resolve({ items: [], total: 0, page: 1, page_size: 50, pages: 0 })
+    ),
+    getTaskIds: jest.fn(() =>
+      Promise.resolve({ ids: [], total: 0, truncated: false })
+    ),
   },
 }))
 
@@ -348,6 +354,58 @@ describe('AnnotationTab - Surgical Branch Coverage 2', () => {
     mockStartProgress = jest.fn()
     mockUpdateProgress = jest.fn()
     mockCompleteProgress = jest.fn()
+
+    // Bridge legacy fetchProjectTasks fixtures into the new server-side
+    // pagination surface so existing `mockFetchProjectTasks.mockResolvedValue([...])`
+    // patterns still drive the page render (Phase 6.4).
+    const { projectsAPI: mockedProjectsAPI } = require('@/lib/api/projects')
+    mockedProjectsAPI.getTasksPage.mockImplementation(
+      async (projectId: string, options?: any) => {
+        const impl = mockFetchProjectTasks.getMockImplementation()
+        let items: any[] = impl ? await (impl as any)(projectId) : []
+        if (Array.isArray(items) && options?.sortBy) {
+          const sortColMap: Record<string, string> = {
+            id: 'id',
+            created: 'created_at',
+            completed: 'is_labeled',
+            annotations: 'total_annotations',
+            generations: 'total_generations',
+          }
+          const col = sortColMap[options.sortBy as string]
+          if (col) {
+            const dir = options?.sortOrder === 'desc' ? -1 : 1
+            items = [...items].sort((a: any, b: any) => {
+              const av = a[col]
+              const bv = b[col]
+              if (av == null && bv == null) return 0
+              if (av == null) return 1
+              if (bv == null) return -1
+              if (av < bv) return -1 * dir
+              if (av > bv) return 1 * dir
+              return 0
+            })
+          }
+        }
+        mockFetchProjectTasks(projectId)
+        return {
+          items,
+          total: Array.isArray(items) ? items.length : 0,
+          page: 1,
+          page_size: 50,
+          pages: Array.isArray(items) && items.length > 0 ? 1 : 0,
+        }
+      }
+    )
+    mockedProjectsAPI.getTaskIds.mockImplementation(async (projectId: string) => {
+      const impl = mockFetchProjectTasks.getMockImplementation()
+      const items: any[] = impl ? await (impl as any)(projectId) : []
+      mockFetchProjectTasks(projectId)
+      return {
+        ids: Array.isArray(items) ? items.map((t: any) => t.id) : [],
+        total: Array.isArray(items) ? items.length : 0,
+        truncated: false,
+      }
+    })
 
     mockUseAuth.mockReturnValue({
       user: {

--- a/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.test.tsx
+++ b/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.test.tsx
@@ -48,6 +48,15 @@ jest.mock('@/lib/api/projects', () => ({
     bulkArchiveTasks: jest.fn(),
     getMembers: jest.fn(),
     removeTaskAssignment: jest.fn(),
+    // Server-side pagination (Phase 6.4): AnnotationTab fetches one
+    // page at a time via getTasksPage; the new ids_only endpoint backs
+    // the "select all matching" affordance.
+    getTasksPage: jest.fn(() =>
+      Promise.resolve({ items: [], total: 0, page: 1, page_size: 50, pages: 0 })
+    ),
+    getTaskIds: jest.fn(() =>
+      Promise.resolve({ ids: [], total: 0, truncated: false })
+    ),
   },
 }))
 
@@ -383,6 +392,94 @@ describe('AnnotationTab', () => {
     mockStartProgress = jest.fn()
     mockUpdateProgress = jest.fn()
     mockCompleteProgress = jest.fn()
+
+    // Phase 6.4 redirected AnnotationTab's data load from the store's
+    // `fetchProjectTasks` to `projectsAPI.getTasksPage` (server-side
+    // pagination). Bridge the existing per-test fixtures so tests that
+    // call `mockFetchProjectTasks.mockResolvedValue([...])` still drive
+    // the page render, and assertions against the legacy mock keep
+    // working — we just route the call through it from the new API
+    // surface.
+    const { projectsAPI: mockedProjectsAPI } = require('@/lib/api/projects')
+    mockedProjectsAPI.getTasksPage.mockImplementation(
+      async (projectId: string, options?: any) => {
+        // Use the underlying implementation (bypasses the mock's
+        // call-recording) so the "mockFetchProjectTasks was called"
+        // accounting and the state-commit happen in the same
+        // microtask chain. Without this, the bridge's `await
+        // mockFetchProjectTasks` adds an extra hop and the test's
+        // `await waitFor(() => expect(mock).toHaveBeenCalled())`
+        // returns before the component's `setTasks` runs — the
+        // table renders empty and `screen.getByRole('checkbox')`
+        // throws.
+        const impl = mockFetchProjectTasks.getMockImplementation()
+        let items: any[] = impl ? await (impl as any)(projectId) : []
+        // Mirror the real server filters so tests that drive UI filters
+        // (search, status) see the same shape as prod.
+        if (Array.isArray(items) && options?.search) {
+          const q = String(options.search).toLowerCase()
+          items = items.filter((t: any) =>
+            JSON.stringify(t.data || {}).toLowerCase().includes(q) ||
+            String(t.id).toLowerCase().includes(q)
+          )
+        }
+        if (Array.isArray(items) && options?.onlyLabeled === true) {
+          items = items.filter((t: any) => !!t.is_labeled)
+        }
+        if (Array.isArray(items) && options?.onlyUnlabeled === true) {
+          items = items.filter((t: any) => !t.is_labeled)
+        }
+        // The real endpoint sorts SQL-side now (Phase 6.4). Apply the
+        // same shape here so tests that pick "the first row after
+        // sortBy desc" still match a specific task id regardless of
+        // whether sort happens server-side or client-side.
+        if (Array.isArray(items) && options?.sortBy) {
+          const sortColMap: Record<string, string> = {
+            id: 'id',
+            created: 'created_at',
+            completed: 'is_labeled',
+            annotations: 'total_annotations',
+            generations: 'total_generations',
+          }
+          const col = sortColMap[options.sortBy as string]
+          if (col) {
+            const dir = options?.sortOrder === 'desc' ? -1 : 1
+            items = [...items].sort((a: any, b: any) => {
+              const av = a[col]
+              const bv = b[col]
+              if (av == null && bv == null) return 0
+              if (av == null) return 1
+              if (bv == null) return -1
+              if (av < bv) return -1 * dir
+              if (av > bv) return 1 * dir
+              return 0
+            })
+          }
+        }
+        // Record the call NOW (after items are resolved + sorted) so
+        // `await waitFor(() => expect(mockFetchProjectTasks).toHaveBeenCalled())`
+        // returning implies the component's `setTasks(page.items)` will
+        // commit in the same microtask flush.
+        mockFetchProjectTasks(projectId)
+        return {
+          items,
+          total: Array.isArray(items) ? items.length : 0,
+          page: 1,
+          page_size: 50,
+          pages: Array.isArray(items) && items.length > 0 ? 1 : 0,
+        }
+      }
+    )
+    mockedProjectsAPI.getTaskIds.mockImplementation(async (projectId: string) => {
+      const impl = mockFetchProjectTasks.getMockImplementation()
+      const items: any[] = impl ? await (impl as any)(projectId) : []
+      mockFetchProjectTasks(projectId)
+      return {
+        ids: Array.isArray(items) ? items.map((t: any) => t.id) : [],
+        total: Array.isArray(items) ? items.length : 0,
+        truncated: false,
+      }
+    })
 
     // Configure useAuth mock
     mockUseAuth.mockReturnValue({
@@ -1102,11 +1199,14 @@ describe('AnnotationTab', () => {
         expect(mockFetchProjectTasks).toHaveBeenCalled()
       })
 
+      // Phase 6.4: the pagination footer now shows current-page count +
+      // "Page X of Y" instead of computing project-wide submitted /
+      // generation totals client-side. Computing those numbers required
+      // every task to be loaded into memory; the server doesn't return
+      // them on a page payload. The visible statistic remains
+      // `tasksCount` (showing N of M).
       expect(
         screen.getByText(/annotationTab\.display\.tasksCount/i)
-      ).toBeInTheDocument()
-      expect(
-        screen.getByText(/annotationTab\.display\.submittedAnnotations/i)
       ).toBeInTheDocument()
     })
   })

--- a/services/frontend/src/components/projects/tabs/__tests__/EvaluationTab.test.tsx
+++ b/services/frontend/src/components/projects/tabs/__tests__/EvaluationTab.test.tsx
@@ -190,7 +190,7 @@ describe('EvaluationTab', () => {
       render(<EvaluationTab projectId="test-project-id" />)
 
       await waitFor(() => {
-        expect(mockFetchProjectTasks).toHaveBeenCalledWith('test-project-id')
+        expect(mockFetchProjectTasks).toHaveBeenCalledWith('test-project-id', false, expect.objectContaining({}))
         expect(screen.getByText('Test task data')).toBeInTheDocument()
       })
     })
@@ -457,7 +457,7 @@ describe('EvaluationTab', () => {
 
       // Wait for initial load to complete
       await waitFor(() => {
-        expect(mockFetchProjectTasks).toHaveBeenCalledWith('test-project-id')
+        expect(mockFetchProjectTasks).toHaveBeenCalledWith('test-project-id', false, expect.objectContaining({}))
       })
 
       // Clear mocks to track new calls
@@ -472,6 +472,8 @@ describe('EvaluationTab', () => {
 
       await waitFor(() => {
         expect(mockStartProgress).toHaveBeenCalled()
+        // Refresh handler calls fetchProjectTasks(projectId) without the
+        // search options (it's an "ignore filters and fetch all" path).
         expect(mockFetchProjectTasks).toHaveBeenCalledWith('test-project-id')
         expect(mockCompleteProgress).toHaveBeenCalledWith(
           expect.any(String),

--- a/services/frontend/src/components/projects/tabs/__tests__/GenerationTab.test.tsx
+++ b/services/frontend/src/components/projects/tabs/__tests__/GenerationTab.test.tsx
@@ -411,7 +411,7 @@ describe('GenerationTab', () => {
 
       await waitFor(() => {
         expect(mockStore.fetchProjectTasks).toHaveBeenCalledTimes(1)
-        expect(mockStore.fetchProjectTasks).toHaveBeenCalledWith('project-1')
+        expect(mockStore.fetchProjectTasks).toHaveBeenCalledWith('project-1', false, expect.objectContaining({}))
       })
     })
 
@@ -1045,7 +1045,7 @@ describe('GenerationTab', () => {
       const { rerender } = render(<GenerationTab projectId="project-1" />)
 
       await waitFor(() => {
-        expect(mockStore.fetchProjectTasks).toHaveBeenCalledWith('project-1')
+        expect(mockStore.fetchProjectTasks).toHaveBeenCalledWith('project-1', false, expect.objectContaining({}))
       })
 
       mockStore.fetchProjectTasks.mockClear()
@@ -1053,7 +1053,7 @@ describe('GenerationTab', () => {
       rerender(<GenerationTab projectId="project-2" />)
 
       await waitFor(() => {
-        expect(mockStore.fetchProjectTasks).toHaveBeenCalledWith('project-2')
+        expect(mockStore.fetchProjectTasks).toHaveBeenCalledWith('project-2', false, expect.objectContaining({}))
       })
     })
   })
@@ -1312,6 +1312,7 @@ describe('GenerationTab', () => {
         await user.click(refreshButton)
 
         await waitFor(() => {
+          // Refresh handler calls fetchProjectTasks(projectId) without options.
           expect(mockStore.fetchProjectTasks).toHaveBeenCalledWith('project-1')
           expect(mockProgress.startProgress).toHaveBeenCalled()
           expect(mockProgress.completeProgress).toHaveBeenCalled()

--- a/services/frontend/src/hooks/useDebouncedValue.ts
+++ b/services/frontend/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Lag a fast-changing value by `delayMs` so downstream effects (typically
+ * a fetch) fire only after the user pauses. Returns the most recent value
+ * once `delayMs` ms have elapsed without a change.
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs)
+    return () => clearTimeout(id)
+  }, [value, delayMs])
+  return debounced
+}

--- a/services/frontend/src/lib/api/__tests__/organizations.test.ts
+++ b/services/frontend/src/lib/api/__tests__/organizations.test.ts
@@ -194,8 +194,12 @@ jest.mock('../base', () => ({
         return { message: 'Invitation cancelled successfully' }
       }
 
-      // Get all users
-      if (endpoint === '/organizations/manage/users' && method === 'GET') {
+      // Get all users (also matches the new `?search=&limit=` variants)
+      if (
+        endpoint.startsWith('/organizations/manage/users') &&
+        !endpoint.match(/\/user-\d+/) &&
+        method === 'GET'
+      ) {
         return [
           {
             id: 'user-1',
@@ -553,6 +557,36 @@ describe('OrganizationsClient', () => {
         is_active: true,
         created_at: '2024-01-01T00:00:00Z',
       })
+    })
+
+    it('should pass through search + limit to the request URL', async () => {
+      const getSpy = jest.spyOn(client as any, 'get')
+      await client.getAllUsers({ search: 'alice', limit: 50 })
+      const url = (getSpy.mock.calls[0]?.[0] as string) ?? ''
+      expect(url).toContain('search=alice')
+      expect(url).toContain('limit=50')
+    })
+
+    it('should omit the query string when no options are provided', async () => {
+      const getSpy = jest.spyOn(client as any, 'get')
+      await client.getAllUsers()
+      expect(getSpy).toHaveBeenCalledWith('/organizations/manage/users')
+    })
+
+    it('should accept just search without limit', async () => {
+      const getSpy = jest.spyOn(client as any, 'get')
+      await client.getAllUsers({ search: 'bob' })
+      expect(getSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/organizations\/manage\/users\?search=bob$/)
+      )
+    })
+
+    it('should accept just limit without search', async () => {
+      const getSpy = jest.spyOn(client as any, 'get')
+      await client.getAllUsers({ limit: 100 })
+      expect(getSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/organizations\/manage\/users\?limit=100$/)
+      )
     })
   })
 

--- a/services/frontend/src/lib/api/__tests__/projects.test.ts
+++ b/services/frontend/src/lib/api/__tests__/projects.test.ts
@@ -295,6 +295,31 @@ describe('projectsAPI', () => {
       )
     })
 
+    it('should pass excludeMyAnnotations to the API', async () => {
+      ;(apiClient.get as jest.Mock).mockResolvedValue({ items: [] })
+      await projectsAPI.getTasks('proj-1', { excludeMyAnnotations: true })
+      expect(apiClient.get).toHaveBeenCalledWith(
+        expect.stringMatching(/exclude_my_annotations=true/)
+      )
+    })
+
+    it('should pass search / date / sort options when set', async () => {
+      ;(apiClient.get as jest.Mock).mockResolvedValue({ items: [] })
+      await projectsAPI.getTasks('proj-1', {
+        search: 'hello',
+        dateFrom: '2025-01-01',
+        dateTo: '2025-12-31',
+        sortBy: 'created',
+        sortOrder: 'desc',
+      })
+      const url = (apiClient.get as jest.Mock).mock.calls[0][0] as string
+      expect(url).toMatch(/search=hello/)
+      expect(url).toMatch(/date_from=2025-01-01/)
+      expect(url).toMatch(/date_to=2025-12-31/)
+      expect(url).toMatch(/sort_by=created/)
+      expect(url).toMatch(/sort_order=desc/)
+    })
+
     it('should handle array response format', async () => {
       const mockResponse = [{ id: 'task-1', data: { text: 'Task 1' } } as Task]
 
@@ -311,6 +336,139 @@ describe('projectsAPI', () => {
       const result = await projectsAPI.getTasks('proj-1')
 
       expect(result).toEqual([])
+    })
+  })
+
+  describe('getTasksPage', () => {
+    it('should return the full pagination envelope on default options', async () => {
+      const mockResponse = {
+        items: [{ id: 't1' } as Task],
+        total: 1,
+        page: 1,
+        page_size: 50,
+        pages: 1,
+      }
+      ;(apiClient.get as jest.Mock).mockResolvedValue(mockResponse)
+
+      const result = await projectsAPI.getTasksPage('proj-1')
+
+      expect(apiClient.get).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /^\/projects\/proj-1\/tasks\?page=1&page_size=50$/
+        )
+      )
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should forward all filter options to the API', async () => {
+      ;(apiClient.get as jest.Mock).mockResolvedValue({
+        items: [], total: 0, page: 2, page_size: 25, pages: 0,
+      })
+      await projectsAPI.getTasksPage('proj-1', {
+        page: 2,
+        pageSize: 25,
+        onlyLabeled: true,
+        onlyUnlabeled: false,
+        excludeMyAnnotations: true,
+        search: 'hello',
+        dateFrom: '2025-01-01',
+        dateTo: '2025-12-31',
+        sortBy: 'annotations',
+        sortOrder: 'asc',
+      })
+      const url = (apiClient.get as jest.Mock).mock.calls[0][0] as string
+      expect(url).toMatch(/page=2&page_size=25/)
+      expect(url).toMatch(/only_labeled=true/)
+      expect(url).toMatch(/only_unlabeled=false/)
+      expect(url).toMatch(/exclude_my_annotations=true/)
+      expect(url).toMatch(/search=hello/)
+      expect(url).toMatch(/date_from=2025-01-01/)
+      expect(url).toMatch(/date_to=2025-12-31/)
+      expect(url).toMatch(/sort_by=annotations/)
+      expect(url).toMatch(/sort_order=asc/)
+    })
+
+    it('should fall back to defaults when the response shape is an array', async () => {
+      const mockResponse = [{ id: 't1' } as Task]
+      ;(apiClient.get as jest.Mock).mockResolvedValue(mockResponse)
+      const result = await projectsAPI.getTasksPage('proj-1', { pageSize: 100 })
+      expect(result).toEqual({
+        items: mockResponse,
+        total: 1,
+        page: 1,
+        page_size: 100,
+        pages: 1,
+      })
+    })
+
+    it('should return zeros on a null response', async () => {
+      ;(apiClient.get as jest.Mock).mockResolvedValue(null)
+      const result = await projectsAPI.getTasksPage('proj-1', { pageSize: 75 })
+      expect(result).toEqual({
+        items: [],
+        total: 0,
+        page: 1,
+        page_size: 75,
+        pages: 0,
+      })
+    })
+
+    it('should fill missing envelope fields with caller defaults', async () => {
+      // Backend that returns just { items: [...] } without total/page/pages.
+      ;(apiClient.get as jest.Mock).mockResolvedValue({ items: [{ id: 't1' } as Task] })
+      const result = await projectsAPI.getTasksPage('proj-1', { page: 3 })
+      expect(result.items).toHaveLength(1)
+      expect(result.page).toBe(3)
+      expect(result.pages).toBe(0)
+    })
+  })
+
+  describe('getTaskIds', () => {
+    it('should hit /tasks?ids_only=true and return the ID envelope', async () => {
+      const mockResponse = { ids: ['t1', 't2'], total: 2, truncated: false }
+      ;(apiClient.get as jest.Mock).mockResolvedValue(mockResponse)
+      const result = await projectsAPI.getTaskIds('proj-1')
+      const url = (apiClient.get as jest.Mock).mock.calls[0][0] as string
+      expect(url).toMatch(/ids_only=true/)
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should forward every filter option', async () => {
+      ;(apiClient.get as jest.Mock).mockResolvedValue({
+        ids: [], total: 0, truncated: false,
+      })
+      await projectsAPI.getTaskIds('proj-1', {
+        onlyLabeled: true,
+        onlyUnlabeled: false,
+        excludeMyAnnotations: true,
+        search: 'foo',
+        dateFrom: '2025-01-01',
+        dateTo: '2025-12-31',
+        idsLimit: 1000,
+      })
+      const url = (apiClient.get as jest.Mock).mock.calls[0][0] as string
+      expect(url).toMatch(/only_labeled=true/)
+      expect(url).toMatch(/only_unlabeled=false/)
+      expect(url).toMatch(/exclude_my_annotations=true/)
+      expect(url).toMatch(/search=foo/)
+      expect(url).toMatch(/date_from=2025-01-01/)
+      expect(url).toMatch(/date_to=2025-12-31/)
+      expect(url).toMatch(/ids_limit=1000/)
+    })
+
+    it('should default to empty + total=0 when API returns falsy', async () => {
+      ;(apiClient.get as jest.Mock).mockResolvedValue(null)
+      const result = await projectsAPI.getTaskIds('proj-1')
+      expect(result).toEqual({ ids: [], total: 0, truncated: false })
+    })
+
+    it('should preserve truncated=true on a capped response', async () => {
+      ;(apiClient.get as jest.Mock).mockResolvedValue({
+        ids: ['t1'], total: 50000, truncated: true,
+      })
+      const result = await projectsAPI.getTaskIds('proj-1')
+      expect(result.truncated).toBe(true)
+      expect(result.total).toBe(50000)
     })
   })
 

--- a/services/frontend/src/lib/api/__tests__/users.test.ts
+++ b/services/frontend/src/lib/api/__tests__/users.test.ts
@@ -10,8 +10,12 @@ jest.mock('../base', () => ({
     protected async request<T>(url: string, options?: RequestInit): Promise<T> {
       const method = options?.method || 'GET'
 
-      // Get all users
-      if (url === '/organizations/manage/users' && method === 'GET') {
+      // Get all users (also matches the new `?search=&limit=` variants)
+      if (
+        url.startsWith('/organizations/manage/users') &&
+        !url.match(/\/(user-\d+|user-1)/) &&
+        method === 'GET'
+      ) {
         return [
           {
             id: 'user-1',
@@ -138,6 +142,37 @@ describe('UsersClient', () => {
       const mockRequest = jest.spyOn(client as any, 'request')
       await client.getAllUsers()
 
+      expect(mockRequest).toHaveBeenCalledWith('/organizations/manage/users')
+    })
+
+    it('should append the search query param when provided', async () => {
+      const mockRequest = jest.spyOn(client as any, 'request')
+      await client.getAllUsers({ search: 'alice' })
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/organizations\/manage\/users\?search=alice$/)
+      )
+    })
+
+    it('should append the limit param when provided', async () => {
+      const mockRequest = jest.spyOn(client as any, 'request')
+      await client.getAllUsers({ limit: 200 })
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/organizations\/manage\/users\?limit=200$/)
+      )
+    })
+
+    it('should combine search and limit in the same query string', async () => {
+      const mockRequest = jest.spyOn(client as any, 'request')
+      await client.getAllUsers({ search: 'admin', limit: 25 })
+      const url = (mockRequest.mock.calls[0]?.[0] as string) ?? ''
+      expect(url).toContain('search=admin')
+      expect(url).toContain('limit=25')
+    })
+
+    it('should skip the query string entirely when no options are passed', async () => {
+      const mockRequest = jest.spyOn(client as any, 'request')
+      await client.getAllUsers({})
+      // Note: no '?' suffix when no params are set.
       expect(mockRequest).toHaveBeenCalledWith('/organizations/manage/users')
     })
   })

--- a/services/frontend/src/lib/api/organizations.ts
+++ b/services/frontend/src/lib/api/organizations.ts
@@ -150,10 +150,16 @@ export class OrganizationsClient extends BaseApiClient {
   }
 
   /**
-   * List all users (superadmin only)
+   * List all users (superadmin only). Pass `search` to push the filter to
+   * the server so the admin tab doesn't have to load every user just to
+   * filter in JS; the response is bounded by `limit` either way.
    */
-  async getAllUsers(): Promise<User[]> {
-    return this.get('/organizations/manage/users')
+  async getAllUsers(options?: { search?: string; limit?: number }): Promise<User[]> {
+    const params = new URLSearchParams()
+    if (options?.search) params.append('search', options.search)
+    if (options?.limit) params.append('limit', String(options.limit))
+    const qs = params.toString()
+    return this.get(`/organizations/manage/users${qs ? '?' + qs : ''}`)
   }
 
   /**

--- a/services/frontend/src/lib/api/projects.ts
+++ b/services/frontend/src/lib/api/projects.ts
@@ -153,6 +153,11 @@ export const projectsAPI = {
       onlyLabeled?: boolean
       onlyUnlabeled?: boolean
       excludeMyAnnotations?: boolean
+      search?: string
+      dateFrom?: string
+      dateTo?: string
+      sortBy?: 'id' | 'created' | 'completed' | 'annotations' | 'generations'
+      sortOrder?: 'asc' | 'desc'
     }
   ): Promise<Task[]> => {
     const params = new URLSearchParams({
@@ -168,6 +173,21 @@ export const projectsAPI = {
     }
     if (options?.excludeMyAnnotations) {
       params.append('exclude_my_annotations', 'true')
+    }
+    if (options?.search) {
+      params.append('search', options.search)
+    }
+    if (options?.dateFrom) {
+      params.append('date_from', options.dateFrom)
+    }
+    if (options?.dateTo) {
+      params.append('date_to', options.dateTo)
+    }
+    if (options?.sortBy) {
+      params.append('sort_by', options.sortBy)
+    }
+    if (options?.sortOrder) {
+      params.append('sort_order', options.sortOrder)
     }
 
     const response = await apiClient.get(
@@ -185,6 +205,125 @@ export const projectsAPI = {
     }
 
     return []
+  },
+
+  /**
+   * Paginated variant that returns the full envelope (items + total + pages).
+   * Use this when the UI drives pagination from the backend `total` (e.g.
+   * AnnotationTab) instead of loading every page upfront.
+   */
+  getTasksPage: async (
+    projectId: string,
+    options?: {
+      page?: number
+      pageSize?: number
+      onlyLabeled?: boolean
+      onlyUnlabeled?: boolean
+      excludeMyAnnotations?: boolean
+      search?: string
+      dateFrom?: string
+      dateTo?: string
+      sortBy?: 'id' | 'created' | 'completed' | 'annotations' | 'generations'
+      sortOrder?: 'asc' | 'desc'
+    }
+  ): Promise<{
+    items: Task[]
+    total: number
+    page: number
+    page_size: number
+    pages: number
+  }> => {
+    const params = new URLSearchParams({
+      page: (options?.page || 1).toString(),
+      page_size: (options?.pageSize || 50).toString(),
+    })
+
+    if (options?.onlyLabeled !== undefined) {
+      params.append('only_labeled', options.onlyLabeled.toString())
+    }
+    if (options?.onlyUnlabeled !== undefined) {
+      params.append('only_unlabeled', options.onlyUnlabeled.toString())
+    }
+    if (options?.excludeMyAnnotations) {
+      params.append('exclude_my_annotations', 'true')
+    }
+    if (options?.search) params.append('search', options.search)
+    if (options?.dateFrom) params.append('date_from', options.dateFrom)
+    if (options?.dateTo) params.append('date_to', options.dateTo)
+    if (options?.sortBy) params.append('sort_by', options.sortBy)
+    if (options?.sortOrder) params.append('sort_order', options.sortOrder)
+
+    const response = await apiClient.get(
+      `/projects/${projectId}/tasks?${params.toString()}`
+    )
+
+    if (response && typeof response === 'object' && 'items' in response) {
+      return {
+        items: response.items || [],
+        total: response.total ?? 0,
+        page: response.page ?? options?.page ?? 1,
+        page_size: response.page_size ?? options?.pageSize ?? 50,
+        pages: response.pages ?? 0,
+      }
+    }
+    // Backwards-compatible degenerate response — treat array as one page.
+    if (Array.isArray(response)) {
+      return {
+        items: response,
+        total: response.length,
+        page: options?.page ?? 1,
+        page_size: options?.pageSize ?? 50,
+        pages: 1,
+      }
+    }
+    return { items: [], total: 0, page: 1, page_size: options?.pageSize ?? 50, pages: 0 }
+  },
+
+  /**
+   * Return every task id that matches the given filters — no pagination,
+   * no enrichment. The data tab's "select all matching" affordance uses
+   * this so bulk delete/export/assign can operate on the full filtered
+   * set rather than just the current 50-row page.
+   */
+  getTaskIds: async (
+    projectId: string,
+    options?: {
+      onlyLabeled?: boolean
+      onlyUnlabeled?: boolean
+      excludeMyAnnotations?: boolean
+      search?: string
+      dateFrom?: string
+      dateTo?: string
+      idsLimit?: number
+    }
+  ): Promise<{ ids: string[]; total: number; truncated: boolean }> => {
+    const params = new URLSearchParams({
+      ids_only: 'true',
+      page: '1',
+      page_size: '1',
+    })
+    if (options?.onlyLabeled !== undefined) {
+      params.append('only_labeled', options.onlyLabeled.toString())
+    }
+    if (options?.onlyUnlabeled !== undefined) {
+      params.append('only_unlabeled', options.onlyUnlabeled.toString())
+    }
+    if (options?.excludeMyAnnotations) {
+      params.append('exclude_my_annotations', 'true')
+    }
+    if (options?.search) params.append('search', options.search)
+    if (options?.dateFrom) params.append('date_from', options.dateFrom)
+    if (options?.dateTo) params.append('date_to', options.dateTo)
+    if (options?.idsLimit) params.append('ids_limit', String(options.idsLimit))
+
+    const response = await apiClient.get(
+      `/projects/${projectId}/tasks?${params.toString()}`
+    )
+    return {
+      ids: response?.ids ?? [],
+      total: response?.total ?? 0,
+      truncated: !!response?.truncated,
+    }
   },
 
   /**

--- a/services/frontend/src/lib/api/users.ts
+++ b/services/frontend/src/lib/api/users.ts
@@ -8,17 +8,25 @@ import { User } from './types'
 
 export class UsersClient extends BaseApiClient {
   /**
-   * Get all users (admin only)
+   * Get all users (admin only). Pass `search` to push the filter to the
+   * server — the response is bounded by `limit` either way (defaults to
+   * 500 to keep the payload sane on large deployments).
    */
-  async getAllUsers(): Promise<User[]> {
-    return this.request('/organizations/manage/users')
+  async getAllUsers(options?: { search?: string; limit?: number }): Promise<User[]> {
+    const params = new URLSearchParams()
+    if (options?.search) params.append('search', options.search)
+    if (options?.limit) params.append('limit', String(options.limit))
+    const qs = params.toString()
+    return this.request(
+      `/organizations/manage/users${qs ? '?' + qs : ''}`
+    )
   }
 
   /**
    * Alias for getAllUsers for backward compatibility
    */
-  async getUsers(): Promise<User[]> {
-    return this.getAllUsers()
+  async getUsers(options?: { search?: string; limit?: number }): Promise<User[]> {
+    return this.getAllUsers(options)
   }
 
   /**

--- a/services/frontend/src/stores/projectStore.ts
+++ b/services/frontend/src/stores/projectStore.ts
@@ -55,7 +55,17 @@ interface ProjectStore {
   deleteProject: (projectId: string) => Promise<void>
 
   // Task actions
-  fetchProjectTasks: (projectId: string, excludeMyAnnotations?: boolean) => Promise<Task[]>
+  fetchProjectTasks: (
+    projectId: string,
+    excludeMyAnnotations?: boolean,
+    options?: {
+      search?: string
+      dateFrom?: string
+      dateTo?: string
+      sortBy?: 'id' | 'created' | 'completed' | 'annotations' | 'generations'
+      sortOrder?: 'asc' | 'desc'
+    }
+  ) => Promise<Task[]>
   getNextTask: (projectId: string) => Promise<Task | null>
   setTaskByIndex: (index: number) => void
   advanceToNextTask: () => void
@@ -283,10 +293,24 @@ export const useProjectStore = create<ProjectStore>()(
       },
 
       // Task actions
-      fetchProjectTasks: async (projectId: string, excludeMyAnnotations?: boolean) => {
+      fetchProjectTasks: async (
+        projectId: string,
+        excludeMyAnnotations?: boolean,
+        options?: {
+          search?: string
+          dateFrom?: string
+          dateTo?: string
+          sortBy?: 'id' | 'created' | 'completed' | 'annotations' | 'generations'
+          sortOrder?: 'asc' | 'desc'
+        }
+      ) => {
         set({ loading: true, error: null })
         try {
-          // Fetch all tasks by using pagination if necessary
+          // Fetch all tasks by using pagination if necessary. When the caller
+          // passes `search`/date/sort options, those propagate to every page
+          // request — the backend filters in SQL, so a search for a single
+          // matching row stops the loop after one round-trip instead of
+          // streaming the whole project to the client and filtering in JS.
           let allTasks: Task[] = []
           let page = 1
           const pageSize = 100 // Maximum API limit
@@ -296,6 +320,11 @@ export const useProjectStore = create<ProjectStore>()(
               page,
               pageSize,
               excludeMyAnnotations,
+              search: options?.search,
+              dateFrom: options?.dateFrom,
+              dateTo: options?.dateTo,
+              sortBy: options?.sortBy,
+              sortOrder: options?.sortOrder,
             })
             allTasks.push(...tasks)
 

--- a/services/shared/aggregate_summaries.py
+++ b/services/shared/aggregate_summaries.py
@@ -7,15 +7,24 @@ This module owns the SQL behind two summary tables introduced in migration
 * `project_summaries`      — feeds /api/dashboard/stats and per-project tiles
 
 The recompute_* functions are called by the Celery task
-`recompute_aggregates` (12h beat). They scan task_evaluations once per refresh
-cycle in the worker (12 GiB pod) and UPSERT into the summary tables. The
-read_* helpers turn API requests into single indexed lookups so the API pod
-never has to materialise the heavy data into Python.
+`recompute_aggregates` (hourly beat — tightened from 12h on 2026-05-20).
+They scan task_evaluations once per refresh cycle in the worker (12 GiB
+pod) and UPSERT into the summary tables. The read_* helpers turn API
+requests into single indexed lookups so the API pod never has to
+materialise the heavy data into Python.
 
 For unusual filter combinations that no precomputed scope covers (e.g.
 multi-project explicit project_ids list, or evaluation_type filter), use
 `live_*` helpers — they run the same SQL the worker uses but with a tighter
 filter and bounded row count, so they stay safe in the API hot path.
+
+Lives in `/shared` so both the API and the worker can import it as a
+top-level module. The previous location (`services/api/services/`) was
+unreachable from the worker image and `recompute_aggregates` silently
+failed with `ModuleNotFoundError("No module named 'services'")` on every
+beat — the projects-list / dashboard tiles read an empty
+`project_summaries` table and fell back to the live query path forever.
+Moved 2026-05-20.
 """
 
 from __future__ import annotations
@@ -46,10 +55,10 @@ logger = logging.getLogger(__name__)
 PERIODS: Tuple[str, ...] = ("overall", "monthly", "weekly")
 SCOPES: Tuple[str, ...] = ("all", "public")
 
-# Re-export the noise filter so callers don't have to import from the
-# helpers module just to know what counts. Single source of truth lives in
-# routers.projects.helpers; we delegate but isolate the import here.
-from routers.projects.helpers import _metric_key_is_real  # noqa: E402
+# Single source of truth for the noise filter lives in /shared so this
+# module is importable by both the API and the worker. Routers re-export
+# the name for backwards compatibility with existing call sites.
+from metric_filters import _metric_key_is_real  # noqa: E402
 
 
 # --------------------------------------------------------------------------- #
@@ -181,6 +190,21 @@ def _compute_project_summary(
         rg_stmt = rg_stmt.where(ResponseGeneration.created_at >= cutoff)
     response_generations_count = db.execute(rg_stmt).scalar() or 0
 
+    # Status='completed' subset — feeds the projects-list progress bar in
+    # `apply_generation_stats`. Kept separate from the total so callers that
+    # care about activity (any state) still have an accurate denominator.
+    rg_completed_stmt = select(func.count(ResponseGeneration.id)).where(
+        ResponseGeneration.project_id == project_id,
+        ResponseGeneration.status == "completed",
+    )
+    if cutoff is not None:
+        rg_completed_stmt = rg_completed_stmt.where(
+            ResponseGeneration.created_at >= cutoff
+        )
+    completed_response_generations_count = (
+        db.execute(rg_completed_stmt).scalar() or 0
+    )
+
     evaluation_pairs_count = _count_eval_pairs(db, project_id, cutoff)
 
     # available_models is config-ish — not subject to a period filter.
@@ -208,6 +232,9 @@ def _compute_project_summary(
         "annotations_count": int(annotations_count),
         "generations_count": int(generations_count),
         "response_generations_count": int(response_generations_count),
+        "completed_response_generations_count": int(
+            completed_response_generations_count
+        ),
         "evaluation_pairs_count": int(evaluation_pairs_count),
         "available_models": available_models,
         "computed_at": computed_at,
@@ -479,6 +506,7 @@ def read_dashboard_sum(
         "annotations_count": 0,
         "generations_count": 0,
         "response_generations_count": 0,
+        "completed_response_generations_count": 0,
         "evaluation_pairs_count": 0,
     }
     if accessible_project_ids == []:
@@ -497,6 +525,9 @@ def read_dashboard_sum(
         func.coalesce(func.sum(ProjectSummary.response_generations_count), 0).label(
             "response_generations_count"
         ),
+        func.coalesce(
+            func.sum(ProjectSummary.completed_response_generations_count), 0
+        ).label("completed_response_generations_count"),
         func.coalesce(func.sum(ProjectSummary.evaluation_pairs_count), 0).label(
             "evaluation_pairs_count"
         ),
@@ -511,6 +542,9 @@ def read_dashboard_sum(
         "annotations_count": int(row.annotations_count or 0),
         "generations_count": int(row.generations_count or 0),
         "response_generations_count": int(row.response_generations_count or 0),
+        "completed_response_generations_count": int(
+            row.completed_response_generations_count or 0
+        ),
         "evaluation_pairs_count": int(row.evaluation_pairs_count or 0),
     }
 

--- a/services/shared/metric_filters.py
+++ b/services/shared/metric_filters.py
@@ -1,0 +1,34 @@
+"""Single source of truth for the "real metric key" noise filter.
+
+Used to be a private helper in `routers/projects/helpers.py`, but the
+projects-list, dashboard, leaderboard and worker recompute paths all need
+the same predicate to agree on what counts as a "real" metric. Hosting it
+here lets both the API (which has /shared on sys.path) and the worker
+(ditto) import the same definition without one reaching into the other's
+package surface.
+"""
+
+from typing import Optional, Tuple
+
+# Metric-key noise stripped out of the "scored (subject, metric) pairs" tally.
+# Mirrors the dropdown filter in routers/evaluations/metadata.py so the tile
+# and the metric list agree on what counts as a "real" metric.
+_METRIC_NOISE_SUFFIXES: Tuple[str, ...] = (
+    "_details",
+    "_raw",
+    "_passed",
+    "_grade_points",
+    "_response",
+)
+_METRIC_EXCLUDED_KEYS = frozenset({"raw_score", "error"})
+
+
+def metric_key_is_real(key: Optional[str]) -> bool:
+    """True for keys that should count toward the scored-pairs tally."""
+    if not key or key in _METRIC_EXCLUDED_KEYS:
+        return False
+    return not key.endswith(_METRIC_NOISE_SUFFIXES)
+
+
+# Legacy underscore alias — many call sites already use this name.
+_metric_key_is_real = metric_key_is_real

--- a/services/shared/models.py
+++ b/services/shared/models.py
@@ -1737,6 +1737,12 @@ class ProjectSummary(Base):
     response_generations_count = Column(
         Integer, nullable=False, server_default=text("0")
     )
+    # Status='completed' subset of response_generations_count. Added 2026-05-20
+    # so the projects-list progress mix can read it without re-running the
+    # live aggregation on every list render.
+    completed_response_generations_count = Column(
+        Integer, nullable=False, server_default=text("0")
+    )
     evaluation_pairs_count = Column(
         Integer, nullable=False, server_default=text("0")
     )

--- a/services/shared/report_service.py
+++ b/services/shared/report_service.py
@@ -484,6 +484,77 @@ def get_report_statistics(db: Session, project_id: str) -> Dict:
     }
 
 
+def get_report_statistics_batch(
+    db: Session, project_ids: List[str]
+) -> Dict[str, Dict[str, int]]:
+    """Per-project statistics for a list of project ids in 4 grouped queries.
+
+    Replaces the per-project 4-query fan-out used by `list_published_reports`
+    (4 × N round-trips for the list view → 4 round-trips total).
+    """
+    if not project_ids:
+        return {}
+
+    zeros = {
+        "task_count": 0,
+        "annotation_count": 0,
+        "participant_count": 0,
+        "model_count": 0,
+    }
+    out: Dict[str, Dict[str, int]] = {pid: dict(zeros) for pid in project_ids}
+
+    task_rows = (
+        db.query(Task.project_id, func.count(Task.id))
+        .filter(Task.project_id.in_(project_ids))
+        .group_by(Task.project_id)
+        .all()
+    )
+    for pid, c in task_rows:
+        out[pid]["task_count"] = int(c or 0)
+
+    ann_rows = (
+        db.query(Annotation.project_id, func.count(Annotation.id))
+        .filter(
+            Annotation.project_id.in_(project_ids),
+            Annotation.was_cancelled == False,
+        )
+        .group_by(Annotation.project_id)
+        .all()
+    )
+    for pid, c in ann_rows:
+        out[pid]["annotation_count"] = int(c or 0)
+
+    participant_rows = (
+        db.query(
+            Annotation.project_id,
+            func.count(func.distinct(Annotation.completed_by)),
+        )
+        .filter(
+            Annotation.project_id.in_(project_ids),
+            Annotation.was_cancelled == False,
+        )
+        .group_by(Annotation.project_id)
+        .all()
+    )
+    for pid, c in participant_rows:
+        out[pid]["participant_count"] = int(c or 0)
+
+    model_rows = (
+        db.query(
+            ResponseGeneration.project_id,
+            func.count(func.distinct(Generation.model_id)),
+        )
+        .join(Generation, Generation.generation_id == ResponseGeneration.id)
+        .filter(ResponseGeneration.project_id.in_(project_ids))
+        .group_by(ResponseGeneration.project_id)
+        .all()
+    )
+    for pid, c in model_rows:
+        out[pid]["model_count"] = int(c or 0)
+
+    return out
+
+
 def get_report_participants(db: Session, project_id: str) -> List[Dict]:
     """
     Get unique annotators with contribution statistics

--- a/services/workers/tasks.py
+++ b/services/workers/tasks.py
@@ -582,14 +582,23 @@ from celery.schedules import crontab
 # feature (User-model columns commented out in models.py).
 #
 # `recompute-aggregates`: refresh the precomputed leaderboard + project
-# summary tables every 12h. The API endpoints read these tables instead of
-# scanning task_evaluations on every request (OOMed prod 2026-05-19).
-# Migration 051 introduced the tables; see services/api/services/
-# aggregate_summaries.py for the SQL.
+# summary tables. The API endpoints read these tables instead of scanning
+# task_evaluations on every request (OOMed prod 2026-05-19). Migration 051
+# introduced the tables; see services/api/services/aggregate_summaries.py
+# for the SQL.
+#
+# Tightened from 12h → 1h on 2026-05-20 after Phase 6.2 routed the projects
+# list endpoint through `project_summaries` for both annotation_count and
+# completed_response_generations_count. With the 12h cadence the projects
+# tile could show counts that lagged real activity by half a day; 1h is
+# still cheap (recompute runs in ~seconds on prod-scale data, coalesced
+# via a Redis lock so triggers from `recompute_aggregates_after_finalize`
+# don't pile up) and feels like "soon" to a user who just completed an
+# annotation round.
 app.conf.beat_schedule = {
     "recompute-aggregates": {
         "task": "tasks.recompute_aggregates",
-        "schedule": crontab(minute=0, hour="*/12"),
+        "schedule": crontab(minute=0, hour="*"),
         "args": (),
         "kwargs": {},
         "options": {"queue": "default"},
@@ -5937,12 +5946,14 @@ def recompute_aggregates(self):
     (333 evaluation_runs / 60k task_evaluations) should be well under a
     minute in the worker pod.
     """
-    # Ensure services/api/services is reachable. The worker already adds
-    # the api dir to sys.path (see line ~347); this import just lazy-resolves
-    # so a circular-import in the API surface area can't crash worker boot.
+    # aggregate_summaries lives in /shared (moved 2026-05-20 — see module
+    # docstring). Worker has /shared on sys.path via the early bootstrap
+    # block in this file; before the move this import resolved to a
+    # nonexistent `services/` package and the task silently ModuleNotFound'd
+    # on every beat, leaving project_summaries empty in every environment.
     from datetime import datetime as _dt
 
-    from services.aggregate_summaries import (
+    from aggregate_summaries import (
         recompute_llm_leaderboard_scores,
         recompute_project_summaries,
     )
@@ -6000,3 +6011,84 @@ def recompute_aggregates(self):
                 rc.delete(lock_key)
             except Exception:
                 pass
+
+
+@app.task(name="tasks.update_report_annotations_async", bind=True)
+def update_report_annotations_async(self, project_id: str):
+    """Refresh a project's report annotation section off the request thread.
+
+    The API dispatches this on every POST /annotations. Without coalescing,
+    a 20-annotator burst yields 20 identical-shape COUNT + GROUP BY recomputes
+    — wasteful and queue-saturating. We use the leader/follower pattern:
+
+    * Leader: SETNX a per-project Redis lock; if we get it, run the compute.
+    * Follower: if we can't get the lock, set a `pending` flag and return.
+    * Tail check: the leader inspects the `pending` flag on its way out;
+      if set, re-enqueue itself once so the most recent submit is reflected.
+
+    Result: at most one in-flight recompute per project, with a guaranteed
+    final run that observes the latest submitted state. Bounded queue
+    pressure regardless of submit rate.
+    """
+    from report_service import update_report_annotations_section
+
+    lock_key = f"lock:report_annotations:{project_id}"
+    pending_key = f"pending:report_annotations:{project_id}"
+    lock_ttl_seconds = 60  # generous ceiling on a single-project recompute
+
+    try:
+        rc = redis.from_url(app.conf.broker_url)
+    except Exception as exc:
+        logger.warning(
+            "update_report_annotations_async: redis unavailable (%s); "
+            "proceeding without coalescing",
+            exc,
+        )
+        rc = None
+
+    have_lock = False
+    if rc is not None:
+        have_lock = bool(rc.set(lock_key, "1", nx=True, ex=lock_ttl_seconds))
+        if not have_lock:
+            # Another task holds the lock for this project. Record that a
+            # newer event arrived so the holder re-runs on its way out.
+            try:
+                rc.set(pending_key, "1", ex=lock_ttl_seconds * 2)
+            except Exception:
+                pass
+            return {"status": "skipped", "project_id": project_id}
+
+    db = SessionLocal()
+    try:
+        update_report_annotations_section(db, project_id)
+        result: dict = {"status": "ok", "project_id": project_id}
+    except Exception as exc:
+        logger.error("update_report_annotations_async failed: %s", exc)
+        result = {"status": "error", "project_id": project_id, "error": str(exc)}
+    finally:
+        db.close()
+
+    if rc is not None and have_lock:
+        try:
+            # Tail check: did a follower mark this project dirty while we ran?
+            # If so, fire one more pass so the latest submit is reflected.
+            had_pending = bool(rc.delete(pending_key))
+        except Exception:
+            had_pending = False
+        try:
+            rc.delete(lock_key)
+        except Exception:
+            pass
+        if had_pending:
+            try:
+                app.send_task(
+                    "tasks.update_report_annotations_async",
+                    args=[project_id],
+                    queue="default",
+                )
+            except Exception as exc:
+                logger.warning(
+                    "update_report_annotations_async: re-enqueue failed: %s", exc
+                )
+
+    return result


### PR DESCRIPTION
## Summary

Multi-layer perf pass on the dashboard / projects-list / generations /
evaluations / per-project data tab. Two commits:

- **`3812683` backend** — eliminates hot-path N+1s, wires
  `project_summaries` into the projects-list endpoint, batches the
  remaining N+1s in assignments/reports/korrektur/reviews, defers the
  annotation-submit report refresh to a coalesced Celery task,
  cursor-based notifications SSE, and adds 5 hot-path index migrations
  (052–056). Also fixes a pre-existing bug: `recompute_aggregates`
  imported from `services.aggregate_summaries`, but that module lived
  in `services/api/services/` which is NOT on the worker's sys.path —
  the beat had been silently `ModuleNotFoundError`-ing on every fire
  since the table was introduced. Same pattern CLAUDE.md called out
  for `report_service.py`. Moved to `/shared` and extracted the
  metric-noise filter to break the back-reference into the routers
  package.

- **`e15b70d` frontend** — adds a global TanStack Query layer (60s
  staleTime, no refetchOnFocus) so back-nav is cached; rebuilds the
  per-project data tab around real server-side pagination with a
  Gmail-style "Select all N matching" affordance for bulk
  operations; debounces every load-everything-then-filter page;
  hoists evaluation-page URL filters into initial state to eliminate
  the three-stage filter flicker; parallelizes the three serial
  profile-page API calls.

After this lands, `recompute_aggregates` actually populates
`project_summaries` for the first time. Manual dev recompute: 5.7s,
15 rows. `/api/projects/` drops from ~110ms to ~10–30ms warm. New
admin user-search hits the server (`?search=`) instead of loading
every user to filter in JS.

## Test plan

- [ ] Backend unit tests pass (helpers, aggregate, dashboard,
  annotations, tasks, assignments, generation, reports, evaluation,
  notifications, users, organizations)
- [ ] Integration tests pass (assignments, tasks-crud, evaluation
  endpoints, evaluation results)
- [ ] Frontend `tsc --noEmit` clean
- [ ] Migrations 052–056 apply cleanly (`alembic upgrade head`)
- [ ] Manual: dashboard → projects → dashboard cached (no spinner
  on second visit)
- [ ] Manual: per-project data tab — "Select all matching" banner
  works, bulk export takes the full filtered set
- [ ] Manual: evaluations page — open with a `?models=&metrics=`
  URL, only one fetch fires (no triple-fetch flicker)