### PR TITLE
projects: export task_evaluation.created_by

### DIFF
--- a/services/api/routers/projects/serializers.py
+++ b/services/api/routers/projects/serializers.py
@@ -155,6 +155,11 @@ def serialize_task_evaluation(
         # multi-judge configs (where one EvaluationRun spawns N EvaluationJudgeRuns,
         # one per judge model) remain distinguishable in the export.
         "judge_run_id": te.judge_run_id,
+        # Grader user_id. Populated on rows written by a human (korrektur
+        # grades, manual rubric edits) and on LLM-judge rows (the dispatcher).
+        # Downstream analysis joins this to users.id when grader identity is
+        # needed — IRR, creator-vs-blind, judge-vs-human comparisons.
+        "created_by": te.created_by,
         "created_at": _isoformat(te.created_at),
     }
     if mode == "data":

--- a/services/api/tests/routers/projects/test_serializers.py
+++ b/services/api/tests/routers/projects/test_serializers.py
@@ -100,6 +100,7 @@ def _mock_task_evaluation(**overrides):
     te.processing_time_ms = 150
     te.judge_run_id = None
     te.judge_prompts_used = None
+    te.created_by = "user-grader-1"
     te.created_at = datetime(2026, 1, 4)
     for k, v in overrides.items():
         setattr(te, k, v)
@@ -217,6 +218,7 @@ class TestSerializeTaskEvaluation:
         assert result["judge_model"] == "gpt-4o-judge"
         assert result["annotation_id"] == "ann-1"
         assert result["judge_run_id"] == "jr-1"
+        assert result["created_by"] == "user-grader-1"
         # Data mode should NOT have raw FK fields
         assert "evaluation_id" not in result
         assert "task_id" not in result


### PR DESCRIPTION
## Summary

- `serialize_task_evaluation` dropped `TaskEvaluation.created_by` from every exported row — consumers couldn't recover the grader's user_id on rows written by a human (korrektur grades, manual rubric edits) or on LLM-judge rows (the dispatcher).
- Without `created_by` in the export, any downstream IRR / creator-vs-blind / judge-vs-human analysis broke silently — even when the grade itself shipped correctly.

## Motivation

Discovered while finishing the ARR/Dataset paper revision against the 2026-05-21 Benchathon export. Prod has 157 korrektur grades from 7 named graders across 48 picks; the export carried the grades (105 at task-level via `task.evaluations[]`, 50 nested under generations) but every row had its grader identity stripped. The paper pipeline had to dump grades+identity directly from prod via `kubectl exec` SQL into a sidecar to compute named-rater IRR; after this PR the regular export is sufficient.

## Change

- Add `te.created_by` to the unconditional fields in `serialize_task_evaluation` — follows the same convention as `Task.created_by`, `EvaluationRun.created_by`, `KorrekturComment.created_by` (user_id, not resolved to email; downstream joins to `users.id` for identity).
- Mock + assertion updated in `test_serializers.py`.

## Test plan

- [x] `make test-api FILE="tests/routers/projects/test_serializers.py"` — 20/20 pass
- [x] `make test-api FILE="tests/routers/projects/test_export_import_roundtrip.py tests/routers/projects/test_bulk_export_tasks.py"` — 26/26 pass
- [ ] Post-merge: re-export Benchathon, confirm `task_evaluations[*].created_by` is populated, retire the local sidecar in `publications/Dataset_ARR/`.

(Existing `TestBuildJudgeModelLookup` failures in `test_serializers_full_coverage.py` / `test_pure_functions_coverage.py` pre-date this PR — they reference the old `eval_metadata`-based lookup signature replaced by the EvaluationJudgeRun-based one in 79a3cf0; out of scope here.)