### PR TITLE
leaderboard: lift falloesung grade_points to top-level metric

### DIFF
--- a/services/api/tests/unit/test_aggregate_summaries.py
+++ b/services/api/tests/unit/test_aggregate_summaries.py
@@ -403,3 +403,231 @@ class TestReadLLMModelAggregate:
         )
         assert agg["metrics"] == {}
         assert agg["evaluation_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Falllösung grade-points lift
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def seeded_falloesung(test_db: Session):
+    """Two task_evaluations carrying the canonical Falllösung metric shape:
+    `metrics.llm_judge_falloesung = {value, details: {raw_score, grade_points}}`.
+
+    Grade points live INSIDE `details`, not as a sibling top-level key. The
+    aggregator must lift them out via the dedicated UNION ALL branch so the
+    leaderboard's default column (`llm_judge_falloesung_grade_points`) has
+    rows to render.
+    """
+    user = User(
+        id=str(uuid.uuid4()),
+        username=f"fal_{uuid.uuid4().hex[:6]}",
+        email=f"fal_{uuid.uuid4().hex[:6]}@example.com",
+        name="Falloesung Test User",
+        hashed_password="x",
+        is_active=True,
+        is_superadmin=False,
+        email_verified=True,
+    )
+    test_db.add(user)
+
+    project = Project(
+        id=str(uuid.uuid4()),
+        title="Falloesung lift test",
+        description="for test_aggregate_summaries",
+        created_by=user.id,
+        label_config="<View/>",
+        is_public=True,
+        public_role="ANNOTATOR",
+    )
+    test_db.add(project)
+    test_db.flush()
+
+    task = Task(
+        id=str(uuid.uuid4()),
+        project_id=project.id,
+        data={"text": "fal task"},
+        inner_id=1,
+        is_labeled=True,
+    )
+    test_db.add(task)
+    test_db.flush()
+
+    rg = ResponseGeneration(
+        id=str(uuid.uuid4()),
+        project_id=project.id,
+        task_id=task.id,
+        model_id="gpt-4o",
+        status="completed",
+        created_by=user.id,
+    )
+    test_db.add(rg)
+    test_db.flush()
+
+    gen_high = Generation(
+        id=str(uuid.uuid4()),
+        generation_id=rg.id,
+        task_id=task.id,
+        model_id="gpt-4o",
+        run_index=0,
+        response_content="answer A",
+        case_data=json.dumps({}),
+        status="completed",
+        parse_status="success",
+    )
+    gen_low = Generation(
+        id=str(uuid.uuid4()),
+        generation_id=rg.id,
+        task_id=task.id,
+        model_id="gpt-4o",
+        run_index=1,
+        response_content="answer B",
+        case_data=json.dumps({}),
+        status="completed",
+        parse_status="success",
+    )
+    test_db.add_all([gen_high, gen_low])
+    test_db.flush()
+
+    er = EvaluationRun(
+        id=str(uuid.uuid4()),
+        project_id=project.id,
+        model_id="gpt-4o",
+        evaluation_type_ids=["llm_judge_falloesung"],
+        metrics={},
+        eval_metadata={},
+        status="completed",
+        samples_evaluated=2,
+        created_by=user.id,
+        created_at=datetime.now(timezone.utc),
+        completed_at=datetime.now(timezone.utc),
+    )
+    test_db.add(er)
+    test_db.flush()
+
+    jr = EvaluationJudgeRun(
+        id=str(uuid.uuid4()),
+        evaluation_id=er.id,
+        judge_model_id=None,
+        run_index=0,
+        status="completed",
+    )
+    test_db.add(jr)
+    test_db.flush()
+
+    # Raw_score 80 → grade_points 14 (per FALLOESUNG_GRADE_TABLE).
+    # Raw_score 40 → grade_points 4.
+    # Mean grade_points = 9.0.
+    te_high = TaskEvaluation(
+        id=str(uuid.uuid4()),
+        evaluation_id=er.id,
+        judge_run_id=jr.id,
+        task_id=task.id,
+        generation_id=gen_high.id,
+        field_name="llm_judge_falloesung",
+        answer_type="text",
+        ground_truth=None,
+        prediction=None,
+        metrics={
+            "llm_judge_falloesung": {
+                "value": 0.8,
+                "method": "llm_judge_falloesung",
+                "details": {
+                    "raw_score": 80.0,
+                    "grade_points": 14,
+                    "passed": True,
+                },
+                "error": None,
+            }
+        },
+        passed=True,
+    )
+    te_low = TaskEvaluation(
+        id=str(uuid.uuid4()),
+        evaluation_id=er.id,
+        judge_run_id=jr.id,
+        task_id=task.id,
+        generation_id=gen_low.id,
+        field_name="llm_judge_falloesung",
+        answer_type="text",
+        ground_truth=None,
+        prediction=None,
+        metrics={
+            "llm_judge_falloesung": {
+                "value": 0.4,
+                "method": "llm_judge_falloesung",
+                "details": {
+                    "raw_score": 40.0,
+                    "grade_points": 4,
+                    "passed": False,
+                },
+                "error": None,
+            }
+        },
+        passed=False,
+    )
+    # A third row missing grade_points — must NOT emit the synthetic metric.
+    te_missing = TaskEvaluation(
+        id=str(uuid.uuid4()),
+        evaluation_id=er.id,
+        judge_run_id=jr.id,
+        task_id=task.id,
+        generation_id=gen_high.id,
+        field_name="llm_judge_falloesung",
+        answer_type="text",
+        ground_truth=None,
+        prediction=None,
+        metrics={
+            "llm_judge_falloesung": {
+                "value": None,
+                "details": {"error": "parse failed"},
+                "error": "parse failed",
+            }
+        },
+        passed=False,
+    )
+    test_db.add_all([te_high, te_low, te_missing])
+    test_db.commit()
+
+    return {"project": project, "evaluation_run": er}
+
+
+class TestFalloesungGradePointsLift:
+    def test_synthetic_metric_emitted_per_row(self, test_db, seeded_falloesung):
+        rows = live_aggregate_leaderboard(
+            test_db,
+            project_ids=[seeded_falloesung["project"].id],
+            period="overall",
+            evaluation_types=None,
+        )
+        metric_keys = {(r["model_id"], r["metric"]) for r in rows}
+        assert ("gpt-4o", "llm_judge_falloesung") in metric_keys
+        assert ("gpt-4o", "llm_judge_falloesung_grade_points") in metric_keys
+
+    def test_synthetic_metric_score_is_mean_of_per_row_grade_points(
+        self, test_db, seeded_falloesung
+    ):
+        rows = live_aggregate_leaderboard(
+            test_db,
+            project_ids=[seeded_falloesung["project"].id],
+            period="overall",
+            evaluation_types=None,
+        )
+        gp_row = next(
+            r for r in rows
+            if r["model_id"] == "gpt-4o"
+            and r["metric"] == "llm_judge_falloesung_grade_points"
+        )
+        # Mean of grade_points 14 and 4 (the parse-failed row contributes nothing).
+        assert gp_row["score"] == pytest.approx(9.0, abs=1e-3)
+
+    def test_precomputed_path_includes_grade_points(self, test_db, seeded_falloesung):
+        recompute_llm_leaderboard_scores(test_db)
+        gp_rows = test_db.query(LLMLeaderboardScore).filter(
+            LLMLeaderboardScore.model_id == "gpt-4o",
+            LLMLeaderboardScore.metric == "llm_judge_falloesung_grade_points",
+        ).all()
+        # At least one row per (scope, period) combo that the recompute writes.
+        assert gp_rows
+        # The grade_points scale is 0..18, so the mean is well above 1.
+        assert all(r.score is not None and r.score > 1 for r in gp_rows)

--- a/services/api/tests/unit/test_metric_filters.py
+++ b/services/api/tests/unit/test_metric_filters.py
@@ -1,0 +1,48 @@
+"""Coverage for the shared metric-key noise filter.
+
+`metric_filters.metric_key_is_real` is the single source of truth used by
+the projects-list tally, the leaderboard aggregator, and the worker
+recompute path. Drift between these would silently drop or double-count
+metrics in tiles.
+"""
+
+from __future__ import annotations
+
+from metric_filters import metric_key_is_real
+
+
+class TestNoiseSuffixes:
+    def test_real_metric_keys_pass(self):
+        for k in ("accuracy", "bleu", "rouge", "llm_judge_falloesung"):
+            assert metric_key_is_real(k) is True, k
+
+    def test_noise_suffix_keys_filtered(self):
+        for k in (
+            "accuracy_details",
+            "bleu_raw",
+            "accuracy_passed",
+            "bleu_grade_points",
+            "rouge_response",
+        ):
+            assert metric_key_is_real(k) is False, k
+
+    def test_excluded_keys_filtered(self):
+        assert metric_key_is_real("raw_score") is False
+        assert metric_key_is_real("error") is False
+
+    def test_empty_or_none_filtered(self):
+        assert metric_key_is_real(None) is False
+        assert metric_key_is_real("") is False
+
+
+class TestRegisteredOverrides:
+    def test_llm_judge_falloesung_grade_points_passes(self):
+        # Even though the key ends in `_grade_points` (normally a noise
+        # suffix), it's a registered displayable sub-metric and must reach
+        # the leaderboard aggregator.
+        assert metric_key_is_real("llm_judge_falloesung_grade_points") is True
+
+    def test_other_grade_points_keys_still_filtered(self):
+        # Override is explicit; unknown `*_grade_points` keys stay filtered.
+        assert metric_key_is_real("accuracy_grade_points") is False
+        assert metric_key_is_real("bleu_grade_points") is False

--- a/services/shared/aggregate_summaries.py
+++ b/services/shared/aggregate_summaries.py
@@ -364,6 +364,14 @@ def _aggregate_leaderboard_rows(
     )
 
     # jsonb_each returns a record type; using text() for clarity.
+    #
+    # The UNION ALL branch synthesises a `llm_judge_falloesung_grade_points`
+    # triple per row from `metrics.llm_judge_falloesung.details.grade_points`.
+    # The worker stores grade points inside `details` (next to raw_score), so
+    # jsonb_each above only ever sees the parent `llm_judge_falloesung`
+    # (0–1 normalised score). The frontend leaderboard defaults to the
+    # grade_points metric — without this lift the column is always n/a even
+    # though the per-row value exists.
     raw_sql = text(
         """
         SELECT
@@ -378,6 +386,23 @@ def _aggregate_leaderboard_rows(
           AND te.generation_id IS NOT NULL
           AND te.metrics IS NOT NULL
           AND jsonb_typeof(te.metrics::jsonb) = 'object'
+
+        UNION ALL
+
+        SELECT
+            g.model_id,
+            'llm_judge_falloesung_grade_points' AS metric_key,
+            te.metrics::jsonb->'llm_judge_falloesung'->'details'->'grade_points' AS metric_val
+        FROM task_evaluations te
+        JOIN generations g ON g.id = te.generation_id
+        JOIN evaluation_runs er ON er.id = te.evaluation_id
+        WHERE te.evaluation_id = ANY(:run_ids)
+          AND te.generation_id IS NOT NULL
+          AND te.metrics IS NOT NULL
+          AND jsonb_typeof(te.metrics::jsonb) = 'object'
+          AND te.metrics::jsonb ? 'llm_judge_falloesung'
+          AND te.metrics::jsonb->'llm_judge_falloesung'->'details' ? 'grade_points'
+          AND jsonb_typeof(te.metrics::jsonb->'llm_judge_falloesung'->'details'->'grade_points') = 'number'
         """
     ).bindparams(run_ids=run_ids)
 

--- a/services/shared/metric_filters.py
+++ b/services/shared/metric_filters.py
@@ -22,11 +22,21 @@ _METRIC_NOISE_SUFFIXES: Tuple[str, ...] = (
 )
 _METRIC_EXCLUDED_KEYS = frozenset({"raw_score", "error"})
 
+# Sub-metric names that look like noise (end in a suffix above) but are
+# registered as displayable standalone metrics in the frontend metric
+# registry. Without this override the aggregator + tile counters would drop
+# them on the floor and the leaderboard column shows n/a for everyone even
+# though the per-row value exists (see aggregate_summaries.py — the
+# UNION ALL that lifts grade_points out of `details`).
+_METRIC_REGISTERED_OVERRIDES = frozenset({"llm_judge_falloesung_grade_points"})
+
 
 def metric_key_is_real(key: Optional[str]) -> bool:
     """True for keys that should count toward the scored-pairs tally."""
     if not key or key in _METRIC_EXCLUDED_KEYS:
         return False
+    if key in _METRIC_REGISTERED_OVERRIDES:
+        return True
     return not key.endswith(_METRIC_NOISE_SUFFIXES)
 
 


### PR DESCRIPTION
## Summary

- The LLM leaderboard's default column **Notenpunkte (Falllösung)** showed `n/a` for every model on prod even though prod has ~11k `llm_judge_falloesung` evaluations. Root cause: the aggregator (`aggregate_summaries.py`) only extracts top-level metric keys from `task_evaluations.metrics`, while grade points live inside `details.grade_points`. The synthetic metric `llm_judge_falloesung_grade_points` was therefore never written to `llm_leaderboard_scores`.
- Fix: `UNION ALL` a synthetic `(model_id, 'llm_judge_falloesung_grade_points', details.grade_points)` triple per row in the aggregator SQL. **No data migration needed** — 10,825 prod rows already carry numeric grade_points inside `details`.
- Allowlist the synthetic key in `metric_filters._METRIC_REGISTERED_OVERRIDES` so the `_grade_points` noise-suffix filter doesn't drop it.

## Prod validation (read-only dry-run of the new query)

| Model | Rows | Mean NP |
|---|---:|---:|
| gpt-5.4 | 759 | 13.87 |
| claude-sonnet-4-6 | 864 | 12.82 |
| claude-opus-4-7 | 729 | 12.69 |
| gemini-3.1-pro-preview | 825 | 11.49 |
| llama-maverick-17B | 664 | 6.44 |

16 distinct models will get rows, totaling 9,508 source `task_evaluations`. Min/max NP = 0/18, full Notenpunkte range represented.

## Post-deploy steps

1. Wait for the next `recompute_aggregates` cron tick (hourly) **or** trigger it manually:
   ```
   kubectl exec -n benger deployment/benger-workers -- celery -A workers call workers.tasks.recompute_aggregates
   ```
2. Verify rows landed:
   ```sql
   SELECT model_id, score, samples_evaluated FROM llm_leaderboard_scores
   WHERE metric = 'llm_judge_falloesung_grade_points' ORDER BY score DESC LIMIT 20;
   ```
3. Reload https://what-a-benger.net/leaderboards (LLMs tab) — "Notenpunkte (Falllösung)" column should populate.

## Test plan

- [x] Unit tests for synthetic metric emission, mean grade_points calculation, and parse-failed row exclusion (`test_aggregate_summaries.py::TestFalloesungGradePointsLift`)
- [x] Unit tests for the noise filter allowlist (`test_metric_filters.py`)
- [x] SQL dry-run against prod (read-only) — distribution verified above
- [ ] CI green
- [ ] Post-merge: trigger recompute, verify SQL count + UI

## Risk + rollback

Purely additive at the aggregator level. Rollback = revert the commit + (optionally) `DELETE FROM llm_leaderboard_scores WHERE metric = 'llm_judge_falloesung_grade_points'` to clean the cache.

## Non-goals

- No data cleanup or deletions — verified all 10,825 dimension-bearing rows are internally consistent (raw_score == sum of dimensions, all 100-point schemas, no overflows). The "0-1 scale leak" rows initially suspected turned out to be legitimately bad model outputs (model copied prompt → judge correctly scored ~0.5/100).
- No worker change — worker continues to write the canonical `metrics.llm_judge_falloesung = {value, details: {raw_score, grade_points, …}}` shape.