### PR TITLE
leaderboard: open scope='all' to any authenticated user

### DIFF
--- a/services/api/routers/leaderboards.py
+++ b/services/api/routers/leaderboards.py
@@ -278,15 +278,22 @@ def _project_scope_key_for_request(
 
     Returns:
       - single-project id when exactly one project is in the filter
-      - 'all' for superadmin with no filter
-      - 'public' for visitors/contributors with no filter (default visibility)
+      - 'all' for any authenticated user with no filter — logged-in users see
+        aggregate leaderboard scores across every project (the leaderboard is
+        aggregate-only, never row-level data, so private-project rankings are
+        the legitimate signal we want them to act on)
+      - 'public' for anonymous visitors with no filter — the public web
+        leaderboard stays scoped to is_public=True projects so private
+        project rankings don't leak to the open internet
       - None when no precomputed scope matches (multi-project explicit filter)
     """
     if project_ids and len(project_ids) == 1:
         return project_ids[0]
     if project_ids:
         return None  # multi-project filter → live fallback
-    return "all" if getattr(current_user, "is_superadmin", False) else "public"
+    if current_user is not None:
+        return "all"
+    return "public"
 
 
 def _evaluation_types_in_scope(

--- a/services/api/tests/unit/test_leaderboards_visibility.py
+++ b/services/api/tests/unit/test_leaderboards_visibility.py
@@ -56,15 +56,21 @@ def test_helper_falls_back_to_is_public_when_no_project_ids():
     assert "if project_ids:" in body
 
 
-def test_default_scope_falls_back_to_public_for_non_superadmin():
-    """After the precomputed-summary refactor (migration 051), visibility
-    is enforced at the scope-key level rather than via .filter() calls on
-    EvaluationRun. The contract is the same: a non-superadmin user with
-    no `project_ids` filter must read from the 'public' scope (which the
-    worker precomputes from `Project.is_public=True` only), NOT from 'all'.
+def test_default_scope_splits_by_authentication():
+    """Visibility contract for the precomputed leaderboard:
 
-    Closes the same regression as PR 5 (ZJS Fälle bleeding into the
-    global per-model averages).
+    * **Anonymous visitors** (no auth cookie / no token) → 'public' scope.
+      Private project rankings must NOT leak to the open internet via
+      the unauthenticated /leaderboards endpoint.
+    * **Any authenticated user** (superadmin or not) → 'all' scope. Logged-in
+      users see aggregate scores from every project. Aggregates are not
+      row-level data; the private-project signal is the whole point of
+      the leaderboard for evaluators.
+
+    Replaces the older non-superadmin → 'public' rule. The original
+    motivation (ZJS Fälle on a 34k-row BLEU project skewing the global
+    average) is preserved for anonymous visitors; the change only opens
+    the inside view to authenticated users.
     """
     src = _src()
     m = re.search(
@@ -77,14 +83,19 @@ def test_default_scope_falls_back_to_public_for_non_superadmin():
     )
     assert m, "_project_scope_key_for_request helper missing — refactor reverted?"
     body = m.group(0)
-    # Default branch (no project_ids) must select 'public' unless superadmin.
-    assert "is_superadmin" in body, (
-        "Scope selector must branch on is_superadmin so non-superadmins land "
-        "on the 'public' scope by default"
+    # Authenticated branch must exist and return 'all'.
+    assert "current_user is not None" in body, (
+        "Scope selector must branch on whether the user is authenticated "
+        "(current_user is not None) so logged-in users land on 'all'"
     )
+    assert "'all'" in body or '"all"' in body, (
+        "Authenticated default must be 'all' — otherwise SebaN-style users "
+        "can't see private-project leaderboard data"
+    )
+    # Anonymous fallback must still be 'public'.
     assert "'public'" in body or '"public"' in body, (
-        "Default scope key for non-superadmin without project_ids must be "
-        "'public' — otherwise private projects leak into the leaderboard"
+        "Anonymous fallback must be 'public' — otherwise private project "
+        "rankings leak to the open internet via /leaderboards"
     )
 
 


### PR DESCRIPTION
## Summary

Follow-up to #114 (which made the Notenpunkte data exist). PR #114 fixed the aggregator so `llm_judge_falloesung_grade_points` rows now appear in `llm_leaderboard_scores`, but only under `project_scope_key='all'`. The endpoint maps non-superadmins to `'public'`, and **no** projects holding falloesung evaluations are public (Benchathon, ZJS Fälle, Klausurenwerkstatt all have `is_public=False`). So logged-in users still see `n/a`.

## Change

`_project_scope_key_for_request` in `services/api/routers/leaderboards.py`:

| Caller | Old scope | New scope |
|---|---|---|
| Anonymous visitor, no project filter | `public` | `public` (unchanged — anti-skew preserved) |
| Authenticated user, no project filter | `public` | **`all`** |
| Superadmin, no project filter | `all` | `all` (unchanged) |
| Single project filter | that project's key | that project's key (unchanged) |
| Multi-project filter | live SQL | live SQL (unchanged) |

The aggregate leaderboard is not row-level data — it ranks models by mean metric scores. Authenticated users have a legitimate reason to see those rankings across all projects they're evaluating models for.

Anonymous visitors keep the `'public'` default so private-project rankings still don't leak to the open internet, preserving the PR 5 / issue #30 anti-skew motivation for that code path.

## Tests

- `test_leaderboards_visibility::test_default_scope_splits_by_authentication` (renamed from `_falls_back_to_public_for_non_superadmin`) locks in the new contract.

## Verification after deploy

Reload https://what-a-benger.net/leaderboards as a logged-in non-superadmin (e.g. SebaN). LLMs tab → "Notenpunkte (Falllösung)" column should be populated for 16 models (gpt-5.4 leads at 14.08 NP), "Generierungen" should show real per-model counts.

## Risk

- Anyone with a BenGER login now sees aggregate falloesung scores from your private projects. If that's not desired for some accounts (e.g. annotator-only volunteers), the proper next step is per-org or per-role gating, not flipping back to scope='public'.
- Rollback: revert this commit; superadmins still see all data via the existing `scope='all'` branch.