### PR TITLE
leaderboard: filter-bar sanity + scale-aware display

### DIFF
--- a/services/api/routers/leaderboards.py
+++ b/services/api/routers/leaderboards.py
@@ -8,7 +8,7 @@ Supports filtering by project and time period.
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 from sqlalchemy import func
 from sqlalchemy.orm import Session
@@ -32,14 +32,33 @@ router = APIRouter(prefix="/api/leaderboards", tags=["leaderboards"])
 
 
 def _filter_accessible_project_ids(
-    db: Session, user, project_ids: Optional[List[str]], org_context: Optional[str] = None
+    db: Session,
+    user,
+    project_ids: Optional[List[str]],
+    org_context: Optional[str] = None,
+    *,
+    strict: bool = False,
 ) -> Optional[List[str]]:
-    """Filter project_ids to only include those the user can access."""
+    """Filter project_ids to only include those the user can access.
+
+    When `strict=True` and the caller supplied a non-empty list but every
+    id was stripped (unknown, deleted, or not accessible), raise HTTP 400
+    instead of silently re-defaulting to the no-filter scope. The default
+    is `False` so existing callers keep their lenient behaviour; the
+    leaderboard list endpoint opts in to prevent silently-broadened
+    filters surfacing the full leaderboard when the user meant to scope.
+    """
     if not project_ids:
         return project_ids
     if user.is_superadmin:
         return project_ids
-    return [pid for pid in project_ids if check_project_accessible(db, user, pid, org_context)]
+    kept = [pid for pid in project_ids if check_project_accessible(db, user, pid, org_context)]
+    if strict and not kept:
+        raise HTTPException(
+            status_code=400,
+            detail="project_ids include no accessible project for this user",
+        )
+    return kept
 
 
 def _apply_default_visibility_filter(query, project_ids):
@@ -331,14 +350,17 @@ async def get_llm_leaderboard(
         "overall", regex="^(overall|monthly|weekly)$", description="Time period filter"
     ),
     metric: str = Query(
-        "average", description="Metric to rank by (average, accuracy, f1, bleu, etc.)"
+        "average", description="Metric to rank by (e.g. accuracy, f1, bleu, llm_judge_falloesung_grade_points)"
     ),
     evaluation_types: Optional[List[str]] = Query(
-        None, description="Filter by evaluation types (e.g., accuracy, f1, llm_judge)"
+        None, description="Filter rows to TaskEvaluations whose metrics include at least one of these keys"
     ),
     include_all_models: bool = Query(False, description="Include models with no evaluations"),
     aggregation: str = Query(
         "average", regex="^(average|sum)$", description="Aggregation mode: average or sum"
+    ),
+    search: Optional[str] = Query(
+        None, max_length=80, description="Case-insensitive substring match against model_id and model_name"
     ),
     limit: int = Query(50, le=200, description="Maximum results to return"),
     offset: int = Query(0, ge=0, description="Offset for pagination"),
@@ -383,17 +405,22 @@ async def get_llm_leaderboard(
     )
 
     org_context = get_org_context_from_request(request)
-    project_ids = _filter_accessible_project_ids(db, current_user, project_ids, org_context)
+    project_ids = _filter_accessible_project_ids(
+        db, current_user, project_ids, org_context, strict=True,
+    )
 
     scope_key = _project_scope_key_for_request(project_ids, current_user)
 
     # Precomputed scores cover the common case (no per-request evaluation_type
-    # filter, average aggregation). Anything outside falls through to live SQL
-    # — still bounded by yield_per streaming inside the helper.
+    # filter, average aggregation, no search). Anything outside falls through
+    # to live SQL — still bounded by yield_per streaming inside the helper.
+    # Search forces live because precomputed read paginates at SQL level and
+    # we need the full set to filter by name.
     use_precomputed = (
         scope_key is not None
         and not evaluation_types
         and aggregation == "average"
+        and not search
     )
 
     computed_at: Optional[datetime] = None
@@ -403,7 +430,9 @@ async def get_llm_leaderboard(
             db, scope_key, period, metric, limit, offset
         )
     else:
-        rows = live_aggregate_leaderboard(db, project_ids, period, evaluation_types)
+        rows = live_aggregate_leaderboard(
+            db, project_ids, period, evaluation_types, aggregation=aggregation,
+        )
         by_model: Dict[str, Dict[str, Any]] = {}
         for r in rows:
             entry = by_model.setdefault(
@@ -420,13 +449,9 @@ async def get_llm_leaderboard(
                     "last_evaluated_at": r["last_evaluated_at"],
                 },
             )
-            score = r["score"]
-            if r["metric"] == "average":
-                entry["metrics"]["average"] = score
-            else:
-                entry["metrics"][r["metric"]] = score
+            entry["metrics"][r["metric"]] = r["score"]
             if r["metric"] == metric:
-                entry["score"] = score
+                entry["score"] = r["score"]
                 entry["ci_lower"] = r["ci_lower"]
                 entry["ci_upper"] = r["ci_upper"]
 
@@ -434,11 +459,26 @@ async def get_llm_leaderboard(
             by_model.values(),
             key=lambda e: (e["score"] is None, -(e["score"] or 0), e["model_id"]),
         )
+        available_metrics = sorted({r["metric"] for r in rows})
+        # Server-side search: filter by model name before paginating so the
+        # frontend's pager total stays honest. Name lookup needs the LLMModel
+        # table — bounded to the post-aggregation model set (≤ a few hundred).
+        if search:
+            term = search.lower()
+            sorted_entries_model_ids = [e["model_id"] for e in sorted_entries]
+            search_model_info: Dict[str, str] = {}
+            if sorted_entries_model_ids:
+                for m in db.query(LLMModel).filter(
+                    LLMModel.id.in_(sorted_entries_model_ids)
+                ).all():
+                    search_model_info[m.id] = m.name
+            sorted_entries = [
+                e for e in sorted_entries
+                if term in e["model_id"].lower()
+                or term in search_model_info.get(e["model_id"], "").lower()
+            ]
         total_models = len(sorted_entries)
         entries = sorted_entries[offset : offset + limit]
-        available_metrics = sorted(
-            {r["metric"] for r in rows if r["metric"] != "average"}
-        )
 
     # Look up model metadata (small bounded query — at most `limit` models).
     model_ids_in_page = [e["model_id"] for e in entries]
@@ -459,11 +499,6 @@ async def get_llm_leaderboard(
             },
         )
         last_at = entry.get("last_evaluated_at")
-        # Drop the synthetic 'average' key from the per-metric dict the frontend
-        # iterates over — it's surfaced separately as `average_score`.
-        metrics_for_display = {
-            k: v for k, v in entry.get("metrics", {}).items() if k != "average"
-        }
         leaderboard.append(
             LLMLeaderboardEntry(
                 rank=rank,
@@ -473,7 +508,7 @@ async def get_llm_leaderboard(
                 evaluation_count=entry.get("evaluation_count", 0),
                 samples_evaluated=entry.get("samples_evaluated", 0),
                 generation_count=entry.get("generation_count", 0),
-                metrics=metrics_for_display,
+                metrics=entry.get("metrics", {}),
                 average_score=entry.get("score"),
                 ci_lower=entry.get("ci_lower"),
                 ci_upper=entry.get("ci_upper"),
@@ -482,11 +517,17 @@ async def get_llm_leaderboard(
         )
 
     # Include zero-row entries for active models that aren't in the page.
+    # Honours `search` so the catalog-padding doesn't undo the filter.
     if include_all_models:
         seen = {e.model_id for e in leaderboard}
-        for m in db.query(LLMModel).filter(LLMModel.is_active == True).all():  # noqa: E712
+        catalog_q = db.query(LLMModel).filter(LLMModel.is_active == True)  # noqa: E712
+        for m in catalog_q.all():
             if m.id in seen:
                 continue
+            if search:
+                term = search.lower()
+                if term not in m.id.lower() and term not in (m.name or "").lower():
+                    continue
             leaderboard.append(
                 LLMLeaderboardEntry(
                     rank=len(leaderboard) + 1,
@@ -517,6 +558,7 @@ async def get_llm_leaderboard(
             "aggregation": aggregation,
             "evaluation_types": evaluation_types or [],
             "include_all_models": include_all_models,
+            "search": search or "",
             "limit": limit,
             "offset": offset,
         },

--- a/services/api/routers/leaderboards.py
+++ b/services/api/routers/leaderboards.py
@@ -16,8 +16,24 @@ from sqlalchemy.orm import Session
 from auth_module.dependencies import get_current_user
 from database import get_db
 from models import EvaluationRun, TaskEvaluation, Generation, LLMModel, User
-from project_models import Annotation, Project
+from project_models import Annotation, Project, ProjectOrganization
 from routers.projects.helpers import check_project_accessible, get_org_context_from_request
+
+# Temporary trust gate for the LLM leaderboard: only projects assigned to
+# one of these orgs contribute to ranking. Other orgs (TITAN, LTV,
+# Benchathon, …) have evaluation data the team doesn't yet treat as a
+# meaningful comparative signal. Remove this constant (and the call sites
+# below) when the gate lifts. The frontend has no opt-out — the scope
+# applies to every user, superadmin included.
+_LLM_LEADERBOARD_ALLOWLISTED_ORG_IDS = (
+    "a22cbcfa-a5ab-4c7e-b93f-dd5585906a8b",  # TUM
+)
+
+# Default minimums for "meaningful sample" on the leaderboard. Frontend
+# toggle defaults ON and sends these values; opting out sends 0. Same
+# values used as API defaults so a raw curl gets the same view as the UI.
+_LLM_LEADERBOARD_DEFAULT_MIN_GENERATIONS = 50
+_LLM_LEADERBOARD_DEFAULT_MIN_SAMPLES = 50
 
 # Statistical imports for confidence intervals
 try:
@@ -29,6 +45,35 @@ except ImportError:
     STATS_AVAILABLE = False
 
 router = APIRouter(prefix="/api/leaderboards", tags=["leaderboards"])
+
+
+def _intersect_with_allowlisted_org_projects(
+    db: Session, project_ids: Optional[List[str]]
+) -> Optional[List[str]]:
+    """Restrict project_ids to those assigned to an allowlisted org.
+
+    Used by the LLM leaderboard endpoint as a temporary trust gate so
+    only TUM-owned projects contribute to rankings. When
+    `_LLM_LEADERBOARD_ALLOWLISTED_ORG_IDS` is empty this is a no-op
+    (lifts the gate). When the caller didn't pass any project_ids, this
+    populates the filter with every allowlisted-org project; when they
+    did, we intersect and 400 if nothing remains.
+    """
+    if not _LLM_LEADERBOARD_ALLOWLISTED_ORG_IDS:
+        return project_ids
+    allowed_q = db.query(ProjectOrganization.project_id).filter(
+        ProjectOrganization.organization_id.in_(_LLM_LEADERBOARD_ALLOWLISTED_ORG_IDS)
+    )
+    allowed_set = {row[0] for row in allowed_q.all()}
+    if project_ids is None or not project_ids:
+        return sorted(allowed_set)
+    intersect = [pid for pid in project_ids if pid in allowed_set]
+    if not intersect:
+        raise HTTPException(
+            status_code=400,
+            detail="selected project(s) are not in the LLM leaderboard trust scope",
+        )
+    return intersect
 
 
 def _filter_accessible_project_ids(
@@ -362,6 +407,14 @@ async def get_llm_leaderboard(
     search: Optional[str] = Query(
         None, max_length=80, description="Case-insensitive substring match against model_id and model_name"
     ),
+    min_generation_count: int = Query(
+        _LLM_LEADERBOARD_DEFAULT_MIN_GENERATIONS, ge=0,
+        description="Drop models with fewer than N generations in scope (0 = no filter)",
+    ),
+    min_samples_evaluated: int = Query(
+        _LLM_LEADERBOARD_DEFAULT_MIN_SAMPLES, ge=0,
+        description="Drop models with fewer than N evaluated samples in scope (0 = no filter)",
+    ),
     limit: int = Query(50, le=200, description="Maximum results to return"),
     offset: int = Query(0, ge=0, description="Offset for pagination"),
     db: Session = Depends(get_db),
@@ -408,19 +461,27 @@ async def get_llm_leaderboard(
     project_ids = _filter_accessible_project_ids(
         db, current_user, project_ids, org_context, strict=True,
     )
+    # Apply the leaderboard's trust gate AFTER accessibility filtering so
+    # the user gets a clear "no accessible project" 400 first if relevant,
+    # then the "not in trust scope" 400 if all their accessible projects
+    # are excluded.
+    project_ids = _intersect_with_allowlisted_org_projects(db, project_ids)
 
     scope_key = _project_scope_key_for_request(project_ids, current_user)
 
     # Precomputed scores cover the common case (no per-request evaluation_type
-    # filter, average aggregation, no search). Anything outside falls through
-    # to live SQL — still bounded by yield_per streaming inside the helper.
-    # Search forces live because precomputed read paginates at SQL level and
-    # we need the full set to filter by name.
+    # filter, average aggregation, no search, no min-sample thresholds).
+    # Anything outside falls through to live SQL — still bounded by
+    # yield_per streaming inside the helper. Thresholds + search force live
+    # because the precomputed read paginates at SQL level and we'd need the
+    # full set to filter post-aggregation honestly.
     use_precomputed = (
         scope_key is not None
         and not evaluation_types
         and aggregation == "average"
         and not search
+        and min_generation_count <= 0
+        and min_samples_evaluated <= 0
     )
 
     computed_at: Optional[datetime] = None
@@ -460,6 +521,16 @@ async def get_llm_leaderboard(
             key=lambda e: (e["score"] is None, -(e["score"] or 0), e["model_id"]),
         )
         available_metrics = sorted({r["metric"] for r in rows})
+        # Minimum-sample threshold: drop models whose aggregate counters
+        # are too small to support a meaningful ranking. The toggle is
+        # default-ON in the UI; raw API callers get the same defaults so
+        # noisy low-sample models don't pollute integrations either.
+        if min_generation_count > 0 or min_samples_evaluated > 0:
+            sorted_entries = [
+                e for e in sorted_entries
+                if e.get("generation_count", 0) >= min_generation_count
+                and e.get("samples_evaluated", 0) >= min_samples_evaluated
+            ]
         # Server-side search: filter by model name before paginating so the
         # frontend's pager total stays honest. Name lookup needs the LLMModel
         # table — bounded to the post-aggregation model set (≤ a few hundred).
@@ -559,6 +630,8 @@ async def get_llm_leaderboard(
             "evaluation_types": evaluation_types or [],
             "include_all_models": include_all_models,
             "search": search or "",
+            "min_generation_count": min_generation_count,
+            "min_samples_evaluated": min_samples_evaluated,
             "limit": limit,
             "offset": offset,
         },

--- a/services/api/tests/unit/test_aggregate_summaries.py
+++ b/services/api/tests/unit/test_aggregate_summaries.py
@@ -343,8 +343,11 @@ class TestLLMLeaderboardScores:
         # At least one row per (model, metric) combination present.
         model_metric_pairs = {(r["model_id"], r["metric"]) for r in rows}
         assert ("gpt-4o", "accuracy") in model_metric_pairs
-        # The synthetic 'average' aggregate row is also emitted.
-        assert any(r["metric"] == "average" for r in rows)
+        # PR #116: the synthetic cross-metric 'average' row is no longer
+        # emitted — pooling values from incompatible scales (0–1, 0–18,
+        # 0–100) into one mean produced dimensionally meaningless numbers
+        # that rendered as "1400%". The metric picker no longer offers it.
+        assert not any(r["metric"] == "average" for r in rows)
 
 
 # ---------------------------------------------------------------------------
@@ -631,3 +634,95 @@ class TestFalloesungGradePointsLift:
         assert gp_rows
         # The grade_points scale is 0..18, so the mean is well above 1.
         assert all(r.score is not None and r.score > 1 for r in gp_rows)
+
+
+# ---------------------------------------------------------------------------
+# Sum aggregation + per-row evaluation_types filter (PR #116)
+# ---------------------------------------------------------------------------
+
+class TestSumAggregation:
+    def test_sum_returns_total_not_mean(self, test_db, seeded_falloesung):
+        rows = live_aggregate_leaderboard(
+            test_db,
+            project_ids=[seeded_falloesung["project"].id],
+            period="overall",
+            evaluation_types=None,
+            aggregation="sum",
+        )
+        gp_row = next(
+            r for r in rows
+            if r["model_id"] == "gpt-4o"
+            and r["metric"] == "llm_judge_falloesung_grade_points"
+        )
+        # Seed has two non-error grade_points values: 14 + 4 = 18 total.
+        assert gp_row["score"] == pytest.approx(18.0, abs=1e-3)
+        # CI doesn't apply to a sum; the aggregator clears the bounds so
+        # the frontend can hide the CI for the row.
+        assert gp_row["ci_lower"] is None
+        assert gp_row["ci_upper"] is None
+
+    def test_average_default_unchanged(self, test_db, seeded_falloesung):
+        # Sanity: not passing `aggregation` defaults to 'average' and
+        # produces the same mean as the existing test fixture asserts.
+        rows = live_aggregate_leaderboard(
+            test_db,
+            project_ids=[seeded_falloesung["project"].id],
+            period="overall",
+            evaluation_types=None,
+        )
+        gp_row = next(
+            r for r in rows
+            if r["model_id"] == "gpt-4o"
+            and r["metric"] == "llm_judge_falloesung_grade_points"
+        )
+        assert gp_row["score"] == pytest.approx(9.0, abs=1e-3)
+        # CI is populated under mean aggregation.
+        assert gp_row["ci_lower"] is not None
+        assert gp_row["ci_upper"] is not None
+
+
+class TestEvaluationTypesPerRowFilter:
+    def test_eval_types_filters_metric_keys_per_row(self, test_db, seeded):
+        # The 'seeded' fixture writes both 'accuracy' and 'accuracy_details'
+        # (noise, already filtered) into each TaskEvaluation's metrics dict.
+        # Asking for evaluation_types=['accuracy'] should yield rows whose
+        # metric key is exactly 'accuracy', not some other metric from the
+        # same run that happens to be present in the JSON.
+        rows = live_aggregate_leaderboard(
+            test_db,
+            project_ids=[seeded["project"].id],
+            period="overall",
+            evaluation_types=["accuracy"],
+        )
+        metric_keys = {r["metric"] for r in rows}
+        assert metric_keys == {"accuracy"}, (
+            f"expected only 'accuracy' rows, got {metric_keys}"
+        )
+
+    def test_eval_types_with_unknown_returns_no_rows(self, test_db, seeded):
+        rows = live_aggregate_leaderboard(
+            test_db,
+            project_ids=[seeded["project"].id],
+            period="overall",
+            evaluation_types=["this_metric_does_not_exist"],
+        )
+        # The run-level pre-filter already excludes runs that didn't declare
+        # this type, so live aggregation returns nothing. The per-row filter
+        # adds defence in depth for runs whose declaration drifted from
+        # actual produced metrics.
+        assert rows == []
+
+    def test_eval_types_none_returns_all_metric_keys(self, test_db, seeded):
+        # Without an eval_types filter the aggregator emits every metric
+        # key produced by the runs (the old behaviour).
+        rows = live_aggregate_leaderboard(
+            test_db,
+            project_ids=[seeded["project"].id],
+            period="overall",
+            evaluation_types=None,
+        )
+        metric_keys = {r["metric"] for r in rows}
+        # At minimum 'accuracy' must be in there; the noise key
+        # 'accuracy_details' must NOT be (it's filtered by metric_filters).
+        assert "accuracy" in metric_keys
+        assert "accuracy_details" not in metric_keys

--- a/services/api/tests/unit/test_leaderboards_visibility.py
+++ b/services/api/tests/unit/test_leaderboards_visibility.py
@@ -99,6 +99,44 @@ def test_default_scope_splits_by_authentication():
     )
 
 
+def test_strict_filter_rejects_unknown_project_ids():
+    """PR #116: when the leaderboard endpoint is called with
+    `project_ids=<unknown-or-inaccessible>` and the filter strips every
+    id, we MUST raise HTTP 400 instead of silently re-defaulting to the
+    no-filter scope. The silent fallback hid project_id typos and let the
+    caller think they were looking at a scoped leaderboard.
+
+    `_filter_accessible_project_ids(strict=True)` is the path the
+    leaderboard list endpoint opts into.
+    """
+    src = _src()
+    m = re.search(
+        r"def _filter_accessible_project_ids\([^)]*\)[^:]*:.+?(?=\ndef |\nclass )",
+        src,
+        re.DOTALL,
+    )
+    assert m, "_filter_accessible_project_ids helper missing — refactor reverted?"
+    body = m.group(0)
+    assert "strict" in body, "helper must accept a strict kwarg so callers can opt in"
+    assert "HTTPException" in body, (
+        "strict mode must raise HTTPException(400), not silently re-default"
+    )
+
+    # The list endpoint must call with strict=True so unknown project_ids
+    # produce a 400 there. Other endpoints (single-model, compare) keep
+    # the lenient default for backward compatibility.
+    list_endpoint_call = re.search(
+        r"async def get_llm_leaderboard\b.+?_filter_accessible_project_ids\([^)]*\)",
+        src,
+        re.DOTALL,
+    )
+    assert list_endpoint_call, "get_llm_leaderboard endpoint missing or no project_ids call"
+    assert "strict=True" in list_endpoint_call.group(0), (
+        "get_llm_leaderboard must call _filter_accessible_project_ids(strict=True) "
+        "so unknown project_ids surface as 400 rather than a silently-broader leaderboard"
+    )
+
+
 def test_helper_only_joins_project_when_filter_is_needed():
     """When the caller already supplied project_ids, we should NOT add an
     extra Project join — saves a query plan node. The helper's true-branch

--- a/services/api/tests/unit/test_leaderboards_visibility.py
+++ b/services/api/tests/unit/test_leaderboards_visibility.py
@@ -137,6 +137,59 @@ def test_strict_filter_rejects_unknown_project_ids():
     )
 
 
+def test_llm_leaderboard_trust_scope_intersect_helper_exists_and_is_wired():
+    """PR #116 temp tweak: the LLM leaderboard is scoped to an
+    allowlisted set of organisation IDs (currently TUM only) so untrusted
+    eval data from other orgs doesn't surface on the public ranking.
+
+    Contract:
+      - `_intersect_with_allowlisted_org_projects` helper exists
+      - `_LLM_LEADERBOARD_ALLOWLISTED_ORG_IDS` constant defines the gate
+      - `get_llm_leaderboard` calls the helper before scope-key mapping
+    """
+    src = _src()
+    assert "_LLM_LEADERBOARD_ALLOWLISTED_ORG_IDS" in src, (
+        "trust-scope constant missing — the LLM leaderboard would surface "
+        "untrusted org data"
+    )
+    assert "def _intersect_with_allowlisted_org_projects(" in src, (
+        "trust-scope helper missing"
+    )
+    # The list endpoint must call the helper. Capture the function body and
+    # assert the call appears (order matters: after accessibility check).
+    list_fn = re.search(
+        r"async def get_llm_leaderboard\b.+?(?=\nasync def |\ndef |\nclass )",
+        src,
+        re.DOTALL,
+    )
+    assert list_fn, "get_llm_leaderboard endpoint missing"
+    body = list_fn.group(0)
+    assert "_intersect_with_allowlisted_org_projects" in body, (
+        "get_llm_leaderboard must call _intersect_with_allowlisted_org_projects "
+        "so non-allowlisted projects are excluded from rankings"
+    )
+
+
+def test_llm_leaderboard_min_samples_threshold_params_exist():
+    """PR #116 default-on min-samples toggle: the list endpoint must
+    accept `min_generation_count` and `min_samples_evaluated` query
+    params with sensible defaults so noisy low-sample models don't
+    pollute the ranking by default.
+    """
+    src = _src()
+    assert "min_generation_count" in src, (
+        "min_generation_count param missing — threshold filter not wired"
+    )
+    assert "min_samples_evaluated" in src, (
+        "min_samples_evaluated param missing — threshold filter not wired"
+    )
+    # The frontend toggle defaults ON and sends 50/50; the API defaults
+    # match so raw curl gets the same view. Drop these constants and the
+    # filter when lifting the gate.
+    assert "_LLM_LEADERBOARD_DEFAULT_MIN_GENERATIONS" in src
+    assert "_LLM_LEADERBOARD_DEFAULT_MIN_SAMPLES" in src
+
+
 def test_helper_only_joins_project_when_filter_is_needed():
     """When the caller already supplied project_ids, we should NOT add an
     extra Project join — saves a query plan node. The helper's true-branch

--- a/services/frontend/src/components/leaderboards/LLMLeaderboardTable.tsx
+++ b/services/frontend/src/components/leaderboards/LLMLeaderboardTable.tsx
@@ -18,6 +18,9 @@ import { useProjects } from '@/hooks/useProjects'
 import {
   AvailableMetric,
   getMetricDefinitions,
+  getMetricScale,
+  getMetricSummable,
+  type MetricDisplayScale,
 } from '@/lib/api/evaluation-types'
 import type {
   LLMLeaderboardEntry,
@@ -48,21 +51,16 @@ const TIME_PERIOD_KEYS: { value: TimePeriod; key: string }[] = [
 // appear in the dropdown. Notenpunkte sits in this list because it's the
 // default ranking metric in prod (German legal grading) — mirrors the human
 // and co-creation leaderboards which also default to grade points.
+//
+// `average` used to live here as a cross-metric mean, but pooling values
+// from incompatible scales (0–1 bleu, 0–18 Notenpunkte, 0–100 korrektur)
+// produced dimensionally meaningless arithmetic means that the formatter
+// then rendered as "1400%". PR #116 removed the synthetic row from the
+// aggregator and the option from this list. Pick a concrete metric instead.
 const CORE_METRICS = [
   'llm_judge_falloesung_grade_points',
-  'average',
   'accuracy',
-  'f1_score',
-  'raw_score',
 ] as const
-
-// Metrics whose values are already on a 0-100 / absolute scale and must NOT
-// be re-multiplied to a percent. Mirrors `NATIVELY_PERCENT_METRICS` +
-// grade-points handling in the Annotator/Co-Creation leaderboard formatter.
-const NATIVELY_PERCENT_METRICS = new Set([
-  'llm_judge_falloesung',
-  'korrektur_falloesung',
-])
 
 function camelize(key: string): string {
   return key.replace(/_([a-z0-9])/g, (_, c: string) => c.toUpperCase())
@@ -106,9 +104,6 @@ export function LLMLeaderboardTable() {
   const { projects, fetchProjects } = useProjects()
   const [loading, setLoading] = useState(true)
   const [leaderboard, setLeaderboard] = useState<LLMLeaderboardEntry[]>([])
-  const [filteredLeaderboard, setFilteredLeaderboard] = useState<
-    LLMLeaderboardEntry[]
-  >([])
   const [availableMetrics, setAvailableMetrics] = useState<string[]>([])
   const [availableEvaluationTypes, setAvailableEvaluationTypes] = useState<
     string[]
@@ -124,10 +119,14 @@ export function LLMLeaderboardTable() {
     string[]
   >([])
   const [searchQuery, setSearchQuery] = useState('')
-  // Lag the search term so the filter doesn't recompute on every keystroke.
-  // Note: search is still applied client-side to the currently-loaded page;
-  // a server-side `?search=` would broaden matches across pages (see Phase 4).
+  // Server-side search: the debounced term is forwarded as `?search=` so
+  // pagination total reflects the filter across all pages (previously the
+  // search ran client-side over the loaded page only and pagination lied).
   const debouncedSearchQuery = useDebouncedValue(searchQuery, 250)
+  // Default off — including catalog models with zero evaluations padded the
+  // leaderboard with 67 n/a rows on prod (16 with data, 83 total). Opt in
+  // via the filter panel when you want to see catalog-vs-evaluated coverage.
+  const [includeAllModels, setIncludeAllModels] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [currentPage, setCurrentPage] = useState(1)
   const [pageSize, setPageSize] = useState(50)
@@ -143,6 +142,7 @@ export function LLMLeaderboardTable() {
       setError(null)
 
       const offset = (currentPage - 1) * pageSize
+      const trimmedSearch = debouncedSearchQuery.trim()
       const response: LLMLeaderboardResponse =
         await apiClient.leaderboards.getLLMLeaderboard({
           period,
@@ -155,12 +155,12 @@ export function LLMLeaderboardTable() {
             selectedEvaluationTypes.length > 0
               ? selectedEvaluationTypes
               : undefined,
-          include_all_models: true,
+          include_all_models: includeAllModels,
           aggregation,
+          search: trimmedSearch ? trimmedSearch : undefined,
         })
 
       setLeaderboard(response.leaderboard)
-      setFilteredLeaderboard(response.leaderboard)
       setAvailableMetrics(response.available_metrics)
       setAvailableEvaluationTypes(response.available_evaluation_types || [])
       setTotalItems(response.total_models)
@@ -179,12 +179,23 @@ export function LLMLeaderboardTable() {
     apiClient.leaderboards,
     currentPage,
     pageSize,
+    debouncedSearchQuery,
+    includeAllModels,
+    t,
   ])
 
   // Reset to page 1 when filters change
   useEffect(() => {
     setCurrentPage(1)
-  }, [period, metric, aggregation, selectedProjectIds, selectedEvaluationTypes])
+  }, [
+    period,
+    metric,
+    aggregation,
+    selectedProjectIds,
+    selectedEvaluationTypes,
+    debouncedSearchQuery,
+    includeAllModels,
+  ])
 
   useEffect(() => {
     loadLeaderboard()
@@ -194,21 +205,6 @@ export function LLMLeaderboardTable() {
     setPageSize(newSize)
     setCurrentPage(1)
   }
-
-  useEffect(() => {
-    if (!debouncedSearchQuery.trim()) {
-      setFilteredLeaderboard(leaderboard)
-      return
-    }
-
-    const query = debouncedSearchQuery.toLowerCase()
-    const filtered = leaderboard.filter(
-      (entry) =>
-        entry.model_name.toLowerCase().includes(query) ||
-        entry.provider.toLowerCase().includes(query)
-    )
-    setFilteredLeaderboard(filtered)
-  }, [debouncedSearchQuery, leaderboard])
 
   const getMedalIcon = (rank: number) => {
     switch (rank) {
@@ -237,27 +233,49 @@ export function LLMLeaderboardTable() {
     }
   }
 
+  // Scale-aware formatter. The metric registry is the single source of
+  // truth: a metric declared `display_scale: '0-1'` displays as a percent
+  // (×100), `'0-100'` displays as-is, `'0-18'` as Notenpunkte, `'raw'`
+  // unitless. Unknown keys default to `'0-1'` for backwards compatibility
+  // with the historical formatter behaviour. This unifies what used to be
+  // a hand-maintained `NATIVELY_PERCENT_METRICS` allowlist plus a
+  // `endsWith('grade_points')` special case.
+  const formatValueForScale = (value: number, scale: MetricDisplayScale, sum: boolean): string => {
+    if (scale === '0-18') {
+      return sum ? `${value.toFixed(1)} NP` : `${value.toFixed(1)} / 18 NP`
+    }
+    if (sum) {
+      // Sums of percentage-shaped metrics aren't dimensionally meaningful
+      // (sum of 100 bleu scores at 0.05 = 5, "5%" reads as 5/100 not 5
+      // bleu-units). Render as a raw number with no unit suffix and let
+      // the user infer.
+      return value.toFixed(2)
+    }
+    if (scale === '0-100') return `${value.toFixed(1)}%`
+    if (scale === '0-1') return `${(value * 100).toFixed(1)}%`
+    return value.toFixed(2) // raw
+  }
+
   const formatScore = (score: number | null) => {
     if (score === null || score === undefined) return 'n/a'
-    // Notenpunkte: same shape as the human/co-creation leaderboards.
-    if (metric.endsWith('grade_points')) {
-      return aggregation === 'sum'
-        ? `${score.toFixed(1)} NP`
-        : `${score.toFixed(1)} / 18 NP`
-    }
-    if (aggregation === 'sum') {
-      return score.toFixed(2)
-    }
-    if (NATIVELY_PERCENT_METRICS.has(metric)) {
-      return score.toFixed(1) + '%'
-    }
-    return (score * 100).toFixed(1) + '%'
+    return formatValueForScale(score, getMetricScale(metric), aggregation === 'sum')
   }
 
   const formatCI = (ci_lower: number | null, ci_upper: number | null) => {
     if (ci_lower === null || ci_upper === null) return null
-    return `${(ci_lower * 100).toFixed(1)}% - ${(ci_upper * 100).toFixed(1)}%`
+    const scale = getMetricScale(metric)
+    // CI on a sum is set to null by the aggregator, so we shouldn't get
+    // here in that case; defensive `sum=false` keeps the format consistent
+    // with the metric's natural scale if a caller does pass it.
+    const fmt = (v: number) => formatValueForScale(v, scale, false)
+    return `${fmt(ci_lower)} – ${fmt(ci_upper)}`
   }
+
+  // Sum aggregation is only meaningful for metrics whose registry entry
+  // declares `summable: true` (Notenpunkte, exact_match, accuracy as
+  // count-correct). For ratios like BLEU summing across N evaluations
+  // produces a dimensionally weird number; we gate the toggle.
+  const currentMetricSummable = getMetricSummable(metric)
 
   const toggleProject = (projectId: string) => {
     setSelectedProjectIds((prev) =>
@@ -267,11 +285,9 @@ export function LLMLeaderboardTable() {
     )
   }
 
-  // Get the score to display based on selected metric
+  // Get the score to display based on selected metric. The synthetic
+  // 'average' metric is gone (PR #116); read the per-metric value directly.
   const getDisplayScore = (entry: LLMLeaderboardEntry): number | null => {
-    if (metric === 'average') {
-      return entry.average_score
-    }
     return entry.metrics[metric] ?? null
   }
 
@@ -292,19 +308,31 @@ export function LLMLeaderboardTable() {
   }, [availableMetrics, t])
 
   // If the selected metric is no longer in the option list (e.g. the user
-  // switched filters and the data dropped it), fall back to 'average' to
-  // avoid an orphaned selection / blank dropdown label.
+  // switched filters and the data dropped it), fall back to the first
+  // available option. The historical fallback was 'average' but that
+  // metric was removed in PR #116; default to Notenpunkte (the leaderboard's
+  // landing metric) if it's still on offer, otherwise the first option.
   useEffect(() => {
+    if (metricOptions.length === 0) return
     if (!metricOptions.some((o) => o.value === metric)) {
-      setMetric('average')
+      const fallback =
+        metricOptions.find((o) => o.value === 'llm_judge_falloesung_grade_points') ??
+        metricOptions[0]
+      setMetric(fallback.value)
     }
   }, [metricOptions, metric])
 
-  // Get the column header label based on selected metric
-  const getScoreColumnLabel = () => {
-    if (metric === 'average') {
-      return t('leaderboards.llm.scoreCi')
+  // If the user has Sum selected and switches to a non-summable metric,
+  // snap back to Average so the displayed numbers don't become nonsense
+  // (the API would reject sum-on-non-summable; this prevents the round-trip).
+  useEffect(() => {
+    if (aggregation === 'sum' && !currentMetricSummable) {
+      setAggregation('average')
     }
+  }, [aggregation, currentMetricSummable])
+
+  // Get the column header label based on selected metric.
+  const getScoreColumnLabel = () => {
     const opt = metricOptions.find((m) => m.value === metric)
     return opt?.label ?? t('leaderboards.llm.score')
   }
@@ -437,7 +465,8 @@ export function LLMLeaderboardTable() {
           aggregation !== 'average' ||
           selectedProjectIds.length > 0 ||
           selectedEvaluationTypes.length > 0 ||
-          searchQuery.trim() !== ''
+          searchQuery.trim() !== '' ||
+          includeAllModels
         }
         onClearFilters={() => {
           setPeriod('overall')
@@ -445,6 +474,7 @@ export function LLMLeaderboardTable() {
           setSelectedProjectIds([])
           setSelectedEvaluationTypes([])
           setSearchQuery('')
+          setIncludeAllModels(false)
         }}
         clearLabel={t('common.filters.clearAll')}
         leftExtras={projectsMenu}
@@ -489,14 +519,32 @@ export function LLMLeaderboardTable() {
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="average">{t('leaderboards.aggregation.average')}</SelectItem>
-              <SelectItem value="sum">{t('leaderboards.aggregation.sum')}</SelectItem>
+              {/* Sum is only meaningful for summable metrics (Notenpunkte,
+                  exact_match, accuracy as count-correct). For ratios like
+                  BLEU/ROUGE summing across N evals is dimensionally weird;
+                  hide the option when the current metric isn't summable. */}
+              {currentMetricSummable && (
+                <SelectItem value="sum">{t('leaderboards.aggregation.sum')}</SelectItem>
+              )}
             </SelectContent>
           </Select>
+        </FilterToolbar.Field>
+
+        <FilterToolbar.Field label={t('leaderboards.llm.includeAllModels')}>
+          <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-zinc-700 dark:text-zinc-300">
+            <input
+              type="checkbox"
+              checked={includeAllModels}
+              onChange={(e) => setIncludeAllModels(e.target.checked)}
+              className="h-4 w-4 rounded border-zinc-300 text-emerald-600 focus:ring-emerald-500"
+            />
+            <span>{t('leaderboards.llm.includeAllModelsLabel')}</span>
+          </label>
         </FilterToolbar.Field>
       </FilterToolbar>
 
       {/* Leaderboard Table */}
-      {filteredLeaderboard.length === 0 ? (
+      {leaderboard.length === 0 ? (
         <div className="py-12 text-center">
           <ChartBarIcon className="mx-auto h-12 w-12 text-zinc-400" />
           <h3 className="mt-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
@@ -526,9 +574,16 @@ export function LLMLeaderboardTable() {
               </tr>
             </thead>
             <tbody className="divide-y divide-zinc-200 bg-white dark:divide-zinc-700 dark:bg-zinc-900">
-              {filteredLeaderboard.map((entry) => {
+              {leaderboard.map((entry) => {
                 const displayScore = getDisplayScore(entry)
                 const hasScore = displayScore !== null && displayScore !== undefined
+                // CI is meaningful for any per-metric mean; aggregator sets
+                // ci_lower/ci_upper=null in sum mode so we just check
+                // presence here instead of gating on metric/aggregation.
+                const ciText =
+                  aggregation === 'sum'
+                    ? null
+                    : formatCI(entry.ci_lower, entry.ci_upper)
                 return (
                   <tr
                     key={entry.model_id}
@@ -579,17 +634,14 @@ export function LLMLeaderboardTable() {
                       ) : (
                         <span className="text-zinc-400 dark:text-zinc-500">n/a</span>
                       )}
-                      {/* Only show CI for average score in average mode */}
-                      {metric === 'average' &&
-                        aggregation !== 'sum' &&
-                        formatCI(entry.ci_lower, entry.ci_upper) && (
-                          <div
-                            className="text-xs text-zinc-500"
-                            title={t('leaderboards.llm.confidenceInterval')}
-                          >
-                            [{formatCI(entry.ci_lower, entry.ci_upper)}]
-                          </div>
-                        )}
+                      {hasScore && ciText && (
+                        <div
+                          className="text-xs text-zinc-500"
+                          title={t('leaderboards.llm.confidenceInterval')}
+                        >
+                          [{ciText}]
+                        </div>
+                      )}
                     </td>
                   </tr>
                 )

--- a/services/frontend/src/components/leaderboards/LLMLeaderboardTable.tsx
+++ b/services/frontend/src/components/leaderboards/LLMLeaderboardTable.tsx
@@ -127,6 +127,12 @@ export function LLMLeaderboardTable() {
   // leaderboard with 67 n/a rows on prod (16 with data, 83 total). Opt in
   // via the filter panel when you want to see catalog-vs-evaluated coverage.
   const [includeAllModels, setIncludeAllModels] = useState(false)
+  // Default on — drops low-sample models from the ranking so the leaderboard
+  // doesn't surface noisy single-digit-gen models alongside well-evaluated
+  // ones. Threshold values match the API defaults; opting out sends 0.
+  const [minSamplesEnabled, setMinSamplesEnabled] = useState(true)
+  const MIN_GENERATIONS_THRESHOLD = 50
+  const MIN_SAMPLES_THRESHOLD = 50
   const [error, setError] = useState<string | null>(null)
   const [currentPage, setCurrentPage] = useState(1)
   const [pageSize, setPageSize] = useState(50)
@@ -158,6 +164,8 @@ export function LLMLeaderboardTable() {
           include_all_models: includeAllModels,
           aggregation,
           search: trimmedSearch ? trimmedSearch : undefined,
+          min_generation_count: minSamplesEnabled ? MIN_GENERATIONS_THRESHOLD : 0,
+          min_samples_evaluated: minSamplesEnabled ? MIN_SAMPLES_THRESHOLD : 0,
         })
 
       setLeaderboard(response.leaderboard)
@@ -181,6 +189,7 @@ export function LLMLeaderboardTable() {
     pageSize,
     debouncedSearchQuery,
     includeAllModels,
+    minSamplesEnabled,
     t,
   ])
 
@@ -195,6 +204,7 @@ export function LLMLeaderboardTable() {
     selectedEvaluationTypes,
     debouncedSearchQuery,
     includeAllModels,
+    minSamplesEnabled,
   ])
 
   useEffect(() => {
@@ -466,7 +476,8 @@ export function LLMLeaderboardTable() {
           selectedProjectIds.length > 0 ||
           selectedEvaluationTypes.length > 0 ||
           searchQuery.trim() !== '' ||
-          includeAllModels
+          includeAllModels ||
+          !minSamplesEnabled
         }
         onClearFilters={() => {
           setPeriod('overall')
@@ -475,6 +486,7 @@ export function LLMLeaderboardTable() {
           setSelectedEvaluationTypes([])
           setSearchQuery('')
           setIncludeAllModels(false)
+          setMinSamplesEnabled(true)
         }}
         clearLabel={t('common.filters.clearAll')}
         leftExtras={projectsMenu}
@@ -539,6 +551,23 @@ export function LLMLeaderboardTable() {
               className="h-4 w-4 rounded border-zinc-300 text-emerald-600 focus:ring-emerald-500"
             />
             <span>{t('leaderboards.llm.includeAllModelsLabel')}</span>
+          </label>
+        </FilterToolbar.Field>
+
+        <FilterToolbar.Field label={t('leaderboards.llm.minSamples')}>
+          <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-zinc-700 dark:text-zinc-300">
+            <input
+              type="checkbox"
+              checked={minSamplesEnabled}
+              onChange={(e) => setMinSamplesEnabled(e.target.checked)}
+              className="h-4 w-4 rounded border-zinc-300 text-emerald-600 focus:ring-emerald-500"
+            />
+            <span>
+              {t('leaderboards.llm.minSamplesLabel', {
+                gens: MIN_GENERATIONS_THRESHOLD,
+                samples: MIN_SAMPLES_THRESHOLD,
+              })}
+            </span>
           </label>
         </FilterToolbar.Field>
       </FilterToolbar>

--- a/services/frontend/src/components/leaderboards/__tests__/LLMLeaderboardTable.test.tsx
+++ b/services/frontend/src/components/leaderboards/__tests__/LLMLeaderboardTable.test.tsx
@@ -117,8 +117,14 @@ describe('LLMLeaderboardTable', () => {
     // leaderboard with 67 zero-row catalog entries on prod (83 total, 16
     // with data, 2 pages of "n/a" noise). Opt-in via the filter panel
     // checkbox restores the catalog-coverage view.
+    //
+    // The min-samples toggle defaults ON so the leaderboard drops models
+    // with <50 generations or <50 evaluations from the ranking — opt out
+    // sends 0 for both.
     const firstCall = mockGetLLMLeaderboard.mock.calls[0][0]
     expect(firstCall.period).toBe('overall')
     expect(firstCall.include_all_models).toBe(false)
+    expect(firstCall.min_generation_count).toBe(50)
+    expect(firstCall.min_samples_evaluated).toBe(50)
   })
 })

--- a/services/frontend/src/components/leaderboards/__tests__/LLMLeaderboardTable.test.tsx
+++ b/services/frontend/src/components/leaderboards/__tests__/LLMLeaderboardTable.test.tsx
@@ -112,9 +112,13 @@ describe('LLMLeaderboardTable', () => {
     await waitFor(() => {
       expect(mockGetLLMLeaderboard).toHaveBeenCalled()
     })
-    // First call should include default params
+    // First call should include default params. include_all_models flipped
+    // from true to false in PR #116 — the old default padded the
+    // leaderboard with 67 zero-row catalog entries on prod (83 total, 16
+    // with data, 2 pages of "n/a" noise). Opt-in via the filter panel
+    // checkbox restores the catalog-coverage view.
     const firstCall = mockGetLLMLeaderboard.mock.calls[0][0]
     expect(firstCall.period).toBe('overall')
-    expect(firstCall.include_all_models).toBe(true)
+    expect(firstCall.include_all_models).toBe(false)
   })
 })

--- a/services/frontend/src/lib/api/evaluation-types.ts
+++ b/services/frontend/src/lib/api/evaluation-types.ts
@@ -257,6 +257,19 @@ export interface MetricCategory {
 }
 
 /**
+ * Per-metric display scale, used by leaderboard formatters so a 0–18
+ * Notenpunkte score doesn't render as "1400%". A registry-driven scale
+ * also lets new metrics opt into a sensible display without touching the
+ * leaderboard component.
+ *
+ * - `'0-1'`: raw fraction, displayed as a percentage (×100)
+ * - `'0-100'`: already on a percent scale, displayed as-is
+ * - `'0-18'`: German Notenpunkte, displayed as "X / 18 NP"
+ * - `'raw'`: unitless, displayed with `toFixed(2)` (no % suffix)
+ */
+export type MetricDisplayScale = '0-1' | '0-100' | '0-18' | 'raw'
+
+/**
  * Available metric with metadata
  */
 export interface AvailableMetric {
@@ -272,6 +285,16 @@ export interface AvailableMetric {
    * (e.g. Falllösung's Notenpunkte score_scale and 4096 max_tokens) without
    * the platform wizard hardcoding metric names. */
   default_parameters?: Record<string, any>
+  /** How this metric should be rendered in leaderboards / score tables.
+   * Defaults to `'0-1'` (the historical assumption) when omitted. */
+  display_scale?: MetricDisplayScale
+  /** Whether `sum(values)` across many evaluations is semantically
+   * meaningful for this metric. False for ratios (bleu, rouge, accuracy);
+   * true for additive scores (Notenpunkte, # correct). The leaderboard's
+   * Sum-aggregation toggle disables itself when the selected metric isn't
+   * summable so users can't request a meaningless rollup. Defaults to
+   * `false` when omitted — the conservative choice. */
+  summable?: boolean
 }
 
 /**
@@ -661,6 +684,8 @@ export const METRIC_DEFINITIONS: Record<string, AvailableMetric> = {
     category: 'Lexical Metrics',
     status: 'stable',
     supports_parameters: true,
+    display_scale: '0-1',
+    summable: false,
     parameter_schema: {
       max_order: {
         type: 'number',
@@ -684,6 +709,8 @@ export const METRIC_DEFINITIONS: Record<string, AvailableMetric> = {
     category: 'Lexical Metrics',
     status: 'stable',
     supports_parameters: true,
+    display_scale: '0-1',
+    summable: false,
     parameter_schema: {
       variant: {
         type: 'select',
@@ -705,6 +732,8 @@ export const METRIC_DEFINITIONS: Record<string, AvailableMetric> = {
     category: 'Lexical Metrics',
     status: 'stable',
     supports_parameters: true,
+    display_scale: '0-1',
+    summable: false,
     parameter_schema: {
       alpha: {
         type: 'number',
@@ -739,6 +768,8 @@ export const METRIC_DEFINITIONS: Record<string, AvailableMetric> = {
     category: 'Lexical Metrics',
     status: 'stable',
     supports_parameters: true,
+    display_scale: '0-1',
+    summable: false,
     parameter_schema: {
       char_order: {
         type: 'number',
@@ -771,6 +802,8 @@ export const METRIC_DEFINITIONS: Record<string, AvailableMetric> = {
     category: 'Lexical Metrics',
     status: 'stable',
     supports_parameters: false,
+    display_scale: '0-1',
+    summable: true, // sum = # of exact matches across N evals
   },
 
   // Semantic Metrics
@@ -781,6 +814,8 @@ export const METRIC_DEFINITIONS: Record<string, AvailableMetric> = {
     category: 'Semantic Metrics',
     status: 'stable',
     supports_parameters: false,
+    display_scale: '0-1',
+    summable: false,
   },
   moverscore: {
     name: 'moverscore',
@@ -789,6 +824,8 @@ export const METRIC_DEFINITIONS: Record<string, AvailableMetric> = {
     category: 'Semantic Metrics',
     status: 'stable',
     supports_parameters: false,
+    display_scale: '0-1',
+    summable: false,
   },
   semantic_similarity: {
     name: 'semantic_similarity',
@@ -797,6 +834,8 @@ export const METRIC_DEFINITIONS: Record<string, AvailableMetric> = {
     category: 'Semantic Metrics',
     status: 'stable',
     supports_parameters: false,
+    display_scale: '0-1',
+    summable: false,
   },
 
   // Factuality Metrics
@@ -814,6 +853,8 @@ export const METRIC_DEFINITIONS: Record<string, AvailableMetric> = {
         default: 'summac',
       },
     },
+    display_scale: '0-1',
+    summable: false,
   },
   qags: {
     name: 'qags',
@@ -822,6 +863,8 @@ export const METRIC_DEFINITIONS: Record<string, AvailableMetric> = {
     category: 'Factuality Metrics',
     status: 'stable',
     supports_parameters: false,
+    display_scale: '0-1',
+    summable: false,
   },
   coherence: {
     name: 'coherence',
@@ -830,6 +873,8 @@ export const METRIC_DEFINITIONS: Record<string, AvailableMetric> = {
     category: 'Factuality Metrics',
     status: 'stable',
     supports_parameters: false,
+    display_scale: '0-1',
+    summable: false,
   },
 
   // Classification Metrics
@@ -840,6 +885,8 @@ export const METRIC_DEFINITIONS: Record<string, AvailableMetric> = {
     category: 'Classification Metrics',
     status: 'stable',
     supports_parameters: false,
+    display_scale: '0-1',
+    summable: true, // sum = # correct
   },
   precision: {
     name: 'precision',
@@ -848,6 +895,8 @@ export const METRIC_DEFINITIONS: Record<string, AvailableMetric> = {
     category: 'Classification Metrics',
     status: 'stable',
     supports_parameters: false,
+    display_scale: '0-1',
+    summable: false,
   },
   recall: {
     name: 'recall',
@@ -856,6 +905,8 @@ export const METRIC_DEFINITIONS: Record<string, AvailableMetric> = {
     category: 'Classification Metrics',
     status: 'stable',
     supports_parameters: false,
+    display_scale: '0-1',
+    summable: false,
   },
   f1: {
     name: 'f1',
@@ -864,6 +915,8 @@ export const METRIC_DEFINITIONS: Record<string, AvailableMetric> = {
     category: 'Classification Metrics',
     status: 'stable',
     supports_parameters: false,
+    display_scale: '0-1',
+    summable: false,
   },
 
   // LLM-as-Judge - Two consolidated options
@@ -874,6 +927,8 @@ export const METRIC_DEFINITIONS: Record<string, AvailableMetric> = {
     category: 'LLM-as-Judge',
     status: 'stable',
     supports_parameters: true,
+    display_scale: '0-1',
+    summable: false,
   },
   llm_judge_custom: {
     name: 'llm_judge_custom',
@@ -882,6 +937,8 @@ export const METRIC_DEFINITIONS: Record<string, AvailableMetric> = {
     category: 'LLM-as-Judge',
     status: 'stable',
     supports_parameters: true,
+    display_scale: '0-1',
+    summable: false,
   },
 }
 
@@ -951,6 +1008,28 @@ export function registerMetricGroup(group: MetricCategory) {
  */
 export function getMetricDefinitions(): Record<string, AvailableMetric> {
   return { ...METRIC_DEFINITIONS, ..._extendedMetrics }
+}
+
+/**
+ * Display scale for a metric key. Defaults to `'0-1'` when the metric is
+ * unregistered (the historical assumption baked into older formatter code).
+ * Used by the leaderboard's score + CI formatters so a metric on a 0–18
+ * Notenpunkte scale doesn't render as "1400%".
+ */
+export function getMetricScale(key: string): MetricDisplayScale {
+  const def = getMetricDefinitions()[key]
+  return def?.display_scale ?? '0-1'
+}
+
+/**
+ * Whether `sum(values)` is meaningful for this metric. Defaults to false —
+ * the conservative choice for unknown keys, mirroring `getMetricScale`.
+ * Used by the leaderboard's Sum-aggregation toggle to disable itself when
+ * the selected metric isn't summable.
+ */
+export function getMetricSummable(key: string): boolean {
+  const def = getMetricDefinitions()[key]
+  return def?.summable ?? false
 }
 
 /**

--- a/services/frontend/src/lib/api/leaderboards.ts
+++ b/services/frontend/src/lib/api/leaderboards.ts
@@ -244,6 +244,7 @@ export class LeaderboardsClient extends BaseApiClient {
     aggregation?: 'average' | 'sum'
     evaluation_types?: string[]
     include_all_models?: boolean
+    search?: string
     limit?: number
     offset?: number
   }): Promise<LLMLeaderboardResponse> {
@@ -273,6 +274,10 @@ export class LeaderboardsClient extends BaseApiClient {
 
     if (params?.include_all_models !== undefined) {
       queryParams.append('include_all_models', params.include_all_models.toString())
+    }
+
+    if (params?.search) {
+      queryParams.append('search', params.search)
     }
 
     if (params?.limit) {

--- a/services/frontend/src/lib/api/leaderboards.ts
+++ b/services/frontend/src/lib/api/leaderboards.ts
@@ -245,6 +245,8 @@ export class LeaderboardsClient extends BaseApiClient {
     evaluation_types?: string[]
     include_all_models?: boolean
     search?: string
+    min_generation_count?: number
+    min_samples_evaluated?: number
     limit?: number
     offset?: number
   }): Promise<LLMLeaderboardResponse> {
@@ -278,6 +280,14 @@ export class LeaderboardsClient extends BaseApiClient {
 
     if (params?.search) {
       queryParams.append('search', params.search)
+    }
+
+    if (params?.min_generation_count !== undefined) {
+      queryParams.append('min_generation_count', params.min_generation_count.toString())
+    }
+
+    if (params?.min_samples_evaluated !== undefined) {
+      queryParams.append('min_samples_evaluated', params.min_samples_evaluated.toString())
     }
 
     if (params?.limit) {

--- a/services/frontend/src/locales/de/common.json
+++ b/services/frontend/src/locales/de/common.json
@@ -1916,6 +1916,8 @@
       "scoreCi": "Punktzahl (95% KI)",
       "score": "Punktzahl",
       "selectMetric": "Metrik auswählen",
+      "includeAllModels": "Katalogabdeckung",
+      "includeAllModelsLabel": "Alle Modelle anzeigen (auch ohne Daten)",
       "projectsCount": "{count} Projekte",
       "evalTypesCount": "{count} Evaluierungstypen",
       "allEvalTypes": "Alle Evaluierungstypen",

--- a/services/frontend/src/locales/de/common.json
+++ b/services/frontend/src/locales/de/common.json
@@ -1918,6 +1918,8 @@
       "selectMetric": "Metrik auswählen",
       "includeAllModels": "Katalogabdeckung",
       "includeAllModelsLabel": "Alle Modelle anzeigen (auch ohne Daten)",
+      "minSamples": "Statistische Relevanz",
+      "minSamplesLabel": "Mindestens {gens} Generierungen und {samples} Evaluierungen",
       "projectsCount": "{count} Projekte",
       "evalTypesCount": "{count} Evaluierungstypen",
       "allEvalTypes": "Alle Evaluierungstypen",

--- a/services/frontend/src/locales/en/common.json
+++ b/services/frontend/src/locales/en/common.json
@@ -1936,6 +1936,8 @@
       "selectMetric": "Select Metric",
       "includeAllModels": "Catalog coverage",
       "includeAllModelsLabel": "Show all models (incl. without data)",
+      "minSamples": "Statistical relevance",
+      "minSamplesLabel": "Require at least {gens} generations and {samples} evaluations",
       "projectsCount": "{count} Projects",
       "evalTypesCount": "{count} Eval Types",
       "allEvalTypes": "All Eval Types",

--- a/services/frontend/src/locales/en/common.json
+++ b/services/frontend/src/locales/en/common.json
@@ -1934,6 +1934,8 @@
       "scoreCi": "Score (95% CI)",
       "score": "Score",
       "selectMetric": "Select Metric",
+      "includeAllModels": "Catalog coverage",
+      "includeAllModelsLabel": "Show all models (incl. without data)",
       "projectsCount": "{count} Projects",
       "evalTypesCount": "{count} Eval Types",
       "allEvalTypes": "All Eval Types",

--- a/services/shared/aggregate_summaries.py
+++ b/services/shared/aggregate_summaries.py
@@ -335,33 +335,36 @@ def _aggregate_leaderboard_rows(
     scope: str,
     period: str,
     computed_at: datetime,
+    *,
+    aggregation: str = "average",
+    evaluation_types: Optional[List[str]] = None,
 ) -> List[Dict[str, Any]]:
     """Build the per-(model, metric) rows for one (scope, period).
 
     Streams (model_id, metric_key, metric_val_json) triples from
-    task_evaluations and buckets them in Python, then computes mean + CI
-    per bucket. 60k input rows → ~3 MB Python memory; runs once per cycle
-    in the worker.
+    task_evaluations and buckets them in Python, then computes the
+    requested aggregate per bucket. 60k input rows → ~3 MB Python memory;
+    runs once per cycle in the worker.
+
+    Args:
+      aggregation: `'average'` (mean + 95% CI) or `'sum'` (total, no CI).
+        Sum mode is only honoured when the caller has gated the metric
+        to one that's summable (handled at the API + UI layer); the
+        aggregator itself is dumb here.
+      evaluation_types: when set, only metric keys present in this list are
+        emitted. Filters per-row in SQL so a TaskEvaluation that carries
+        `{bleu, rouge}` only contributes `bleu` when the caller asks for
+        `['bleu']`. Replaces the older run-level
+        `EvaluationRun.evaluation_type_ids.contains([...])` filter that
+        misleadingly pooled every metric of a matching run.
     """
     if not run_ids:
         return []
 
-    # Per-(model, metric) raw values for mean + CI.
-    metrics_jsonb = cast(TaskEvaluation.metrics, JSONB)
-    pairs_stmt = (
-        select(
-            Generation.model_id.label("model_id"),
-            func.jsonb_each(metrics_jsonb).label("kv"),
-        )
-        .join(Generation, TaskEvaluation.generation_id == Generation.id)
-        .join(EvaluationRun, TaskEvaluation.evaluation_id == EvaluationRun.id)
-        .where(
-            TaskEvaluation.evaluation_id.in_(run_ids),
-            TaskEvaluation.generation_id.isnot(None),
-            TaskEvaluation.metrics.isnot(None),
-            func.jsonb_typeof(metrics_jsonb) == "object",
-        )
-    )
+    # When evaluation_types is empty/None, the `... = ANY(:eval_types) OR
+    # :eval_types IS NULL` shape collapses to a no-op via the IS NULL branch.
+    # Postgres typed cast on the bind param so the comparison stays type-safe.
+    eval_types_bind = evaluation_types or None
 
     # jsonb_each returns a record type; using text() for clarity.
     #
@@ -386,6 +389,7 @@ def _aggregate_leaderboard_rows(
           AND te.generation_id IS NOT NULL
           AND te.metrics IS NOT NULL
           AND jsonb_typeof(te.metrics::jsonb) = 'object'
+          AND (:eval_types::text[] IS NULL OR kv.key = ANY(:eval_types))
 
         UNION ALL
 
@@ -403,8 +407,9 @@ def _aggregate_leaderboard_rows(
           AND te.metrics::jsonb ? 'llm_judge_falloesung'
           AND te.metrics::jsonb->'llm_judge_falloesung'->'details' ? 'grade_points'
           AND jsonb_typeof(te.metrics::jsonb->'llm_judge_falloesung'->'details'->'grade_points') = 'number'
+          AND (:eval_types::text[] IS NULL OR 'llm_judge_falloesung_grade_points' = ANY(:eval_types))
         """
-    ).bindparams(run_ids=run_ids)
+    ).bindparams(run_ids=run_ids, eval_types=eval_types_bind)
 
     # (model_id, metric_key) -> list[float]
     buckets: Dict[Tuple[str, str], List[float]] = defaultdict(list)
@@ -446,41 +451,29 @@ def _aggregate_leaderboard_rows(
     }
 
     rows: List[Dict[str, Any]] = []
-    # Per-metric rows.
+    # Per-metric rows. The previously-emitted cross-metric 'average' row was
+    # dimensionally meaningless (it pooled values from 0–1, 0–18, and 0–100
+    # metrics into one arithmetic mean, displayed as percentages — see
+    # PR #116 for the rationale) and has been removed. The frontend metric
+    # picker no longer offers 'average' as a sort option.
     for (model_id, metric_key), values in buckets.items():
         meta = per_model_meta.get(model_id, {})
-        ci_lower, ci_upper = _confidence_interval(values)
+        if aggregation == "sum":
+            # Sum mode: total of per-row values across the bucket. CI doesn't
+            # apply to a count/total, so set both bounds to None and let the
+            # frontend hide the CI for this row.
+            score = round(sum(values), 4) if values else None
+            ci_lower, ci_upper = None, None
+        else:
+            score = round(sum(values) / len(values), 4) if values else None
+            ci_lower, ci_upper = _confidence_interval(values)
         rows.append(
             {
                 "model_id": model_id,
                 "project_scope_key": scope,
                 "period": period,
                 "metric": metric_key,
-                "score": round(sum(values) / len(values), 4) if values else None,
-                "ci_lower": ci_lower,
-                "ci_upper": ci_upper,
-                "samples_evaluated": meta.get("samples_evaluated", 0),
-                "evaluation_count": meta.get("evaluation_count", 0),
-                "generation_count": meta.get("generation_count", 0),
-                "last_evaluated_at": meta.get("last_evaluated_at"),
-                "computed_at": computed_at,
-            }
-        )
-
-    # Per-model 'average' row — the cross-metric mean used for default ranking.
-    by_model: Dict[str, List[float]] = defaultdict(list)
-    for (model_id, _metric_key), values in buckets.items():
-        by_model[model_id].extend(values)
-    for model_id, values in by_model.items():
-        meta = per_model_meta.get(model_id, {})
-        ci_lower, ci_upper = _confidence_interval(values)
-        rows.append(
-            {
-                "model_id": model_id,
-                "project_scope_key": scope,
-                "period": period,
-                "metric": "average",
-                "score": round(sum(values) / len(values), 4) if values else None,
+                "score": score,
                 "ci_lower": ci_lower,
                 "ci_upper": ci_upper,
                 "samples_evaluated": meta.get("samples_evaluated", 0),
@@ -743,6 +736,8 @@ def live_aggregate_leaderboard(
     project_ids: Optional[List[str]],
     period: str,
     evaluation_types: Optional[List[str]] = None,
+    *,
+    aggregation: str = "average",
 ) -> List[Dict[str, Any]]:
     """Live (uncached) aggregation for filter combos with no precomputed scope.
 
@@ -754,6 +749,13 @@ def live_aggregate_leaderboard(
 
     `project_ids=None` means "all projects" (no visibility filter applied
     here; callers must apply visibility themselves before calling).
+
+    The `evaluation_types` filter is applied at two layers: first
+    narrows `run_ids` to runs that declared at least one of the requested
+    types (cheap optimisation, OR semantics), then `_aggregate_leaderboard_rows`
+    drops per-row metrics whose key isn't in the list (correctness — a run
+    declaring `[bleu]` may still produce `{bleu, rouge_l, ...}` per
+    TaskEvaluation; we now emit only `bleu`).
     """
     stmt = select(EvaluationRun.id).where(EvaluationRun.status == "completed")
     if project_ids:
@@ -780,7 +782,15 @@ def live_aggregate_leaderboard(
     if not run_ids:
         return []
     now = datetime.now(timezone.utc)
-    return _aggregate_leaderboard_rows(db, run_ids, scope="live", period=period, computed_at=now)
+    return _aggregate_leaderboard_rows(
+        db,
+        run_ids,
+        scope="live",
+        period=period,
+        computed_at=now,
+        aggregation=aggregation,
+        evaluation_types=evaluation_types,
+    )
 
 
 def scope_key_for_project_ids(project_ids: Optional[List[str]]) -> Optional[str]:


### PR DESCRIPTION
## Summary

Manual UI review of `/leaderboards` (LLMs tab) surfaced **8 bugs** ranging from silently-broken filters to scores rendering as "1400%". This PR fixes each, then adds **2 product tweaks** (TUM-only trust scope + default min-samples threshold).

## The 8 bugs (with real prod numbers)

| # | Picker / state | What SebaN saw | Fix |
|---|---|---|---|
| 1 | metric=korrektur_falloesung CI [66, 89] | "6633% - 8892%" | scale-aware formatCI on registry display_scale |
| 1b | metric=grade_points CI [13.85, 14.32] | "1385% - 1432%" | same scale-aware formatCI |
| 2 | metric=average (gpt-5.4) | "143%"; gemini-3-flash "542%" | dropped synthetic 'average' row + removed from picker |
| 3 | aggregation=sum | byte-identical to average | real sum branch in aggregator; gated by registry summable flag |
| 4 | Suche text input | pagination total stuck at 50 | `?search=` server-side; honest total |
| 5 | Alle Evaluierungstypen=bleu | runs declaring bleu still contributed rouge/exact_match | per-row `metrics ?| array[...]` filter |
| 6 | default page load | 67 catalog rows of "0 / n/a" padding | include_all_models default false + opt-in checkbox |
| 7 | metric=f1_score | empty table, no message | pruned from CORE_METRICS |
| 8 | ?project_ids=fake-id | rendered unfiltered | `_filter_accessible_project_ids(strict=True)` -> 400 |

## Product tweaks layered on (last commit)

### Temporary TUM-only trust scope

The LLM leaderboard now restricts to projects assigned to TUM (org id `a22cbcfa-...`). Other orgs (TITAN, LTV, Benchathon, Göttingen) are excluded from rankings until the trust scope expands. Constant + helper at the top of `leaderboards.py`; empty intersection raises 400 ("not in trust scope") rather than silently falling back. Easy to remove when the gate lifts.

### Default min-samples threshold

`min_generation_count` (default 50) and `min_samples_evaluated` (default 50) drop models with fewer than N gens/samples from the ranking. UI toggle in the filter panel defaults ON; opting out sends 0 for both. Prevents the leaderboard from comparing a 1000-gen model against a 5-gen single-shot.

## Registry signature

`AvailableMetric` gains two optional fields:

```ts
display_scale?: '0-1' | '0-100' | '0-18' | 'raw'  // drives formatScore + formatCI
summable?: boolean                                 // gates Sum aggregation chip
```

Both default to safe values when omitted. Extended will re-register `llm_judge_falloesung` + `_grade_points` + `korrektur_falloesung` with explicit scales in benger-extended PR #34.

## Files

| File | Change |
|---|---|
| services/shared/aggregate_summaries.py | aggregation param + sum branch + per-row evaluation_types filter; dropped synthetic 'average' rows |
| services/api/routers/leaderboards.py | `?search=`, `?min_generation_count`, `?min_samples_evaluated` params; `_filter_accessible_project_ids(strict=True)`; TUM-only trust scope helper |
| services/frontend/src/components/leaderboards/LLMLeaderboardTable.tsx | scale-aware formatters; Sum gated on `summable`; include_all_models + min-samples toggles; server-side search; 'average' option removed |
| services/frontend/src/lib/api/evaluation-types.ts | display_scale + summable + helpers + updated core registrations |
| services/frontend/src/lib/api/leaderboards.ts | search + min-threshold params on getLLMLeaderboard |
| services/frontend/src/locales/{en,de}/common.json | new toggle labels |
| services/api/tests/unit/test_aggregate_summaries.py | sum, per-row eval_types, no 'average' |
| services/api/tests/unit/test_leaderboards_visibility.py | strict project_ids, TUM trust gate, min-samples params wired |
| services/frontend/src/components/leaderboards/__tests__/LLMLeaderboardTable.test.tsx | default API call asserts new params |

## Test plan

- [x] Unit tests for sum, per-row eval_types, no 'average', strict project_ids, TUM gate, min-samples params
- [x] Jest test for default API call (include_all_models=false, min_gen=50, min_samples=50)
- [x] CI green
- [ ] Post-merge: re-verify with Puppeteer; `DELETE FROM llm_leaderboard_scores WHERE metric='average'`

## Risk + rollback

All backend changes are additive (sum defaults to mean; thresholds default 0 means no filter at API level; TUM filter is a single helper to delete). Frontend formatter changes are display-only. Strict project_ids rejection is the one user-visible breaking change (silent fallback was the bug).