### PR TITLE
fix(aggregator): use CAST() for eval_types bind param

### DIFF
--- a/services/shared/aggregate_summaries.py
+++ b/services/shared/aggregate_summaries.py
@@ -389,7 +389,7 @@ def _aggregate_leaderboard_rows(
           AND te.generation_id IS NOT NULL
           AND te.metrics IS NOT NULL
           AND jsonb_typeof(te.metrics::jsonb) = 'object'
-          AND (:eval_types::text[] IS NULL OR kv.key = ANY(:eval_types))
+          AND (CAST(:eval_types AS text[]) IS NULL OR kv.key = ANY(:eval_types))
 
         UNION ALL
 
@@ -407,7 +407,7 @@ def _aggregate_leaderboard_rows(
           AND te.metrics::jsonb ? 'llm_judge_falloesung'
           AND te.metrics::jsonb->'llm_judge_falloesung'->'details' ? 'grade_points'
           AND jsonb_typeof(te.metrics::jsonb->'llm_judge_falloesung'->'details'->'grade_points') = 'number'
-          AND (:eval_types::text[] IS NULL OR 'llm_judge_falloesung_grade_points' = ANY(:eval_types))
+          AND (CAST(:eval_types AS text[]) IS NULL OR 'llm_judge_falloesung_grade_points' = ANY(:eval_types))
         """
     ).bindparams(run_ids=run_ids, eval_types=eval_types_bind)
 


### PR DESCRIPTION
## Summary

Hotfix for PR #116. The new \`(:eval_types::text[] IS NULL OR ...)\` cast in the leaderboard aggregator SQL confused SQLAlchemy's text() bindparam parser — it left \`:eval_types::text[]\` un-substituted and every \`/api/leaderboards/llm-models\` request 500'd with \"syntax error at or near :\". The frontend showed \"Failed to load LLM leaderboard\" after the deploy landed.

Switching the two call sites to \`CAST(:eval_types AS text[])\` parses cleanly and is semantically identical. Verified in-pod against prod DB with both \`eval_types=None\` and \`eval_types=['accuracy']\`.

## Why CI didn't catch it

The platform PR CI runs Jest + lint only — the API pytest suite (which has tests for both the per-row eval_types filter and the None branch) runs in Docker via \`make test-api\` and isn't wired into PR CI. Those tests will catch this on the next API CI run.

## Test plan

- [x] In-pod SQL syntax verification on prod DB
- [ ] CI green
- [ ] Post-merge: re-Puppeteer the leaderboard