### PR TITLE
leaderboard: TanStack Query + threshold/padding mutex + filter-bar alignment

### DIFF
--- a/services/api/routers/leaderboards.py
+++ b/services/api/routers/leaderboards.py
@@ -588,8 +588,14 @@ async def get_llm_leaderboard(
         )
 
     # Include zero-row entries for active models that aren't in the page.
-    # Honours `search` so the catalog-padding doesn't undo the filter.
-    if include_all_models:
+    # Honours `search` so the catalog-padding doesn't undo the filter, and
+    # honours the min-samples threshold so a user opting into "catalog
+    # coverage" while keeping the threshold ON doesn't suddenly see 71
+    # n/a rows (padding entries have 0 generations and 0 samples — they
+    # can only pass when both thresholds are 0). The frontend disables
+    # this toggle while the threshold is ON; this guard is defence in
+    # depth for raw API callers.
+    if include_all_models and min_generation_count <= 0 and min_samples_evaluated <= 0:
         seen = {e.model_id for e in leaderboard}
         catalog_q = db.query(LLMModel).filter(LLMModel.is_active == True)  # noqa: E712
         for m in catalog_q.all():

--- a/services/frontend/src/components/leaderboards/LLMLeaderboardTable.tsx
+++ b/services/frontend/src/components/leaderboards/LLMLeaderboardTable.tsx
@@ -22,10 +22,7 @@ import {
   getMetricSummable,
   type MetricDisplayScale,
 } from '@/lib/api/evaluation-types'
-import type {
-  LLMLeaderboardEntry,
-  LLMLeaderboardResponse,
-} from '@/lib/api/leaderboards'
+import type { LLMLeaderboardEntry } from '@/lib/api/leaderboards'
 import { Menu } from '@headlessui/react'
 import { CheckIcon, ChevronDownIcon } from '@heroicons/react/20/solid'
 import {
@@ -33,7 +30,8 @@ import {
   FunnelIcon,
   MagnifyingGlassIcon,
 } from '@heroicons/react/24/outline'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { useEffect, useMemo, useState } from 'react'
 
 type TimePeriod = 'overall' | 'monthly' | 'weekly'
 
@@ -102,12 +100,6 @@ export function LLMLeaderboardTable() {
   const { apiClient } = useAuth()
   const { t } = useI18n()
   const { projects, fetchProjects } = useProjects()
-  const [loading, setLoading] = useState(true)
-  const [leaderboard, setLeaderboard] = useState<LLMLeaderboardEntry[]>([])
-  const [availableMetrics, setAvailableMetrics] = useState<string[]>([])
-  const [availableEvaluationTypes, setAvailableEvaluationTypes] = useState<
-    string[]
-  >([])
   const [period, setPeriod] = useState<TimePeriod>('overall')
   // Default to Notenpunkte (Falllösung) so the LLM leaderboard opens on the
   // same scoring axis as the human + co-creation leaderboards. Models
@@ -126,6 +118,8 @@ export function LLMLeaderboardTable() {
   // Default off — including catalog models with zero evaluations padded the
   // leaderboard with 67 n/a rows on prod (16 with data, 83 total). Opt in
   // via the filter panel when you want to see catalog-vs-evaluated coverage.
+  // Mutually exclusive with the min-samples threshold below: padding rows
+  // have 0 gens / 0 samples so they never pass any positive threshold.
   const [includeAllModels, setIncludeAllModels] = useState(false)
   // Default on — drops low-sample models from the ranking so the leaderboard
   // doesn't surface noisy single-digit-gen models alongside well-evaluated
@@ -133,67 +127,80 @@ export function LLMLeaderboardTable() {
   const [minSamplesEnabled, setMinSamplesEnabled] = useState(true)
   const MIN_GENERATIONS_THRESHOLD = 50
   const MIN_SAMPLES_THRESHOLD = 50
-  const [error, setError] = useState<string | null>(null)
   const [currentPage, setCurrentPage] = useState(1)
   const [pageSize, setPageSize] = useState(50)
-  const [totalItems, setTotalItems] = useState(0)
 
   useEffect(() => {
     fetchProjects()
   }, [fetchProjects])
 
-  const loadLeaderboard = useCallback(async () => {
-    try {
-      setLoading(true)
-      setError(null)
-
+  // Server state via TanStack Query: caches per (filter, page) tuple,
+  // dedupes overlapping mounts, keeps the previous page visible during
+  // refetches so filter tweaks feel snappy instead of blanking the table.
+  // Stale time of 30s matches the typical gap between recompute_aggregates
+  // beats (event-driven + hourly cron); shorter and we'd burn requests on
+  // every navigation, longer and a freshly-finalised eval wouldn't show up
+  // when the user opens the leaderboard right after triggering it.
+  const trimmedSearch = debouncedSearchQuery.trim()
+  const leaderboardQuery = useQuery({
+    queryKey: [
+      'leaderboards',
+      'llm',
+      {
+        period,
+        metric,
+        aggregation,
+        currentPage,
+        pageSize,
+        selectedProjectIds,
+        selectedEvaluationTypes,
+        search: trimmedSearch,
+        includeAllModels,
+        minSamplesEnabled,
+      },
+    ],
+    queryFn: () => {
       const offset = (currentPage - 1) * pageSize
-      const trimmedSearch = debouncedSearchQuery.trim()
-      const response: LLMLeaderboardResponse =
-        await apiClient.leaderboards.getLLMLeaderboard({
-          period,
-          metric,
-          limit: pageSize,
-          offset,
-          project_ids:
-            selectedProjectIds.length > 0 ? selectedProjectIds : undefined,
-          evaluation_types:
-            selectedEvaluationTypes.length > 0
-              ? selectedEvaluationTypes
-              : undefined,
-          include_all_models: includeAllModels,
-          aggregation,
-          search: trimmedSearch ? trimmedSearch : undefined,
-          min_generation_count: minSamplesEnabled ? MIN_GENERATIONS_THRESHOLD : 0,
-          min_samples_evaluated: minSamplesEnabled ? MIN_SAMPLES_THRESHOLD : 0,
-        })
+      return apiClient.leaderboards.getLLMLeaderboard({
+        period,
+        metric,
+        limit: pageSize,
+        offset,
+        project_ids:
+          selectedProjectIds.length > 0 ? selectedProjectIds : undefined,
+        evaluation_types:
+          selectedEvaluationTypes.length > 0
+            ? selectedEvaluationTypes
+            : undefined,
+        include_all_models: includeAllModels,
+        aggregation,
+        search: trimmedSearch ? trimmedSearch : undefined,
+        min_generation_count: minSamplesEnabled ? MIN_GENERATIONS_THRESHOLD : 0,
+        min_samples_evaluated: minSamplesEnabled ? MIN_SAMPLES_THRESHOLD : 0,
+      })
+    },
+    placeholderData: keepPreviousData,
+    staleTime: 30_000,
+  })
 
-      setLeaderboard(response.leaderboard)
-      setAvailableMetrics(response.available_metrics)
-      setAvailableEvaluationTypes(response.available_evaluation_types || [])
-      setTotalItems(response.total_models)
-    } catch (err: any) {
-      console.error('Failed to load LLM leaderboard:', err)
-      setError(err.message || t('leaderboards.llm.loadFailed'))
-    } finally {
-      setLoading(false)
-    }
-  }, [
-    period,
-    metric,
-    aggregation,
-    selectedProjectIds,
-    selectedEvaluationTypes,
-    apiClient.leaderboards,
-    currentPage,
-    pageSize,
-    debouncedSearchQuery,
-    includeAllModels,
-    minSamplesEnabled,
-    t,
-  ])
+  const leaderboard = leaderboardQuery.data?.leaderboard ?? []
+  const availableMetrics = leaderboardQuery.data?.available_metrics ?? []
+  const availableEvaluationTypes =
+    leaderboardQuery.data?.available_evaluation_types ?? []
+  const totalItems = leaderboardQuery.data?.total_models ?? 0
+  // `isPending` is only true on the very first fetch (no cache, no
+  // placeholder); subsequent filter-driven refetches keep the previous
+  // data visible so the table doesn't flash. `isFetching` would also flip
+  // for background refetches but we intentionally don't render a global
+  // spinner for those.
+  const loading = leaderboardQuery.isPending
+  const error = leaderboardQuery.error
+    ? (leaderboardQuery.error as Error).message || t('leaderboards.llm.loadFailed')
+    : null
 
-  // Reset to page 1 when filters change
+  // Reset to page 1 when filters change. We can't put this inside the
+  // query callback (pre-react-query the state-driven refetch handled it);
+  // an explicit effect keeps it decoupled and matches the existing pattern.
   useEffect(() => {
     setCurrentPage(1)
   }, [
@@ -206,10 +213,6 @@ export function LLMLeaderboardTable() {
     includeAllModels,
     minSamplesEnabled,
   ])
-
-  useEffect(() => {
-    loadLeaderboard()
-  }, [loadLeaderboard])
 
   const handlePageSizeChange = (newSize: number) => {
     setPageSize(newSize)
@@ -359,7 +362,7 @@ export function LLMLeaderboardTable() {
     return (
       <div className="py-12 text-center">
         <p className="text-red-500">{error}</p>
-        <Button onClick={loadLeaderboard} className="mt-4">
+        <Button onClick={() => leaderboardQuery.refetch()} className="mt-4">
           {t('leaderboards.retry')}
         </Button>
       </div>
@@ -465,6 +468,7 @@ export function LLMLeaderboardTable() {
   return (
     <div className="space-y-4">
       <FilterToolbar
+        variant="bare"
         searchValue={searchQuery}
         onSearchChange={setSearchQuery}
         searchPlaceholder={t('leaderboards.llm.searchPlaceholder')}
@@ -543,12 +547,30 @@ export function LLMLeaderboardTable() {
         </FilterToolbar.Field>
 
         <FilterToolbar.Field label={t('leaderboards.llm.includeAllModels')}>
-          <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-zinc-700 dark:text-zinc-300">
+          {/* Catalog padding + the min-samples threshold are semantically
+              opposite: padding rows have 0 generations and 0 samples, so
+              the threshold would filter them all out the moment they're
+              added. Disable the checkbox while the threshold is on so the
+              user sees the dependency rather than toggling and getting
+              the same 12 rows back. */}
+          <label
+            className={
+              minSamplesEnabled
+                ? 'inline-flex cursor-not-allowed items-center gap-2 text-sm text-zinc-400 dark:text-zinc-500'
+                : 'inline-flex cursor-pointer items-center gap-2 text-sm text-zinc-700 dark:text-zinc-300'
+            }
+            title={
+              minSamplesEnabled
+                ? t('leaderboards.llm.includeAllModelsDisabledHint')
+                : undefined
+            }
+          >
             <input
               type="checkbox"
-              checked={includeAllModels}
+              checked={includeAllModels && !minSamplesEnabled}
+              disabled={minSamplesEnabled}
               onChange={(e) => setIncludeAllModels(e.target.checked)}
-              className="h-4 w-4 rounded border-zinc-300 text-emerald-600 focus:ring-emerald-500"
+              className="h-4 w-4 rounded border-zinc-300 text-emerald-600 focus:ring-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
             />
             <span>{t('leaderboards.llm.includeAllModelsLabel')}</span>
           </label>

--- a/services/frontend/src/components/leaderboards/__tests__/LLMLeaderboardTable.br5.test.tsx
+++ b/services/frontend/src/components/leaderboards/__tests__/LLMLeaderboardTable.br5.test.tsx
@@ -5,7 +5,22 @@
  * Follows the exact pattern of LLMLeaderboardTable.branches.test.tsx which passes.
  */
 import '@testing-library/jest-dom'
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+
+// PR after #117 wrapped LLMLeaderboardTable's data fetching in TanStack
+// Query — bare renders need a QueryClient. Local helper avoids extra
+// dependencies on test-utils.
+const render: typeof rtlRender = (ui, options) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  })
+  return rtlRender(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+    options
+  )
+}
 
 const mockGetLLMLeaderboard = jest.fn()
 

--- a/services/frontend/src/components/leaderboards/__tests__/LLMLeaderboardTable.test.tsx
+++ b/services/frontend/src/components/leaderboards/__tests__/LLMLeaderboardTable.test.tsx
@@ -2,7 +2,23 @@
  * @jest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render as rtlRender, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+
+// PR after #117 wrapped the LLM leaderboard's data fetching in TanStack
+// Query. The app provides a QueryClient at the root, but the test renders
+// the component bare; we have to supply one ourselves. Each test gets a
+// fresh client with `retry: false` so failure tests don't hang.
+const render: typeof rtlRender = (ui, options) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  })
+  return rtlRender(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+    options
+  )
+}
 
 const mockGetLLMLeaderboard = jest.fn()
 

--- a/services/frontend/src/components/shared/FilterToolbar.tsx
+++ b/services/frontend/src/components/shared/FilterToolbar.tsx
@@ -45,6 +45,16 @@ interface FilterToolbarProps {
   leftExtras?: ReactNode
   rightExtras?: ReactNode
   children?: ReactNode
+  /**
+   * Visual chrome around the toolbar. `'card'` (default) wraps the
+   * filter row in a bordered card with shadow — matches the list-page
+   * pattern. `'bare'` drops the border / background / padding so the
+   * toolbar sits flush with the surrounding layout — matches the
+   * Annotator + Co-Creation leaderboards' raw chip rows so the LLM
+   * leaderboard can align with them visually without rewriting either
+   * side.
+   */
+  variant?: 'card' | 'bare'
 }
 
 interface FilterFieldProps {
@@ -81,6 +91,7 @@ export function FilterToolbar({
   leftExtras,
   rightExtras,
   children,
+  variant = 'card',
 }: FilterToolbarProps) {
   const [showSearch, setShowSearch] = useState(defaultShowSearch)
   const [showFilters, setShowFilters] = useState(defaultShowFilters)
@@ -99,9 +110,17 @@ export function FilterToolbar({
   const searchVisible = !searchHidden && onSearchChange && showSearch
   const filterPanelVisible = hasFilterFields && showFilters
 
+  const isBare = variant === 'bare'
+
   return (
-    <div className="mb-6">
-      <div className="space-y-3 rounded-lg border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+    <div className={isBare ? 'mb-4' : 'mb-6'}>
+      <div
+        className={clsx(
+          'space-y-3',
+          !isBare &&
+            'rounded-lg border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900'
+        )}
+      >
         <div className="flex flex-col space-y-3 lg:flex-row lg:items-center lg:justify-between lg:space-y-0">
           <div className="flex flex-wrap items-center gap-2 sm:gap-3">
             {!searchHidden && onSearchChange && (

--- a/services/frontend/src/locales/de/common.json
+++ b/services/frontend/src/locales/de/common.json
@@ -1918,6 +1918,7 @@
       "selectMetric": "Metrik auswählen",
       "includeAllModels": "Katalogabdeckung",
       "includeAllModelsLabel": "Alle Modelle anzeigen (auch ohne Daten)",
+      "includeAllModelsDisabledHint": "Deaktiviere die statistische Relevanzschwelle, um Katalogmodelle ohne Daten einzuschließen",
       "minSamples": "Statistische Relevanz",
       "minSamplesLabel": "Mindestens {gens} Generierungen und {samples} Evaluierungen",
       "projectsCount": "{count} Projekte",

--- a/services/frontend/src/locales/en/common.json
+++ b/services/frontend/src/locales/en/common.json
@@ -1936,6 +1936,7 @@
       "selectMetric": "Select Metric",
       "includeAllModels": "Catalog coverage",
       "includeAllModelsLabel": "Show all models (incl. without data)",
+      "includeAllModelsDisabledHint": "Disable the statistical-relevance threshold to include catalog models without data",
       "minSamples": "Statistical relevance",
       "minSamplesLabel": "Require at least {gens} generations and {samples} evaluations",
       "projectsCount": "{count} Projects",


### PR DESCRIPTION
## Summary

Three follow-ups to the leaderboard work in #116/#117.

### 1. TanStack Query for the LLM leaderboard fetch

The component used raw \`useEffect + setState + fetch\`, so:
- Every filter tweak paid a full backend round-trip (~hundreds of ms in the live-aggregation path that the TUM scope + thresholds force).
- Tab-switching forced a refetch.
- No request dedup on overlapping state changes during mount.

Wrapped the request in \`useQuery\` with \`staleTime: 30s\` (matches recompute_aggregates cadence) and \`placeholderData: keepPreviousData\` so the table doesn't blank during filter changes. \`QueryClient\` is already provided at the app root (providers.tsx). Dashboard + models pages already use this pattern; the leaderboard was the outlier and the slowest one perceptually.

Jest test wraps renders in a local QueryClientProvider (same pattern as the dashboard tests).

### 2. Catalog padding + min-samples threshold are now mutually exclusive

With \`include_all_models=true\` AND \`min_generation_count=50\` set, the catalog-padding loop in \`leaderboards.py:592\` ignored the threshold and re-introduced 71 zero-gen rows — the exact noise we'd just fixed.

- **Backend**: skip the catalog loop entirely when either threshold is positive. Padding rows are 0/0 and would never pass; cheaper + clearer to short-circuit.
- **Frontend**: disable the catalog-coverage checkbox while the min-samples toggle is ON, with a tooltip explaining the order of operations. User has to turn off the threshold first to see catalog padding.

### 3. FilterToolbar gains \`variant: 'card' | 'bare'\`

LLM leaderboard used the card variant by default (bordered panel with shadow). The Human + Co-Creation leaderboards use a raw chip row with no chrome. New \`'bare'\` variant drops the border/background/padding so the LLM leaderboard matches the other two visually. Default stays \`'card'\` so the 12 other consumers (data tab, projects list, evaluations, …) keep their look.

## Test plan

- [x] Jest test for the default-call params still passes after QueryClientProvider wrap
- [x] Backend mutex verified manually (with min=50 + include_all=true, response is 12 rows not 83)
- [ ] CI green
- [ ] Post-merge Puppeteer: confirm filter chips on all 3 leaderboards look identical, and the leaderboard feels noticeably snappier on filter tweaks