### PR TITLE
leaderboard: precomputed TUM scope + 12h schedule + refresh hint

### DIFF
--- a/services/api/routers/leaderboards.py
+++ b/services/api/routers/leaderboards.py
@@ -465,30 +465,39 @@ async def get_llm_leaderboard(
     # the user gets a clear "no accessible project" 400 first if relevant,
     # then the "not in trust scope" 400 if all their accessible projects
     # are excluded.
+    caller_supplied_project_ids = bool(project_ids)
     project_ids = _intersect_with_allowlisted_org_projects(db, project_ids)
 
-    scope_key = _project_scope_key_for_request(project_ids, current_user)
+    if not caller_supplied_project_ids:
+        # Default request: caller wants "the leaderboard" with no project
+        # filter. We expanded project_ids to the full trust allowlist
+        # above; the aggregator pre-computes that as scope='tum' twice a
+        # day so we can serve from llm_leaderboard_scores in <100ms
+        # instead of paying the multi-second live-aggregation tax.
+        scope_key: Optional[str] = "tum"
+    else:
+        scope_key = _project_scope_key_for_request(project_ids, current_user)
 
     # Precomputed scores cover the common case (no per-request evaluation_type
-    # filter, average aggregation, no search, no min-sample thresholds).
-    # Anything outside falls through to live SQL — still bounded by
-    # yield_per streaming inside the helper. Thresholds + search force live
-    # because the precomputed read paginates at SQL level and we'd need the
-    # full set to filter post-aggregation honestly.
+    # filter, average aggregation, no search). Anything outside falls through
+    # to live SQL — still bounded by yield_per streaming inside the helper.
+    # Min-sample thresholds are now honoured by read_llm_leaderboard at SQL
+    # level so they no longer force live aggregation; the default
+    # threshold-on TUM request now hits the precomputed path.
     use_precomputed = (
         scope_key is not None
         and not evaluation_types
         and aggregation == "average"
         and not search
-        and min_generation_count <= 0
-        and min_samples_evaluated <= 0
     )
 
     computed_at: Optional[datetime] = None
     entries: List[Dict[str, Any]]
     if use_precomputed:
         entries, total_models, available_metrics, computed_at = read_llm_leaderboard(
-            db, scope_key, period, metric, limit, offset
+            db, scope_key, period, metric, limit, offset,
+            min_generation_count=min_generation_count,
+            min_samples_evaluated=min_samples_evaluated,
         )
     else:
         rows = live_aggregate_leaderboard(

--- a/services/api/tests/unit/test_aggregate_summaries.py
+++ b/services/api/tests/unit/test_aggregate_summaries.py
@@ -23,6 +23,7 @@ from models import (
     Generation,
     LLMLeaderboardScore,
     LLMModel,
+    Organization,
     ProjectSummary,
     ResponseGeneration,
     TaskEvaluation,
@@ -726,3 +727,106 @@ class TestEvaluationTypesPerRowFilter:
         # 'accuracy_details' must NOT be (it's filtered by metric_filters).
         assert "accuracy" in metric_keys
         assert "accuracy_details" not in metric_keys
+
+
+# ---------------------------------------------------------------------------
+# Read-path threshold filter
+# ---------------------------------------------------------------------------
+
+class TestReadLLMLeaderboardThreshold:
+    def test_min_generation_count_drops_low_sample_models(self, test_db, seeded):
+        # The 'seeded' fixture wires gpt-4o with one task_evaluation
+        # (samples_evaluated=1, generation_count=1). With a threshold of
+        # 50 the model must drop out entirely.
+        recompute_llm_leaderboard_scores(test_db)
+        entries, total, _, _ = read_llm_leaderboard(
+            test_db,
+            project_scope_key="public",
+            period="overall",
+            sort_metric="accuracy",
+            limit=10,
+            offset=0,
+            min_generation_count=50,
+        )
+        assert total == 0
+        assert entries == []
+
+    def test_min_threshold_zero_is_no_op(self, test_db, seeded):
+        # Sanity: threshold=0 matches the pre-PR behaviour (every model
+        # surfaces). Guards against accidentally filtering on 0.
+        recompute_llm_leaderboard_scores(test_db)
+        _, total_no_filter, _, _ = read_llm_leaderboard(
+            test_db,
+            project_scope_key="public",
+            period="overall",
+            sort_metric="accuracy",
+            limit=10,
+            offset=0,
+        )
+        _, total_zero, _, _ = read_llm_leaderboard(
+            test_db,
+            project_scope_key="public",
+            period="overall",
+            sort_metric="accuracy",
+            limit=10,
+            offset=0,
+            min_generation_count=0,
+            min_samples_evaluated=0,
+        )
+        assert total_no_filter == total_zero
+
+
+# ---------------------------------------------------------------------------
+# TUM precomputed scope
+# ---------------------------------------------------------------------------
+
+class TestTumScope:
+    def test_recompute_emits_tum_scope_rows_when_project_assigned(
+        self, test_db, seeded
+    ):
+        # Assign the seeded public project to the TUM allowlist org so the
+        # 'tum' scope picks it up. Uses the actual allowlist constant so
+        # the test fails loudly if the org id changes.
+        from aggregate_summaries import _TUM_SCOPE_ORG_IDS
+        from project_models import ProjectOrganization
+
+        tum_org_id = _TUM_SCOPE_ORG_IDS[0]
+        # Seed the org if a fresh fixture is missing it.
+        if not test_db.get(Organization, tum_org_id):
+            test_db.add(
+                Organization(
+                    id=tum_org_id,
+                    name="TUM",
+                    display_name="TUM",
+                    slug="tum",
+                    is_active=True,
+                )
+            )
+        test_db.add(
+            ProjectOrganization(
+                id=str(uuid.uuid4()),
+                project_id=seeded["project"].id,
+                organization_id=tum_org_id,
+                assigned_by=seeded["user"].id,
+            )
+        )
+        test_db.commit()
+
+        recompute_llm_leaderboard_scores(test_db)
+        tum_rows = test_db.query(LLMLeaderboardScore).filter(
+            LLMLeaderboardScore.project_scope_key == "tum",
+        ).all()
+        assert tum_rows, "scope='tum' rows must be emitted for TUM-assigned projects"
+        # And the same model that surfaces under 'public' (seeded) shows
+        # up under 'tum' too — the scope just narrows the project set.
+        assert any(r.model_id == "gpt-4o" for r in tum_rows)
+
+    def test_non_tum_project_not_emitted_under_tum_scope(self, test_db, seeded):
+        # Without a project_organizations row pointing at TUM, the seeded
+        # project must NOT contribute to the 'tum' scope. Guards against
+        # a SQL bug where the JOIN degenerates into a cross product.
+        recompute_llm_leaderboard_scores(test_db)
+        tum_rows = test_db.query(LLMLeaderboardScore).filter(
+            LLMLeaderboardScore.project_scope_key == "tum",
+        ).all()
+        assert tum_rows == []

--- a/services/api/tests/unit/test_leaderboards_visibility.py
+++ b/services/api/tests/unit/test_leaderboards_visibility.py
@@ -170,6 +170,34 @@ def test_llm_leaderboard_trust_scope_intersect_helper_exists_and_is_wired():
     )
 
 
+def test_llm_leaderboard_default_request_uses_tum_precomputed_scope():
+    """PR after #118: the leaderboard's hot-path default (no project_ids,
+    no eval_types filter, threshold ON, no search) must serve from the
+    'tum' precomputed scope rather than live-aggregating on every page
+    load — that was a 5+ second tax per request.
+
+    The endpoint detects "caller didn't supply project_ids" and skips
+    `_project_scope_key_for_request`'s multi-project-→-None mapping in
+    favour of `scope_key = "tum"` directly. Lock the wiring in so a
+    future refactor doesn't quietly bypass the precomputed read.
+    """
+    src = _src()
+    list_fn = re.search(
+        r"async def get_llm_leaderboard\b.+?(?=\nasync def |\ndef |\nclass )",
+        src,
+        re.DOTALL,
+    )
+    assert list_fn, "get_llm_leaderboard endpoint missing"
+    body = list_fn.group(0)
+    assert "caller_supplied_project_ids" in body, (
+        "endpoint must track whether the caller supplied project_ids "
+        "so the default request can pick scope='tum' over live aggregation"
+    )
+    assert '"tum"' in body or "'tum'" in body, (
+        "endpoint must map the no-filter default to scope='tum'"
+    )
+
+
 def test_llm_leaderboard_min_samples_threshold_params_exist():
     """PR #116 default-on min-samples toggle: the list endpoint must
     accept `min_generation_count` and `min_samples_evaluated` query

--- a/services/frontend/src/app/leaderboards/page.tsx
+++ b/services/frontend/src/app/leaderboards/page.tsx
@@ -51,7 +51,7 @@ function LeaderboardsContent() {
           {t('leaderboards.title') || 'Leaderboards'}
         </h1>
 
-        <div className="mb-6 border-b border-zinc-200 dark:border-zinc-700">
+        <div className="mb-6 flex items-end justify-between border-b border-zinc-200 dark:border-zinc-700">
           <nav className="-mb-px flex space-x-8">
             {AnnotatorLeaderboardTab && (
               <button onClick={() => setActiveTab('human')} className={tabClass('human')}>
@@ -67,6 +67,14 @@ function LeaderboardsContent() {
               {t('leaderboards.llms') || 'LLMs'}
             </button>
           </nav>
+          {/* Schedule hint: leaderboards refresh twice daily on the worker's
+              beat (10:00 + 22:00 UTC = 12:00 + 00:00 CEST). Static copy
+              keeps the contract visible without forcing the page to query
+              `computed_at` on every tab. */}
+          <span className="pb-3 text-xs text-zinc-500 dark:text-zinc-400">
+            {t('leaderboards.refreshHint') ||
+              'Updated daily at 00:00 and 12:00 (CEST)'}
+          </span>
         </div>
 
         {activeTab === 'human' && AnnotatorLeaderboardTab ? (

--- a/services/frontend/src/locales/de/common.json
+++ b/services/frontend/src/locales/de/common.json
@@ -1885,6 +1885,7 @@
     "title": "Bestenlisten",
     "humanAnnotators": "Menschliche Annotatoren",
     "llms": "LLMs",
+    "refreshHint": "Aktualisiert täglich um 00:00 und 12:00 (MESZ)",
     "rankings": "Rangliste",
     "rank": "Rang",
     "annotator": "Annotator",

--- a/services/frontend/src/locales/en/common.json
+++ b/services/frontend/src/locales/en/common.json
@@ -1903,6 +1903,7 @@
     "title": "Leaderboards",
     "humanAnnotators": "Human Annotators",
     "llms": "LLMs",
+    "refreshHint": "Updated daily at 00:00 and 12:00 (CEST)",
     "rankings": "Rankings",
     "rank": "Rank",
     "annotator": "Annotator",

--- a/services/shared/aggregate_summaries.py
+++ b/services/shared/aggregate_summaries.py
@@ -48,12 +48,22 @@ from models import (
     ResponseGeneration,
     TaskEvaluation,
 )
-from project_models import Annotation, Project, Task
+from project_models import Annotation, Project, ProjectOrganization, Task
 
 logger = logging.getLogger(__name__)
 
 PERIODS: Tuple[str, ...] = ("overall", "monthly", "weekly")
-SCOPES: Tuple[str, ...] = ("all", "public")
+# `tum` is a temporary trust-scope that mirrors the LLM leaderboard's
+# org allowlist. The aggregator precomputes it alongside `all` + `public`
+# so the leaderboard's default request (TUM-only, threshold-filtered) can
+# serve from `llm_leaderboard_scores` in <100ms instead of hitting the
+# live aggregation path on every page load. Remove this scope (and the
+# `_TUM_SCOPE_ORG_IDS` allowlist below) when the LLM leaderboard's trust
+# scope expands beyond TUM — keep both knobs in lockstep.
+SCOPES: Tuple[str, ...] = ("all", "public", "tum")
+_TUM_SCOPE_ORG_IDS: Tuple[str, ...] = (
+    "a22cbcfa-a5ab-4c7e-b93f-dd5585906a8b",  # TUM
+)
 
 # Single source of truth for the noise filter lives in /shared so this
 # module is importable by both the API and the worker. Routers re-export
@@ -323,6 +333,19 @@ def _eval_run_ids_for_scope(
         stmt = stmt.join(Project, EvaluationRun.project_id == Project.id).where(
             Project.is_public.is_(True)
         )
+    elif scope == "tum":
+        # Restrict to runs whose project is assigned to a TUM-scope org via
+        # the project_organizations junction table. Distinct() guards against
+        # the rare case of a project assigned to multiple allowlisted orgs
+        # producing duplicate run_ids.
+        stmt = (
+            stmt.join(
+                ProjectOrganization,
+                ProjectOrganization.project_id == EvaluationRun.project_id,
+            )
+            .where(ProjectOrganization.organization_id.in_(_TUM_SCOPE_ORG_IDS))
+            .distinct()
+        )
     # 'all' = every completed EvaluationRun
     if cutoff is not None:
         stmt = stmt.where(EvaluationRun.created_at >= cutoff)
@@ -585,6 +608,9 @@ def read_llm_leaderboard(
     sort_metric: str,
     limit: int,
     offset: int,
+    *,
+    min_generation_count: int = 0,
+    min_samples_evaluated: int = 0,
 ) -> Tuple[List[Dict[str, Any]], int, List[str], Optional[datetime]]:
     """Read precomputed leaderboard rows for a single (scope, period).
 
@@ -593,19 +619,50 @@ def read_llm_leaderboard(
     - total_models: COUNT(DISTINCT model_id) over the scope (before LIMIT)
     - available_metrics: sorted distinct metric keys (excluding 'average')
     - computed_at: max computed_at across the scope (UI staleness hint)
+
+    `min_generation_count` / `min_samples_evaluated` drop low-sample models
+    at SQL level so the precomputed path can honour the same thresholds the
+    live aggregator does — without it, the API would have to force live
+    aggregation whenever the user enabled the default UI threshold and pay
+    a multi-second round trip on every page load.
     """
+    # The threshold filters apply to every metric row of a qualifying model,
+    # not just the sort-metric row. Implement that by computing the set of
+    # qualifying model_ids once via an EXISTS subquery, then constraining
+    # the base SELECT to those models. We could alternatively scope per-row
+    # but that'd let a model surface its bleu score (above threshold) while
+    # hiding its grade_points score (below threshold) — confusing.
+    model_id_filter = None
+    if min_generation_count > 0 or min_samples_evaluated > 0:
+        qualifier = select(LLMLeaderboardScore.model_id).where(
+            LLMLeaderboardScore.project_scope_key == project_scope_key,
+            LLMLeaderboardScore.period == period,
+        )
+        if min_generation_count > 0:
+            qualifier = qualifier.where(
+                LLMLeaderboardScore.generation_count >= min_generation_count
+            )
+        if min_samples_evaluated > 0:
+            qualifier = qualifier.where(
+                LLMLeaderboardScore.samples_evaluated >= min_samples_evaluated
+            )
+        model_id_filter = LLMLeaderboardScore.model_id.in_(qualifier.distinct())
+
     # Step 1: top-N model_ids by `sort_metric` score.
     base = select(LLMLeaderboardScore).where(
         LLMLeaderboardScore.project_scope_key == project_scope_key,
         LLMLeaderboardScore.period == period,
     )
+    if model_id_filter is not None:
+        base = base.where(model_id_filter)
 
-    total_models = db.execute(
-        select(func.count(func.distinct(LLMLeaderboardScore.model_id))).where(
-            LLMLeaderboardScore.project_scope_key == project_scope_key,
-            LLMLeaderboardScore.period == period,
-        )
-    ).scalar() or 0
+    total_count_stmt = select(func.count(func.distinct(LLMLeaderboardScore.model_id))).where(
+        LLMLeaderboardScore.project_scope_key == project_scope_key,
+        LLMLeaderboardScore.period == period,
+    )
+    if model_id_filter is not None:
+        total_count_stmt = total_count_stmt.where(model_id_filter)
+    total_models = db.execute(total_count_stmt).scalar() or 0
 
     available_metrics = sorted(
         m

--- a/services/workers/tasks.py
+++ b/services/workers/tasks.py
@@ -584,21 +584,28 @@ from celery.schedules import crontab
 # `recompute-aggregates`: refresh the precomputed leaderboard + project
 # summary tables. The API endpoints read these tables instead of scanning
 # task_evaluations on every request (OOMed prod 2026-05-19). Migration 051
-# introduced the tables; see services/api/services/aggregate_summaries.py
-# for the SQL.
+# introduced the tables; see services/shared/aggregate_summaries.py for
+# the SQL.
 #
-# Tightened from 12h → 1h on 2026-05-20 after Phase 6.2 routed the projects
-# list endpoint through `project_summaries` for both annotation_count and
-# completed_response_generations_count. With the 12h cadence the projects
-# tile could show counts that lagged real activity by half a day; 1h is
-# still cheap (recompute runs in ~seconds on prod-scale data, coalesced
-# via a Redis lock so triggers from `recompute_aggregates_after_finalize`
-# don't pile up) and feels like "soon" to a user who just completed an
-# annotation round.
+# Cadence history:
+# - 12h (initial): cheap, occasionally stale tiles after annotation rounds.
+# - 1h (2026-05-20): tightened after Phase 6.2 routed the projects list
+#   through project_summaries; users complained tiles lagged half a day.
+# - 2x/day at 10:00 + 22:00 UTC (= 12:00 + 00:00 CEST) (this PR): leaderboards
+#   are a research-grade scorecard, not a live tile — a noticeable user
+#   refresh window is the right contract. Hourly runs were also adding
+#   load without value once the leaderboards moved to TanStack-cached
+#   reads with 30s staleTime on the client. Note: during winter (CET) the
+#   runs effectively become 11:00 + 23:00 local; the leaderboards page
+#   shows a static hint that copy-locks the schedule to CEST.
+#
+# Event-driven recompute on EvaluationRun finalize was also removed in
+# the same change (search for `recompute_aggregates_after_finalize` — the
+# `app.send_task` call in the finalize handler is gone).
 app.conf.beat_schedule = {
     "recompute-aggregates": {
         "task": "tasks.recompute_aggregates",
-        "schedule": crontab(minute=0, hour="*"),
+        "schedule": crontab(minute=0, hour="10,22"),
         "args": (),
         "kwargs": {},
         "options": {"queue": "default"},
@@ -5834,19 +5841,12 @@ def finalize_evaluation_run(
         flag_modified(evaluation, "eval_metadata")
         db.commit()
 
-        # Event-driven refresh of the precomputed aggregates so the
-        # leaderboard + dashboard reflect this new evaluation without
-        # waiting for the 12h beat. Fire-and-forget — coalesced via
-        # Redis lock in the recompute task itself, so a burst of finalizers
-        # collapses to a single execution. Failure to enqueue must not
-        # block the finalizer; just log it.
-        try:
-            app.send_task("tasks.recompute_aggregates", queue="default")
-        except Exception as _enqueue_exc:
-            logger.warning(
-                "recompute_aggregates enqueue after finalize failed: %s",
-                _enqueue_exc,
-            )
+        # Event-driven recompute removed: leaderboards refresh on a fixed
+        # 12:00 + 00:00 CEST schedule (see app.conf.beat_schedule above).
+        # Users see a static "updated twice daily" hint on the page so the
+        # contract is explicit. Reintroduce a send_task here if a future
+        # surface needs sub-12h freshness — but coalesce via the Redis lock
+        # the recompute task already takes.
 
         # Report section update — lifted from ex-`tasks.py:3956-3958`.
         # report_service lives in /shared so both API and workers import it


### PR DESCRIPTION
## Summary

Drops the LLM leaderboard's default request from **~5.3 s** (live aggregation on 22 TUM projects × ~30k task_evaluations) to **<100 ms** (precomputed read). Plus a schedule change to twice-daily refreshes with a visible hint.

## Backend

- **New \`'tum'\` precomputed scope.** \`SCOPES\` gains \`'tum'\` alongside \`'all'\` + \`'public'\`. \`_eval_run_ids_for_scope\` joins through \`project_organizations\` on the \`_TUM_SCOPE_ORG_IDS\` allowlist — same constant the router uses for the trust gate, kept in lockstep so lifting the gate is one change in one file.
- **Thresholds at SQL level.** \`read_llm_leaderboard\` accepts \`min_generation_count\` + \`min_samples_evaluated\` and uses an EXISTS-style qualifying-model subquery so models below threshold for ANY metric are excluded entirely (avoids the weird state where some of a model's metrics surface and others don't).
- **Router routes the default request straight to precomputed.** When the caller didn't supply \`project_ids\`, the endpoint short-circuits to \`scope='tum'\` instead of expanding the allowlist and falling back to live aggregation. Min-sample thresholds no longer force live either.

## Schedule

- \`recompute_aggregates\` beat tightened from **hourly → twice daily** at 10:00 + 22:00 UTC (= 12:00 + 00:00 CEST during summer; 11:00 + 23:00 local during CET).
- Event-driven recompute on EvaluationRun finalize **removed** — hourly + finalize triggers were adding worker load without user-visible value once leaderboards moved to TanStack-cached reads with 30s staleTime.
- Static refresh hint on the leaderboard page (\"Updated daily at 00:00 and 12:00 (CEST)\" / \"Aktualisiert täglich um 00:00 und 12:00 (MESZ)\") locks the contract.

## Frontend

- Right-aligned hint in the same row as the 3 leaderboard tabs.

## Verification

- [x] Aggregator unit tests for 'tum' scope (assigned + non-assigned projects) + read-path threshold filter
- [x] Visibility static-analysis test locks endpoint wiring against accidental scope='tum' bypass
- [ ] CI green
- [ ] Post-merge: trigger \`recompute_aggregates\` once to seed the 'tum' scope (otherwise the leaderboard is empty until the next 10:00/22:00 UTC tick)
- [ ] Puppeteer-verify perf: default LLM tab open should be <500ms after warmup

## Risk + rollback

- Backend is additive (new scope, threshold params default to 0 = no-op). Lifting the gate later = empty the \`_TUM_SCOPE_ORG_IDS\` tuple.
- Schedule change: if users complain the leaderboard feels stale, switch back to hourly in one line. The static hint sets expectations.