### PR TITLE
Landing-page citation + unauth legal-page layout fix

### DIFF
--- a/services/frontend/src/components/layout/MinimalLayout.tsx
+++ b/services/frontend/src/components/layout/MinimalLayout.tsx
@@ -19,7 +19,7 @@ export function MinimalLayout({ children, sections = [] }: MinimalLayoutProps) {
 
   return (
     <SectionProvider sections={sections}>
-      <div className="min-h-screen bg-white dark:bg-zinc-900">
+      <div className="min-h-screen w-full bg-white dark:bg-zinc-900">
         {/* Header */}
         <header className="relative z-10">
           <nav

--- a/services/frontend/src/locales/de/common.json
+++ b/services/frontend/src/locales/de/common.json
@@ -3205,9 +3205,9 @@
           "description": "Der Quellcode der BenGER-Plattform ist Open Source unter der Apache License 2.0. Sie dürfen ihn -- auch kommerziell -- frei nutzen, anpassen und weiterverbreiten, solange eine angemessene Namensnennung erfolgt."
         },
         {
-          "label": "Benchmark-Datensatz (geplant)",
-          "title": "CC-BY Lizenz",
-          "description": "Der BenGER-Benchmark-Datensatz wird unter Creative Commons Namensnennung (CC-BY) veröffentlicht. Sie werden die Daten für jeden Zweck teilen und anpassen dürfen, solange eine angemessene Namensnennung erfolgt."
+          "label": "Benchmark-Datensatz",
+          "title": "CC BY 4.0 Lizenz",
+          "description": "Der BenGER-Benchmark-Datensatz ist unter Creative Commons Namensnennung 4.0 (CC BY 4.0) veröffentlicht. Sie dürfen die Daten für jeden Zweck teilen und anpassen, solange eine angemessene Namensnennung erfolgt."
         }
       ],
       "citationTitle": "Zitierweise",
@@ -3219,8 +3219,7 @@
         },
         {
           "label": "BenGER Benchmark-Datensatz",
-          "bibtex": "",
-          "tba": true
+          "bibtex": "@article{nagl2026bengerbench,\n  title={{BenGER}: Benchmarking {LLM} Systems on Subsumption-Based Legal Reasoning in German Law},\n  author={Nagl, Sebastian and Mayrhofer, Ann-Kristin and Heidebach, Martin and Ko{\\c{c}}ak, Aleyna and Zettelmeier, Anne and Breu, Elly and Greiner, Angelina and Milijas, Sofija and Grabmair, Matthias},\n  year={2026},\n  eprint={2605.28183},\n  archivePrefix={arXiv},\n  primaryClass={cs.CL},\n  doi={10.5281/zenodo.20409635}\n}"
         }
       ]
     },

--- a/services/frontend/src/locales/en/common.json
+++ b/services/frontend/src/locales/en/common.json
@@ -3223,9 +3223,9 @@
           "description": "The BenGER platform code is open-source under the Apache License 2.0. You are free to use, modify, and distribute it -- including for commercial purposes -- with attribution."
         },
         {
-          "label": "Benchmark Dataset (planned)",
-          "title": "CC-BY License",
-          "description": "The BenGER benchmark dataset will be released under Creative Commons Attribution (CC-BY). You will be free to share and adapt the data for any purpose, as long as appropriate credit is given."
+          "label": "Benchmark Dataset",
+          "title": "CC BY 4.0 License",
+          "description": "The BenGER benchmark dataset is released under Creative Commons Attribution 4.0 (CC BY 4.0). You are free to share and adapt the data for any purpose, as long as appropriate credit is given."
         }
       ],
       "citationTitle": "How to Cite",
@@ -3237,8 +3237,7 @@
         },
         {
           "label": "BenGER Benchmark Dataset",
-          "bibtex": "",
-          "tba": true
+          "bibtex": "@article{nagl2026bengerbench,\n  title={{BenGER}: Benchmarking {LLM} Systems on Subsumption-Based Legal Reasoning in German Law},\n  author={Nagl, Sebastian and Mayrhofer, Ann-Kristin and Heidebach, Martin and Ko{\\c{c}}ak, Aleyna and Zettelmeier, Anne and Breu, Elly and Greiner, Angelina and Milijas, Sofija and Grabmair, Matthias},\n  year={2026},\n  eprint={2605.28183},\n  archivePrefix={arXiv},\n  primaryClass={cs.CL},\n  doi={10.5281/zenodo.20409635}\n}"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Fill in the benchmark BibTeX in both \`en\` and \`de\` landing-page locales now that the dataset paper is live (arXiv 2605.28183, Zenodo DOI 10.5281/zenodo.20409635). License card flips from "Benchmark Dataset (planned) / will be released" to "Benchmark Dataset / is released" + CC BY 4.0 wording.
- \`MinimalLayout\`: add \`w-full\` to the root div. \`<body>\` is \`display:flex\`, so without an explicit width the layout shrinks to content and \`mx-auto max-w-4xl\` never centers. The fix aligns the unauthenticated Imprint and Data-Protection pages with the centered look they have inside the authenticated app shell.

## Test plan
- [x] Local Puppeteer pass at 1440×900: \`/about/imprint\` and \`/about/data-protection\` render centered with prose typography when logged out.
- [x] Landing page \`/\` still renders correctly (standalone branch in \`ConditionalLayout\` is unaffected).
- [x] Auth path \`/about/imprint\` (sidebar layout) unchanged — \`LegalPageWrapper\` branches on \`user\` and uses \`ResponsiveContainer\` for that case.
- [x] JSON parses for both \`en\` and \`de\` locales; \`tba\` flag removed; renderer at \`LicenseCitationSection.tsx:88\` falls through to the \`<pre>\` block when \`bibtex\` is non-empty.