### PR TITLE
ci(dependabot): fix broken auto-approve by switching to pull_request_target

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,9 +3,16 @@ name: Dependabot Batch
 # 1. Auto-approves eligible dependabot PRs on creation (no CI triggered)
 # 2. Weekly: creates a single batch PR from all approved dependabot PRs
 #    CI runs once on the batch PR — merge manually when ready
+#
+# Trigger: pull_request_target (not pull_request) so the run executes in the
+# base-repo context and reads Actions secrets. Dependabot-triggered pull_request
+# runs only see the separate Dependabot secret store, where the GitHub-App
+# credentials don't live — the approve step would crash with
+# "Input required and not supplied: app-id". Same-repo Dependabot branches make
+# pull_request_target safe here; the approve job never checks out PR code.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
   schedule:
     - cron: "0 2 * * 2"
@@ -18,7 +25,7 @@ permissions:
 jobs:
   approve:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
     steps:
       - name: Generate App Token
         id: app-token


### PR DESCRIPTION
## Summary

The `Dependabot Batch` workflow's `approve` step has been failing on every
dependabot PR since the workflow was added — see the failed
[run on PR #121](https://github.com/SebastianNagl/benger-platform/actions/runs/26377204525/job/77639472941):

```
Error: Input required and not supplied: app-id
```

Cause: `${{ secrets.APP_ID }}` and `${{ secrets.APP_PRIVATE_KEY }}` are defined
in the **Actions** secret store, but `pull_request` runs triggered by
Dependabot read from the separate **Dependabot** secret store, which is empty.
The `actions/create-github-app-token@v1` step then crashes; the PR never
reaches APPROVED state; and the Tuesday-02:00 batch cron always iterates an
empty list (it filters by `reviewDecision == "APPROVED"`).

This PR switches the trigger from `pull_request` to `pull_request_target`.
`pull_request_target` runs execute in the **base-repo context** with access to
Actions secrets, where the GitHub-App credentials already live — no secret
duplication, no manual step. Safe here because Dependabot opens same-repo
branches (the usual `pull_request_target` concern is fork PRs with malicious
workflow edits) and the `approve` job never checks out PR code.

## Effect after merge

- Every new dependabot patch/minor PR is auto-approved by the App token (no CI triggered, by design).
- The Tuesday 02:00 UTC cron starts producing real `dependabot/batch` PRs.
- Major version updates still get a manual-review comment, unchanged.

## Test plan

- [ ] After merge, next dependabot-opened PR shows `approve` check SUCCESS instead of FAILURE.
- [ ] PR appears as APPROVED by the App.
- [ ] Next Tuesday 02:00 UTC, `dependabot/batch` PR opens automatically if there are approved PRs.