### PR TITLE
Make DeepInfraService.generate sync to match base interface

### DIFF
--- a/services/shared/ai_services/deepinfra_service.py
+++ b/services/shared/ai_services/deepinfra_service.py
@@ -147,7 +147,7 @@ class DeepInfraService(BaseAIService):
         return self.client != None
 
     @async_retry_with_exponential_backoff(max_retries=5, base_delay=2.0)
-    async def generate(
+    async def _generate_async(
         self,
         prompt: str,
         system_prompt: str = "",
@@ -393,7 +393,7 @@ Your response must be ONLY the JSON object, no other text before or after.
             enhanced_system_prompt = system_prompt + format_instructions
 
             # Use the base generate method
-            result = await self.generate(
+            result = await self._generate_async(
                 prompt=prompt,
                 system_prompt=enhanced_system_prompt,
                 model_name=model_name,
@@ -460,8 +460,7 @@ Your response must be ONLY the JSON object, no other text before or after.
         finally:
             loop.close()
 
-    # Non-async wrapper for backward compatibility
-    def generate_sync(
+    def generate(
         self,
         prompt: str,
         system_prompt: str = "",
@@ -470,15 +469,14 @@ Your response must be ONLY the JSON object, no other text before or after.
         temperature: float = 0.0,
         **kwargs
     ) -> Dict[str, Any]:
-        """
-        Synchronous wrapper for generate method.
-        """
-        import asyncio
+        """Sync entry point matching `BaseAIService.generate`. Delegates to the
+        async DeepInfra implementation via a private event loop so callers don't
+        need to know this provider is async under the hood."""
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         try:
             return loop.run_until_complete(
-                self.generate(prompt, system_prompt, model_name, max_tokens, temperature, **kwargs)
+                self._generate_async(prompt, system_prompt, model_name, max_tokens, temperature, **kwargs)
             )
         finally:
             loop.close()


### PR DESCRIPTION
## Summary

DeepInfra was the only provider whose `generate` was an async coroutine, violating the sync contract declared by `BaseAIService.generate` and used by every other provider (OpenAI, Anthropic, Google, Cohere, Mistral, Grok). Sync callers that did `ai_service.generate(...).get(...)` crashed on any DeepInfra-hosted model with `'coroutine' object has no attribute 'get'`.

Observed in prod for the Falloesung LLM judge when DeepSeek V4 Pro and Qwen 3.5 397B were configured as judges — every evaluation cell wrote a terminal-error row.

## What changes

- `services/shared/ai_services/deepinfra_service.py`: rename the async impl to `_generate_async` (private), add a sync `def generate` that delegates via a private event loop, drop the old `generate_sync`.
- Mirrors the existing pattern in `grok_service.py:119-150`.

## What this fixes

1. **Falloesung LLM judge** (`benger_extended/api/services/falloesung_evaluator.py:98`) — sync call to `ai_service.generate(...)` now works for DeepInfra models. This was the production bug.
2. **Classic LLM judge** (`services/workers/ml_evaluation/llm_judge_evaluator.py:747, 906`) — same sync pattern; would have broken the moment any DeepInfra model was used as `llm_judge_classic`. Latent bug, now resolved.
3. **Interface contract** — `DeepInfraService.generate` now matches `BaseAIService.generate`'s declared sync signature.

## Why no callsite changes

- The `iscoroutinefunction(ai_service.generate)` guard at `services/workers/tasks.py:1648-1681` (generation path) consistently falls into the sync `else` branch for all providers now. The async-await branch becomes dead code for DeepInfra, but the dispatcher logic is unchanged.
- The old `generate_sync` had zero external callers (verified with grep across both repos).

## Test plan
- [ ] Existing unit tests pass (DeepInfra-related tests mock `DeepInfraService` at the class level with `MagicMock`; sync/async signature change is transparent).
- [ ] Manual verification post-deploy: dispatch evaluate-missing-only on a project with a DeepInfra-hosted LLM judge; confirm `metrics.llm_judge_falloesung.value` is populated (not `null` with `error: "LLM judge evaluation failed"`).