### PR TITLE
Make DeepInfraService.generate_structured sync (follow-up to #133)

### DIFF
--- a/services/shared/ai_services/deepinfra_service.py
+++ b/services/shared/ai_services/deepinfra_service.py
@@ -315,7 +315,7 @@ class DeepInfraService(BaseAIService):
             return self._create_error_response(e, model_name, "DeepInfra")
 
     @async_retry_with_exponential_backoff(max_retries=5, base_delay=2.0)
-    async def generate_structured(
+    async def _generate_structured_async(
         self,
         prompt: str,
         system_prompt: str,
@@ -439,7 +439,7 @@ Your response must be ONLY the JSON object, no other text before or after.
         except Exception as e:
             return self._create_error_response(e, model_name, "DeepInfra")
 
-    def generate_structured_sync(
+    def generate_structured(
         self,
         prompt: str,
         system_prompt: str,
@@ -449,13 +449,14 @@ Your response must be ONLY the JSON object, no other text before or after.
         temperature: float = 0.0,
         **kwargs
     ) -> Dict[str, Any]:
-        """Synchronous wrapper for generate_structured method."""
-        import asyncio
+        """Sync entry point matching `BaseAIService.generate_structured`. Delegates
+        to the async DeepInfra implementation via a private event loop so callers
+        don't need to know this provider is async under the hood."""
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         try:
             return loop.run_until_complete(
-                self.generate_structured(prompt, system_prompt, json_schema, model_name, max_tokens, temperature, **kwargs)
+                self._generate_structured_async(prompt, system_prompt, json_schema, model_name, max_tokens, temperature, **kwargs)
             )
         finally:
             loop.close()


### PR DESCRIPTION
## Summary

Follow-up to #133: `DeepInfraService.generate_structured` had the same async/sync interface mismatch as `generate`. After #133 deployed, the Falloesung LLM judge re-trigger still crashed 100% on Qwen 3.5 397B with the same `'coroutine' object has no attribute 'get'` error, because the worker-side codepath uses `generate_structured`, not `generate`.

## What changes

`services/shared/ai_services/deepinfra_service.py`:
- `async def generate_structured` → `async def _generate_structured_async` (rename to private async impl)
- Old `generate_structured_sync` removed; replaced with a sync `def generate_structured` that delegates via event loop. Same pattern applied in #133 to `generate`.

## Callers that needed the fix (all sync, all DeepInfra-broken before)

- `benger-extended/benger_extended/workers/falloesung_tasks.py:284` — Falloesung worker-side judge (the active prod symptom on this re-run)
- `services/workers/ml_evaluation/llm_judge_evaluator.py:1231` — structured-output classic LLM judge
- `services/workers/tasks.py:1639` — sync `else` branch (already guarded by `iscoroutinefunction`, behavior unchanged, but now consistent)

## Why this wasn't in #133

#133 fixed only `generate`. The grep for fix scoping caught `falloesung_evaluator.py:98` (API-side immediate eval) but missed `falloesung_tasks.py:284` (worker-side, the active dispatch path), which calls `generate_structured` instead. Two separate Falloesung pipelines, two separate ai_service methods. Symptom looked identical but the broken method was different.

## Test plan
- [ ] Existing unit tests pass (DeepInfra mocks at class level; signature change is transparent).
- [ ] Post-deploy: re-trigger evaluate-missing-only on benchathon; confirm DeepSeek and Qwen rows have `metrics.llm_judge_falloesung.value` populated.

Verified the previous prod failure mode in the worker pod's running Python: `DeepInfraService.generate` is sync (this PR's #133 fix is live), but `generate_structured` is still async (this PR addresses).