### PR TITLE
Fix cost estimator over-counting in evaluate-missing-only mode (#132)

### DIFF
--- a/services/api/routers/cost_estimate.py
+++ b/services/api/routers/cost_estimate.py
@@ -266,7 +266,6 @@ def _count_evaluation_judge_calls(
     db: Session,
     project_id: str,
     judge_model_id: str,
-    runs_per_call: int,
     generation_mode: Optional[str],
 ) -> int:
     """Count LLM-judge API calls that would actually fire for
@@ -294,10 +293,12 @@ def _count_evaluation_judge_calls(
                                     well, otherwise the human-side bill
                                     is invisible. Returns generations
                                     AND annotations.
-    - Multiply by `runs` from the judge spec.
+    - Multiply by this config's own `runs` for this judge (NOT the
+      request-level `runs_per_call`, which was the global max across all
+      selected configs and double-counted any per-config `runs:1` when
+      another selected config carried `runs:3` — issue #132).
     - For mode='missing', subtract subjects whose `task_evaluations`
-      row is already scored under the matching field_name pattern
-      `<metric>-<config_id>|<pred_field_normalized>|...`.
+      row is already scored under field_name `{config_id}|{pred_field}|...`.
 
     Returns the total API-call count across all judge configs that
     target ``judge_model_id``.
@@ -312,10 +313,12 @@ def _count_evaluation_judge_calls(
 
     total = 0
     for cfg in cfgs:
-        runs = cfg["runs"] * max(runs_per_call, 1)
-        # `runs_per_call` is the modal-level "runs across this trigger";
-        # `cfg["runs"]` is per-judge in this config. Multiply because
-        # each judge invocation is its own API call.
+        # `cfg["runs"]` is this judge's run count in this specific config.
+        # `runs_per_call` from the request was a global "max runs across all
+        # selected configs' judges" and is intentionally not used here — it
+        # would double-count any config whose per-judge runs differs from
+        # the global max (issue #132).
+        runs = cfg["runs"]
         for pf in cfg["prediction_fields"]:
             subj_keys = _subjects_for_pred_field(
                 pf, gen_ids_by_field=gen_ids_by_field,
@@ -323,7 +326,7 @@ def _count_evaluation_judge_calls(
             )
             if generation_mode == "missing":
                 done = _already_scored_subjects(
-                    db, project_id, metric_id=cfg["metric"], pred_field=pf
+                    db, project_id, config_id=cfg["id"], pred_field=pf
                 )
                 missing = [s for s in subj_keys if s not in done]
                 total += len(missing) * runs
@@ -368,8 +371,17 @@ def _load_llm_judge_configs(db: Session, project_id: str, judge_model_id: str) -
             runs_for_this_judge = max(int(params.get("runs_per_judge") or 1), 1)
         if runs_for_this_judge == 0:
             continue
+        config_id = c.get("id")
+        if not config_id:
+            # Configs without an id can't be skip-set matched against
+            # stored task_evaluations rows; the worker writes
+            # `field_name = "{config_id}|{pred_field}|{ref_field}"` and
+            # we need an exact config_id to match. Skip rather than
+            # over-count.
+            continue
         out.append(
             {
+                "id": config_id,
                 "metric": metric,
                 "prediction_fields": list(c.get("prediction_fields") or []),
                 "runs": runs_for_this_judge,
@@ -433,52 +445,53 @@ def _subjects_for_pred_field(
 
 
 def _already_scored_subjects(
-    db: Session, project_id: str, *, metric_id: str, pred_field: str
+    db: Session, project_id: str, *, config_id: str, pred_field: str
 ) -> set:
     """Return subject keys (`(kind, id)`) already scored for this
-    metric+pred_field combination — i.e. what the worker would skip
+    config+pred_field combination — i.e. what the worker would skip
     under `evaluate_missing_only`.
 
-    field_name in `task_evaluations` follows the convention
-    `<metric>-<config_id>|<pred_field_normalized>|<reference>`.
-    The `<config_id>` suffix is unique per metric instance, so we
-    match on prefix `<metric>-`. Per worker logic, plain field names
-    are recorded with the `human:` prefix in annotation context — so a
-    plain pred_field maps to two field_name patterns, one for each
-    subject kind.
+    The worker writes `task_evaluations.field_name = "{config_id}|{pred_field}|{ref_field}"`
+    (see services/workers/tasks.py:4747, 5318). Match on exact
+    `config_id|pred_field|` prefix; using only `metric_id-%` (issue #132)
+    over-attributes across same-metric configs and silently treats one
+    config's rows as another's, masking real missing cells.
+
+    Plain (unprefixed) field names are stored as-is in the field_name's
+    middle slot for BOTH arms — the worker does NOT add a `human:`
+    prefix when writing the annotation-arm row (see worker write sites
+    around services/workers/tasks.py:4747 and 5318 — same composite,
+    distinguished only by whether `generation_id` or `annotation_id` is
+    populated). So a plain pred_field maps to ONE field_name shape but
+    TWO subject_col lookups.
     """
     from models import TaskEvaluation
 
     if pred_field.startswith("human:") or pred_field == "__all_human__":
-        # Annotation-side field. Match the prefixed form on the
-        # annotation_id side only.
-        norm = pred_field
-        subject_col = TaskEvaluation.annotation_id
-    elif pred_field == "__all_model__" or pred_field.startswith("model:"):
-        norm = pred_field
-        subject_col = TaskEvaluation.generation_id
-    else:
-        # Plain — recorded both as `<pf>` (model side) and `human:<pf>`
-        # (annotation side). Run two queries and union.
-        model_done = _scored_for(
-            db, project_id, metric_id=metric_id, pred_field_norm=pred_field,
-            subject_col=TaskEvaluation.generation_id, kind="generation",
-        )
-        human_done = _scored_for(
-            db, project_id, metric_id=metric_id,
-            pred_field_norm=f"human:{pred_field}",
+        return _scored_for(
+            db, project_id, config_id=config_id, pred_field_norm=pred_field,
             subject_col=TaskEvaluation.annotation_id, kind="annotation",
         )
-        return model_done | human_done
-    return _scored_for(
-        db, project_id, metric_id=metric_id, pred_field_norm=norm,
-        subject_col=subject_col,
-        kind="annotation" if subject_col is TaskEvaluation.annotation_id else "generation",
+    if pred_field == "__all_model__" or pred_field.startswith("model:"):
+        return _scored_for(
+            db, project_id, config_id=config_id, pred_field_norm=pred_field,
+            subject_col=TaskEvaluation.generation_id, kind="generation",
+        )
+    # Plain field — stored under the bare name for both arms; distinguish
+    # by which subject_col is populated. Two queries, union.
+    model_done = _scored_for(
+        db, project_id, config_id=config_id, pred_field_norm=pred_field,
+        subject_col=TaskEvaluation.generation_id, kind="generation",
     )
+    human_done = _scored_for(
+        db, project_id, config_id=config_id, pred_field_norm=pred_field,
+        subject_col=TaskEvaluation.annotation_id, kind="annotation",
+    )
+    return model_done | human_done
 
 
 def _scored_for(
-    db: Session, project_id: str, *, metric_id: str, pred_field_norm: str,
+    db: Session, project_id: str, *, config_id: str, pred_field_norm: str,
     subject_col, kind: str,
 ) -> set:
     from models import TaskEvaluation, EvaluationRun
@@ -487,7 +500,7 @@ def _scored_for(
         .join(EvaluationRun, EvaluationRun.id == TaskEvaluation.evaluation_id)
         .filter(
             EvaluationRun.project_id == project_id,
-            TaskEvaluation.field_name.like(f"{metric_id}-%|{pred_field_norm}|%"),
+            TaskEvaluation.field_name.like(f"{config_id}|{pred_field_norm}|%"),
             TaskEvaluation.metrics.isnot(None),
             TaskEvaluation.error_message.is_(None),
             subject_col.isnot(None),
@@ -676,6 +689,10 @@ def estimate_cost(
     # estimate, so we gate on `evaluation_configs` instead.
     subject_count = 0
     if request.mode == "evaluation":
+        # subject_count is the cell pool across the project for display only.
+        # The per-model dollar math goes through _count_evaluation_judge_calls
+        # below (per-judge, missing-aware). Issue #132: this used to drive
+        # pricing and produced a 63x overshoot on partially-covered projects.
         subject_count = _count_eval_subjects(
             db=db,
             project_id=request.project_id,
@@ -683,9 +700,6 @@ def estimate_cost(
             model_ids=request.model_ids or None,
             annotator_user_ids=request.annotator_user_ids,
         )
-    eval_uses_subject_count = (
-        request.mode == "evaluation" and bool(request.evaluation_configs)
-    )
 
     per_model_costs: List[PerModelCost] = []
     total_usd = 0.0
@@ -723,7 +737,6 @@ def estimate_cost(
                 db=db,
                 project_id=request.project_id,
                 judge_model_id=model_id,
-                runs_per_call=request.runs_per_call,
                 generation_mode=request.generation_mode,
             )
             # The judge-call count already factors run_index, so don't
@@ -771,19 +784,14 @@ def estimate_cost(
             (token_est.input_mean / 1000.0) * pricing["input_per_1k"]
             + (token_est.output_estimate / 1000.0) * pricing["output_per_1k"]
         )
-        # Eval mode with explicit configs (issue #69) prices the actual
-        # (subject × prediction_field) cell count. Otherwise, the legacy
-        # cells-based formula applies — for generation that's
-        # `tasks × structure_keys × samples_per_task` (so structure_keys
-        # multiplication from main is preserved); for eval-without-configs
-        # `cells` is `(tasks × run_index)` and the runs multiplier is
-        # already folded in (`runs_already_counted=True`).
-        if eval_uses_subject_count:
-            per_run = per_call * subject_count * request.samples_per_task
-            model_total = per_run * request.runs_per_call
-        else:
-            per_run = per_call * cells * request.samples_per_task
-            model_total = per_run if runs_already_counted else per_run * request.runs_per_call
+        # Eval mode prices the actual missing-aware per-judge cell count
+        # returned by `_count_evaluation_judge_calls` (issue #132). The
+        # per-judge function already folds in this config's per-judge `runs`,
+        # so `runs_already_counted=True` and no global runs multiplier
+        # applies. The legacy cells-based formula still drives the generation
+        # path (`tasks × structure_keys × samples_per_task`).
+        per_run = per_call * cells * request.samples_per_task
+        model_total = per_run if runs_already_counted else per_run * request.runs_per_call
 
         per_model_costs.append(PerModelCost(
             model_id=model_id,
@@ -831,12 +839,14 @@ def estimate_cost(
         "selected_configuration.model_configs, falling back to the project "
         "default." + utilization_note + mode_note + "."
     )
-    if eval_uses_subject_count:
+    if request.mode == "evaluation" and bool(request.evaluation_configs):
         note += (
-            " Eval-mode estimates assume each generation populates every "
-            "prediction_field and price every judge in the ensemble at the "
-            "maximum runs across that ensemble. Sparse fields or asymmetric "
-            "judge run counts can shift the actual cost by ±20–40%."
+            " Eval-mode estimates count cells per-judge, using each config's "
+            "own per-judge `runs` value, and subtract cells that already have "
+            "a successful task_evaluations row under "
+            "`{config_id}|{prediction_field}|...`. Sparse prediction fields "
+            "or generations missing the parsed field can shift the actual "
+            "cost by ±20%."
         )
 
     from datetime import datetime, timezone

--- a/services/api/tests/integration/test_cost_estimate_subject_count.py
+++ b/services/api/tests/integration/test_cost_estimate_subject_count.py
@@ -28,7 +28,15 @@ from typing import Dict, List
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from models import Generation, LLMModel, ResponseGeneration, User
+from models import (
+    EvaluationJudgeRun,
+    EvaluationRun,
+    Generation,
+    LLMModel,
+    ResponseGeneration,
+    TaskEvaluation,
+    User,
+)
 from project_models import Annotation, Project, ProjectOrganization, Task
 
 
@@ -361,6 +369,338 @@ class TestSubjectCount:
             data["expected_generation_count"] + data["expected_annotation_count"]
         )
         assert body["subject_count"] == expected
+
+
+# ---------------------------------------------------------------------------
+# Issue #132 regression helpers and tests
+# ---------------------------------------------------------------------------
+
+
+JUDGE_A = "test-judge-a"
+JUDGE_B = "test-judge-b"
+
+
+def _set_project_judge_configs(
+    test_db: Session, project: Project, configs: List[Dict],
+) -> None:
+    """Set `project.evaluation_config.evaluation_configs` so the cost
+    endpoint's `_load_llm_judge_configs` can find these configs.
+
+    Each config dict needs: id, metric, prediction_fields, judges:[{judge_model_id, runs}].
+    """
+    project.evaluation_config = {"evaluation_configs": configs}
+    test_db.add(project)
+    test_db.commit()
+    test_db.refresh(project)
+
+
+def _seed_scored_cells(
+    test_db: Session,
+    project: Project,
+    judge_model_id: str,
+    *,
+    config_id: str,
+    pred_field: str,
+    reference_field: str = "musterloesung",
+    generation_ids: List[str] = (),
+    annotation_ids: List[str] = (),
+) -> None:
+    """Create EvaluationRun + EvaluationJudgeRun + TaskEvaluation rows
+    that look identical to what the worker writes under
+    `field_name = "{config_id}|{pred_field}|{reference_field}"`.
+
+    The skip-set query in `_already_scored_subjects` filters on this
+    field_name shape, the project_id (via the EvaluationRun join),
+    metrics is not null, and error_message is null.
+    """
+    admin_id = project.created_by
+    eval_run = EvaluationRun(
+        id=str(uuid.uuid4()),
+        project_id=project.id,
+        model_id=judge_model_id,
+        evaluation_type_ids=["llm_judge_falloesung"],
+        metrics={"placeholder": 1.0},
+        status="completed",
+        created_by=admin_id,
+    )
+    test_db.add(eval_run)
+    test_db.flush()
+    judge_run = EvaluationJudgeRun(
+        id=str(uuid.uuid4()),
+        evaluation_id=eval_run.id,
+        judge_model_id=judge_model_id,
+        run_index=0,
+        status="completed",
+    )
+    test_db.add(judge_run)
+    test_db.flush()
+
+    field_name = f"{config_id}|{pred_field}|{reference_field}"
+    # TaskEvaluation has several NOT NULL columns the worker fills in; we
+    # only care that the skip-set query's WHERE clauses are satisfied
+    # (project_id via EvaluationRun join, field_name LIKE pattern, metrics
+    # not null, error_message null, subject_col not null), but the table
+    # constraints still require task_id/answer_type/ground_truth/etc.
+    gen_to_task: Dict[str, str] = dict(
+        test_db.query(Generation.id, Generation.task_id)
+        .filter(Generation.id.in_(list(generation_ids) or ["__none__"]))
+        .all()
+    )
+    ann_to_task: Dict[str, str] = dict(
+        test_db.query(Annotation.id, Annotation.task_id)
+        .filter(Annotation.id.in_(list(annotation_ids) or ["__none__"]))
+        .all()
+    )
+    for gid in generation_ids:
+        test_db.add(TaskEvaluation(
+            id=str(uuid.uuid4()),
+            evaluation_id=eval_run.id,
+            judge_run_id=judge_run.id,
+            task_id=gen_to_task[gid],
+            generation_id=gid,
+            field_name=field_name,
+            answer_type="long_text",
+            ground_truth={},
+            prediction={},
+            passed=True,
+            metrics={"llm_judge_falloesung": {"value": 0.8, "error": None}},
+            error_message=None,
+        ))
+    for aid in annotation_ids:
+        test_db.add(TaskEvaluation(
+            id=str(uuid.uuid4()),
+            evaluation_id=eval_run.id,
+            judge_run_id=judge_run.id,
+            task_id=ann_to_task[aid],
+            annotation_id=aid,
+            field_name=field_name,
+            answer_type="long_text",
+            ground_truth={},
+            prediction={},
+            passed=True,
+            metrics={"llm_judge_falloesung": {"value": 0.7, "error": None}},
+            error_message=None,
+        ))
+    test_db.commit()
+
+
+def _per_model_cells(body: Dict, judge_id: str) -> int:
+    """Pluck the `cells_to_generate` for a specific judge from the response."""
+    rows = [m for m in body["per_model"] if m["model_id"] == judge_id]
+    assert rows, f"judge {judge_id} not in per_model: {body['per_model']}"
+    return rows[0]["cells_to_generate"]
+
+
+class TestEvaluationJudgeCalls:
+    """Issue #132: `_count_evaluation_judge_calls` regression tests.
+
+    These pin the per-judge cell-count behavior that drives the dollar
+    figure. Pre-fix the estimator over-counted by ~63x on partially-
+    covered projects; each test below kills one defect.
+    """
+
+    def test_missing_subtracts_per_config(
+        self, client, test_db, test_users, test_org, auth_headers
+    ):
+        """Defect 3: skip-set must key off `config_id`, not metric prefix.
+        Two configs share the same metric; one is fully covered, the new
+        one is empty. The covered config's cells must NOT be credited to
+        the new config.
+        """
+        _seed_judge_pricing(test_db, JUDGE_A)
+        data = _seed_project_with_subjects(test_db, test_users, test_org)
+        covered_cfg_id = "llm_judge_falloesung-covered-aaa"
+        new_cfg_id = "llm_judge_falloesung-new-bbb"
+        _set_project_judge_configs(test_db, data["project"], [
+            {
+                "id": covered_cfg_id,
+                "enabled": True,
+                "metric": "llm_judge_falloesung",
+                "prediction_fields": ["__all_model__"],
+                "metric_parameters": {"judges": [{"judge_model_id": JUDGE_A, "runs": 1}]},
+            },
+            {
+                "id": new_cfg_id,
+                "enabled": True,
+                "metric": "llm_judge_falloesung",
+                "prediction_fields": ["__all_model__"],
+                "metric_parameters": {"judges": [{"judge_model_id": JUDGE_A, "runs": 1}]},
+            },
+        ])
+        # Cover every generation under the covered config only.
+        all_gen_ids = [g.id for g in test_db.query(Generation).join(
+            Task, Generation.task_id == Task.id
+        ).filter(Task.project_id == data["project"].id).all()]
+        _seed_scored_cells(
+            test_db, data["project"], JUDGE_A,
+            config_id=covered_cfg_id, pred_field="__all_model__",
+            generation_ids=all_gen_ids,
+        )
+
+        body = _post_estimate(
+            client, auth_headers,
+            project_id=data["project"].id,
+            mode="evaluation",
+            judge_models=[JUDGE_A],
+            generation_mode="missing",
+            runs_per_call=1,
+            evaluation_configs=[{
+                "metric": "llm_judge_falloesung",
+                "prediction_fields": ["__all_model__"],
+            }],
+        )
+        # Pre-fix: skip-set matched both configs via metric_id wildcard, so
+        # `new_cfg`'s subjects also looked "done" — missing reported 0,
+        # under-counting. Post-fix: covered_cfg subtracts only its own rows
+        # (0 missing), new_cfg subtracts nothing (full pool missing).
+        # Total cells = 0 (covered) + N_gens (new) = N_gens.
+        assert _per_model_cells(body, JUDGE_A) == data["expected_generation_count"]
+
+    def test_bare_pred_field_subtracts_both_arms(
+        self, client, test_db, test_users, test_org, auth_headers
+    ):
+        """Defect 3 sub: bare prediction_field rows are stored under the
+        same composite for both arms (`{cfg}|loesung|...`), distinguished
+        by which subject_col is populated. Pre-fix the human-arm subquery
+        looked up `human:loesung` which the worker never writes, so
+        annotation rows under bare-field configs never got subtracted.
+        """
+        _seed_judge_pricing(test_db, JUDGE_A)
+        data = _seed_project_with_subjects(test_db, test_users, test_org)
+        cfg_id = "llm_judge_falloesung-bare-ccc"
+        _set_project_judge_configs(test_db, data["project"], [
+            {
+                "id": cfg_id,
+                "enabled": True,
+                "metric": "llm_judge_falloesung",
+                "prediction_fields": ["loesung"],
+                "metric_parameters": {"judges": [{"judge_model_id": JUDGE_A, "runs": 1}]},
+            },
+        ])
+        all_gen_ids = [g.id for g in test_db.query(Generation).join(
+            Task, Generation.task_id == Task.id
+        ).filter(Task.project_id == data["project"].id).all()]
+        all_ann_ids = [
+            a.id for a in test_db.query(Annotation).filter(
+                Annotation.project_id == data["project"].id,
+                Annotation.was_cancelled == False,  # noqa: E712
+            ).all()
+        ]
+        # Bare-field: worker writes both arms under the same field_name shape.
+        _seed_scored_cells(
+            test_db, data["project"], JUDGE_A,
+            config_id=cfg_id, pred_field="loesung",
+            generation_ids=all_gen_ids, annotation_ids=all_ann_ids,
+        )
+
+        body = _post_estimate(
+            client, auth_headers,
+            project_id=data["project"].id,
+            mode="evaluation",
+            judge_models=[JUDGE_A],
+            generation_mode="missing",
+            runs_per_call=1,
+            evaluation_configs=[{
+                "metric": "llm_judge_falloesung",
+                "prediction_fields": ["loesung"],
+            }],
+        )
+        # Both arms covered → missing should be 0.
+        assert _per_model_cells(body, JUDGE_A) == 0
+
+    def test_per_config_runs_not_inflated_by_other_configs(
+        self, client, test_db, test_users, test_org, auth_headers
+    ):
+        """Defect 2: each config's per-judge `runs` is applied locally.
+        Pre-fix the request-level `runs_per_call` (a global max across
+        all selected configs) multiplied every config's per-judge runs,
+        so a `runs:1` config sitting next to a `runs:3` config was billed
+        at 1×3=3.
+        """
+        _seed_judge_pricing(test_db, JUDGE_A)
+        cfg_runs1 = "llm_judge_falloesung-runs1-ddd"
+        cfg_runs3 = "llm_judge_falloesung-runs3-eee"
+        data = _seed_project_with_subjects(test_db, test_users, test_org)
+        _set_project_judge_configs(test_db, data["project"], [
+            {
+                "id": cfg_runs1,
+                "enabled": True,
+                "metric": "llm_judge_falloesung",
+                "prediction_fields": ["__all_model__"],
+                "metric_parameters": {"judges": [{"judge_model_id": JUDGE_A, "runs": 1}]},
+            },
+            {
+                "id": cfg_runs3,
+                "enabled": True,
+                "metric": "llm_judge_falloesung",
+                "prediction_fields": ["__all_model__"],
+                "metric_parameters": {"judges": [{"judge_model_id": JUDGE_A, "runs": 3}]},
+            },
+        ])
+
+        body = _post_estimate(
+            client, auth_headers,
+            project_id=data["project"].id,
+            mode="evaluation",
+            judge_models=[JUDGE_A],
+            # Frontend sends the global max — backend must IGNORE this in
+            # the eval-with-configs branch and use each cfg's own runs.
+            runs_per_call=3,
+            evaluation_configs=[{
+                "metric": "llm_judge_falloesung",
+                "prediction_fields": ["__all_model__"],
+            }],
+        )
+        n = data["expected_generation_count"]
+        # Pre-fix: (cfg_runs1: n × 1 × 3) + (cfg_runs3: n × 3 × 3) = 12n.
+        # Post-fix: (cfg_runs1: n × 1) + (cfg_runs3: n × 3) = 4n.
+        assert _per_model_cells(body, JUDGE_A) == 4 * n
+
+    def test_judge_only_charged_for_configs_naming_it(
+        self, client, test_db, test_users, test_org, auth_headers
+    ):
+        """Defect 1: per-judge dollar math must route through
+        `_count_evaluation_judge_calls`, not `_count_eval_subjects`.
+        Pre-fix every judge was billed for the full subject_count across
+        all configs, regardless of whether the judge appeared in them.
+        """
+        _seed_judge_pricing(test_db, JUDGE_A)
+        _seed_judge_pricing(test_db, JUDGE_B)
+        data = _seed_project_with_subjects(test_db, test_users, test_org)
+        cfg_a = "llm_judge_falloesung-onlyA-fff"
+        cfg_b = "llm_judge_falloesung-onlyB-ggg"
+        _set_project_judge_configs(test_db, data["project"], [
+            {
+                "id": cfg_a,
+                "enabled": True,
+                "metric": "llm_judge_falloesung",
+                "prediction_fields": ["__all_model__"],
+                "metric_parameters": {"judges": [{"judge_model_id": JUDGE_A, "runs": 1}]},
+            },
+            {
+                "id": cfg_b,
+                "enabled": True,
+                "metric": "llm_judge_falloesung",
+                "prediction_fields": ["__all_model__"],
+                "metric_parameters": {"judges": [{"judge_model_id": JUDGE_B, "runs": 1}]},
+            },
+        ])
+        body = _post_estimate(
+            client, auth_headers,
+            project_id=data["project"].id,
+            mode="evaluation",
+            judge_models=[JUDGE_A, JUDGE_B],
+            runs_per_call=1,
+            evaluation_configs=[{
+                "metric": "llm_judge_falloesung",
+                "prediction_fields": ["__all_model__"],
+            }],
+        )
+        n = data["expected_generation_count"]
+        # Each judge appears in exactly one config of size n. Pre-fix both
+        # judges saw 2n (the union). Post-fix each sees n.
+        assert _per_model_cells(body, JUDGE_A) == n
+        assert _per_model_cells(body, JUDGE_B) == n
 
 
 class TestRequestValidation:

--- a/services/frontend/src/components/shared/CostEstimatePanel.tsx
+++ b/services/frontend/src/components/shared/CostEstimatePanel.tsx
@@ -218,10 +218,13 @@ export function CostEstimatePanel({
               // actual cell count; surface that instead of the project-wide
               // task count so the breakdown matches the dollar number.
               if (estimate.subject_count > 0) {
-                const tpl = t('costEstimate.breakdownCells', '{cells} Zellen × {runs} Lauf/Läufe × {models} Modell(e)')
+                // Runs are folded per-judge into the backend's per-model cell
+                // count (issue #132), so we no longer surface a separate
+                // "× runs" multiplier — it would mislead about how the dollar
+                // figure is composed.
+                const tpl = t('costEstimate.breakdownCells', '{cells} Zellen über {models} Judge-Modell(e)')
                 return String(tpl)
                   .replace('{cells}', String(estimate.subject_count))
-                  .replace('{runs}', String(estimate.runs_per_call))
                   .replace('{models}', String(estimate.per_model.length))
               }
               const tpl = t('costEstimate.breakdown', '{tasks} Tasks × {runs} Lauf/Läufe × {models} Modell(e)')

--- a/services/frontend/src/locales/de/common.json
+++ b/services/frontend/src/locales/de/common.json
@@ -8275,7 +8275,7 @@
     "loading": "Tokens zählen und Preise ermitteln…",
     "totalLabel": "Geschätzte Gesamtkosten",
     "breakdown": "{tasks} Tasks × {runs} Lauf/Läufe × {models} Modell(e)",
-    "breakdownCells": "{cells} Zellen × {runs} Lauf/Läufe × {models} Modell(e)",
+    "breakdownCells": "{cells} Zellen über {models} Judge-Modell(e)",
     "estimatedAt": "Berechnet um {time}",
     "modelCol": "Modell",
     "perCallCol": "Pro Aufruf",

--- a/services/frontend/src/locales/en/common.json
+++ b/services/frontend/src/locales/en/common.json
@@ -8285,7 +8285,7 @@
     "loading": "Counting tokens and resolving prices…",
     "totalLabel": "Estimated total cost",
     "breakdown": "{tasks} tasks × {runs} run/runs × {models} model(s)",
-    "breakdownCells": "{cells} cells × {runs} run/runs × {models} model(s)",
+    "breakdownCells": "{cells} cells across {models} judge model(s)",
     "estimatedAt": "Computed at {time}",
     "modelCol": "Model",
     "perCallCol": "Per call",


### PR DESCRIPTION
Closes #132.

## Summary

The Kostenschätzung panel was showing **\$1473.66** for an evaluate-missing-only trigger on a project whose actual cost ran **\$23.39** — a 63× overshoot. The displayed estimate is the only signal users get before clicking through, so a 63× error makes the panel un-actionable. Three interacting defects in `services/api/routers/cost_estimate.py`:

### Defect 1 — Wrong function drove the dollar math
`estimate_cost` called `_count_evaluation_judge_calls` per judge (per-judge, missing-aware) but only used its return for the display field `cells`. The actual dollar formula at lines 781–783 multiplied by `subject_count` from `_count_eval_subjects`, which sums cells across **all configs** ignoring (a) which judges those configs name and (b) whether the cells already have task_evaluations rows. So every judge model got billed for the union of every config's cell pool.

### Defect 2 — `runs_per_call` applied a second time globally
Line 783 multiplied the eval-mode total by `request.runs_per_call`, which the frontend (`EvaluationControlModal.tsx:100–125`) derives as `max(judges.runs across all selected configs)`. A config with `runs:1` paired with another config carrying `runs:3` ended up priced at 1×3=3.

### Defect 3 — Skip-set lookup over-attributed across same-metric configs
`_scored_for` matched `field_name LIKE '{metric_id}-%|{pred_field}|%'`. Worker writes are `field_name = "{config_id}|{pred_field}|{ref_field}"`, so the metric-prefix wildcard cross-matched every config of the same metric. Sub-variant: bare prediction_fields had the annotation-arm subquery look up `human:{pred_field}`, but the worker writes both arms under the **same** composite key distinguished only by which subject_col is populated — so annotation rows under bare-field configs never subtracted.

## What changes

Single file in the backend (`services/api/routers/cost_estimate.py`):
- Route the eval-with-configs dollar math through `_count_evaluation_judge_calls`. `subject_count` stays on the response (display only).
- `_load_llm_judge_configs` now returns the config's `id`.
- `_already_scored_subjects` / `_scored_for` take `config_id` (exact match) instead of `metric_id` prefix. Bare-field branch uses the same `pred_field_norm` for both arms.
- `runs_per_call` removed from `_count_evaluation_judge_calls` (each config's own `runs` applies); request field stays for backward compat / generation mode.
- Disclaimer text updated.

Frontend:
- `services/frontend/src/components/shared/CostEstimatePanel.tsx`: drop the `× {runs}` multiplier from the cells-row breakdown (runs are folded per-judge into the backend's per-model cells count).
- `services/frontend/src/locales/{de,en}/common.json`: rewrite `costEstimate.breakdownCells`.

`EvaluationControlModal.tsx`'s `costRunsPerCall` derivation is now dead code in the eval branch but harmless — leaving the cleanup as a follow-up.

## Test plan

Added 4 integration regression tests in `services/api/tests/integration/test_cost_estimate_subject_count.py`:
- [x] `test_missing_subtracts_per_config` — Defect 3 regression
- [x] `test_bare_pred_field_subtracts_both_arms` — Defect 3 sub-variant
- [x] `test_per_config_runs_not_inflated_by_other_configs` — Defect 2 regression
- [x] `test_judge_only_charged_for_configs_naming_it` — Defect 1 regression

Manual verification post-deploy:
- [ ] Open EvaluationControlModal on the benchathon project. All configs fully covered. "Evaluate missing only" → estimate should be near-\$0 (pre-fix was \$1473.66).
- [ ] On a project with a partial coverage gap, the estimate should equal `sum(missing_cells_per_judge × per_call_cost_for_that_judge)`, validated against the actual `task_evaluations` row count after a real run.

CI on this PR only runs Frontend Tests + Python Lint per repo policy; the new pytest tests run via `make test-api` on the self-hosted runner.