### PR TITLE
perf(export): stream all formats + structured logging (fix Benchathon OOM truncation)

### DIFF
--- a/services/api/routers/projects/_export_stream.py
+++ b/services/api/routers/projects/_export_stream.py
@@ -1,0 +1,996 @@
+"""Shared streaming helpers for project JSON exports.
+
+Used by both `GET /api/projects/{project_id}/export?format=json` and
+`POST /api/projects/{project_id}/tasks/bulk-export?format=json`. Past
+revisions of the GET handler loaded the entire project (tasks, annotations,
+generations, task_evaluations, korrektur_comments, human-eval blocks) into
+one nested Python dict and then `json.dumps(..., indent=2)`-ed it — that
+peaked at ~3x the row-set's RAM and OOMKilled the API pod on 2026-05-31
+when the Benchathon project (~8k task_evaluations / 400 MB of JSON) was
+exported.
+
+The generator below streams the same JSON tree out chunk-by-chunk and uses
+`yield_per` + batched IN-queries so peak memory stays bounded by
+BATCH_SIZE regardless of project size. The existing
+POST /tasks/bulk-export already used this pattern (commits 7c61a79,
+0ae2be0); this module extracts it so the single-project GET can share it
+without duplicating the row-fetching, batching, and JSON-splicing logic.
+"""
+from __future__ import annotations
+
+import csv
+import io
+import json
+from datetime import datetime
+from typing import Iterable, Iterator, Optional
+
+from sqlalchemy.orm import Session
+
+from models import (
+    EvaluationRun,
+    EvaluationRunMetric,
+    Generation,
+    HumanEvaluationConfig,
+    HumanEvaluationResult,
+    HumanEvaluationSession,
+    LikertScaleEvaluation,
+    PreferenceRanking,
+    ResponseGeneration,
+    TaskEvaluation,
+    User,
+)
+from project_models import (
+    Annotation,
+    KorrekturComment,
+    PostAnnotationResponse,
+    Project,
+    ProjectMember,
+    ProjectOrganization,
+    Task,
+    TaskAssignment,
+)
+from routers.projects.serializers import (
+    build_evaluation_indexes,
+    build_judge_model_lookup,
+    serialize_annotation,
+    serialize_evaluation_run,
+    serialize_generation,
+    serialize_human_evaluation_data,
+    serialize_korrektur_comment,
+    serialize_task,
+    serialize_task_evaluation,
+)
+from sqlalchemy import func as sa_func
+from sqlalchemy import select
+
+BATCH_SIZE = 50
+
+
+def build_batch_objs(
+    db: Session,
+    batch: list,
+    eval_run_by_id: dict,
+    judge_model_lookup: dict,
+) -> list[dict]:
+    """Build per-task export dicts for a batch with 4 batched IN-queries
+    (annotations, questionnaire responses, generations, task_evaluations)
+    instead of 4 queries per task. For a 581-task project this collapses
+    ~2,300 round-trips to ~48.
+    """
+    if not batch:
+        return []
+    batch_ids = [t.id for t in batch]
+
+    anns_all = db.query(Annotation).filter(Annotation.task_id.in_(batch_ids)).all()
+    qrs_all = db.query(PostAnnotationResponse).filter(
+        PostAnnotationResponse.task_id.in_(batch_ids)
+    ).all()
+    gens_all = db.query(Generation).filter(Generation.task_id.in_(batch_ids)).all()
+    if eval_run_by_id:
+        te_all = db.query(TaskEvaluation).filter(
+            TaskEvaluation.task_id.in_(batch_ids),
+            TaskEvaluation.evaluation_id.in_(eval_run_by_id.keys()),
+        ).all()
+    else:
+        te_all = []
+
+    anns_by_task: dict = {}
+    for a in anns_all:
+        anns_by_task.setdefault(a.task_id, []).append(a)
+    qr_by_annotation = {qr.annotation_id: qr for qr in qrs_all}
+    gens_by_task: dict = {}
+    for g in gens_all:
+        gens_by_task.setdefault(g.task_id, []).append(g)
+    te_by_task_id, te_by_gen_id = build_evaluation_indexes(te_all)
+
+    out = []
+    for task in batch:
+        task_data = serialize_task(task, mode="data")
+        task_data["annotations"] = [
+            serialize_annotation(
+                ann, mode="data", questionnaire_response=qr_by_annotation.get(ann.id)
+            )
+            for ann in anns_by_task.get(task.id, [])
+        ]
+        task_data["generations"] = []
+        for gen in gens_by_task.get(task.id, []):
+            gen_evals = te_by_gen_id.get(gen.id, [])
+            eval_dicts = [
+                serialize_task_evaluation(
+                    te, mode="data",
+                    eval_run=eval_run_by_id.get(te.evaluation_id),
+                    judge_model_lookup=judge_model_lookup,
+                )
+                for te in gen_evals
+            ]
+            task_data["generations"].append(
+                serialize_generation(gen, mode="data", evaluations=eval_dicts)
+            )
+
+        task_data["evaluations"] = []
+        for te in te_by_task_id.get(task.id, []):
+            if te.generation_id is not None:
+                continue
+            task_data["evaluations"].append(
+                serialize_task_evaluation(
+                    te, mode="data",
+                    eval_run=eval_run_by_id.get(te.evaluation_id),
+                    judge_model_lookup=judge_model_lookup,
+                )
+            )
+        out.append(task_data)
+    return out
+
+
+def stream_export_json(
+    db: Session,
+    project_id: str,
+    task_ids: Optional[Iterable[str]],
+    header_fields: dict,
+) -> Iterator[str]:
+    """Yield a complete JSON export as string chunks.
+
+    `header_fields` becomes the top-level keys preceding the streamed
+    blocks. The bulk-export endpoint passes a flat
+    {project_id, project_title, exported_at} dict; the single-project GET
+    passes the richer {"project": {...metadata...}} shape its existing
+    consumers expect — both round-trip because we splice via string
+    surgery (`json.dumps(header)[:-1]` drops the closing `}` so we can
+    append more keys).
+
+    Passing `task_ids=None` exports every task in the project; otherwise
+    only the specified subset is included. The eval_runs / korrektur
+    blocks are always project-wide; human-eval is filtered to the same
+    task set we end up streaming.
+    """
+    eval_runs = db.query(EvaluationRun).filter(
+        EvaluationRun.project_id == project_id
+    ).all()
+    eval_run_by_id = {er.id: er for er in eval_runs}
+    judge_model_lookup = build_judge_model_lookup(eval_runs, db)
+
+    header = dict(header_fields)
+    header["evaluation_runs"] = [
+        serialize_evaluation_run(er, mode="data") for er in eval_runs
+    ]
+    yield json.dumps(header)[:-1] + ', "tasks": ['
+
+    first = True
+    task_q = db.query(Task).filter(Task.project_id == project_id)
+    if task_ids is not None:
+        task_q = task_q.filter(Task.id.in_(list(task_ids)))
+
+    batch: list = []
+    streamed_task_ids: list = []
+    for task in task_q.yield_per(BATCH_SIZE):
+        batch.append(task)
+        streamed_task_ids.append(task.id)
+        if len(batch) >= BATCH_SIZE:
+            for obj in build_batch_objs(db, batch, eval_run_by_id, judge_model_lookup):
+                yield ("" if first else ",") + json.dumps(obj)
+                first = False
+            batch = []
+    for obj in build_batch_objs(db, batch, eval_run_by_id, judge_model_lookup):
+        yield ("" if first else ",") + json.dumps(obj)
+        first = False
+
+    yield "], "
+
+    human_eval = serialize_human_evaluation_data(db, project_id, streamed_task_ids) or {}
+    items = list(human_eval.items())
+    for idx, (k, v) in enumerate(items):
+        yield json.dumps(k) + ":" + json.dumps(v)
+        if idx < len(items) - 1:
+            yield ","
+    if items:
+        yield ","
+
+    yield '"korrektur_comments": ['
+    first = True
+    kc_q = db.query(KorrekturComment).filter(KorrekturComment.project_id == project_id)
+    for kc in kc_q.yield_per(100):
+        yield ("" if first else ",") + json.dumps(serialize_korrektur_comment(kc))
+        first = False
+    yield "]}"
+
+
+# Per-row column layout used by GET /{project_id}/export?format=csv|tsv.
+# Each task fans out to max(annotations, generations, evaluations, 1) rows,
+# matching the legacy in-memory CSV builder's shape so existing test
+# assertions (`task_id`, `annotation_id`, `generation_id` in header) and any
+# downstream parsers keep working.
+EXPORT_FLAT_CSV_COLUMNS: list[str] = [
+    "task_id",
+    "task_data",
+    "annotation_id",
+    "annotation_result",
+    "annotation_completed_by",
+    "annotation_created_at",
+    "questionnaire_response",
+    "generation_id",
+    "generation_model",
+    "generation_content",
+    "generation_created_at",
+    "evaluation_field",
+    "evaluation_metrics",
+    "evaluation_passed",
+]
+
+
+def stream_export_flat_csv(
+    db: Session,
+    project_id: str,
+    delimiter: str,
+) -> Iterator[str]:
+    """Yield a flat per-row CSV/TSV export as string chunks.
+
+    Mirrors the legacy `GET /{project_id}/export?format=csv|tsv` shape:
+    one header row, then max(N_anns, N_gens, N_evals, 1) rows per task,
+    columns lined up positionally so each row carries at most one of each
+    sub-entity. Uses the same batched IN-queries as the JSON stream so
+    peak memory stays bounded by BATCH_SIZE regardless of project size.
+    """
+    eval_runs = db.query(EvaluationRun).filter(
+        EvaluationRun.project_id == project_id
+    ).all()
+    eval_run_by_id = {er.id: er for er in eval_runs}
+    judge_model_lookup = build_judge_model_lookup(eval_runs, db)
+
+    buf = io.StringIO()
+    writer = csv.writer(buf, delimiter=delimiter)
+    writer.writerow(EXPORT_FLAT_CSV_COLUMNS)
+    yield buf.getvalue()
+    buf.seek(0); buf.truncate()
+
+    def _emit_rows(task_obj: dict) -> str:
+        anns = task_obj.get("annotations") or []
+        gens = task_obj.get("generations") or []
+        evals = task_obj.get("evaluations") or []
+        max_items = max(len(anns), len(gens), len(evals), 1)
+        for i in range(max_items):
+            ann = anns[i] if i < len(anns) else None
+            gen = gens[i] if i < len(gens) else None
+            ev = evals[i] if i < len(evals) else None
+            writer.writerow([
+                task_obj["id"],
+                json.dumps(task_obj.get("data")),
+                ann["id"] if ann else "",
+                json.dumps(ann["result"]) if ann else "",
+                ann["completed_by"] if ann else "",
+                ann["created_at"] if ann else "",
+                (
+                    json.dumps(ann["questionnaire_response"])
+                    if ann and ann.get("questionnaire_response")
+                    else ""
+                ),
+                gen["id"] if gen else "",
+                gen.get("model_id") if gen else "",
+                gen.get("response_content") if gen else "",
+                gen.get("created_at") if gen else "",
+                ev["field_name"] if ev else "",
+                json.dumps(ev["metrics"]) if ev else "",
+                ev["passed"] if ev else "",
+            ])
+        chunk = buf.getvalue()
+        buf.seek(0); buf.truncate()
+        return chunk
+
+    task_q = db.query(Task).filter(Task.project_id == project_id)
+    batch: list = []
+    for task in task_q.yield_per(BATCH_SIZE):
+        batch.append(task)
+        if len(batch) >= BATCH_SIZE:
+            for obj in build_batch_objs(db, batch, eval_run_by_id, judge_model_lookup):
+                yield _emit_rows(obj)
+            batch = []
+    for obj in build_batch_objs(db, batch, eval_run_by_id, judge_model_lookup):
+        yield _emit_rows(obj)
+
+
+def stream_export_label_studio(
+    db: Session,
+    project_id: str,
+) -> Iterator[str]:
+    """Yield a Label Studio JSON array as string chunks, one task per element.
+
+    Schema matches what the legacy in-memory branch emitted: Label Studio's
+    task object (id, data, annotations[], predictions[], meta, created/updated,
+    is_labeled, project) plus BenGER extensions `generations` and
+    `evaluations`. Span-typed annotation results go through
+    `convert_to_label_studio_format` so the spans round-trip back into
+    Label Studio's UI.
+
+    Uses a smaller `LS_BATCH_SIZE` than the JSON/CSV paths because each LS
+    batch's IN-query against TaskEvaluation pulls every eval for every task
+    in the batch, with no opportunity to filter further (legacy callers
+    expect both task-level and gen-level evals on the LS task object). For
+    Benchathon-sized projects, a 50-task batch would yank ~40k eval rows in
+    one shot and OOMKilled the API pod; 5-task batches keep peak well under
+    the container limit.
+    """
+    from routers.projects.import_export import convert_to_label_studio_format
+
+    LS_BATCH_SIZE = 5
+
+    eval_runs = db.query(EvaluationRun).filter(
+        EvaluationRun.project_id == project_id
+    ).all()
+    eval_run_by_id = {er.id: er for er in eval_runs}
+
+    yield "["
+    first = True
+
+    task_q = db.query(Task).filter(Task.project_id == project_id)
+    batch: list = []
+
+    def _build_ls_objs(task_batch: list) -> list[str]:
+        if not task_batch:
+            return []
+        batch_ids = [t.id for t in task_batch]
+        anns_all = db.query(Annotation).filter(
+            Annotation.task_id.in_(batch_ids)
+        ).all()
+        qrs_all = db.query(PostAnnotationResponse).filter(
+            PostAnnotationResponse.task_id.in_(batch_ids)
+        ).all()
+        gens_all = db.query(Generation).filter(
+            Generation.task_id.in_(batch_ids)
+        ).all()
+        if eval_run_by_id:
+            te_all = db.query(TaskEvaluation).filter(
+                TaskEvaluation.task_id.in_(batch_ids),
+                TaskEvaluation.evaluation_id.in_(eval_run_by_id.keys()),
+            ).all()
+        else:
+            te_all = []
+
+        anns_by_task: dict = {}
+        for a in anns_all:
+            anns_by_task.setdefault(a.task_id, []).append(a)
+        qr_by_annotation = {qr.annotation_id: qr for qr in qrs_all}
+        gens_by_task: dict = {}
+        for g in gens_all:
+            gens_by_task.setdefault(g.task_id, []).append(g)
+        # Legacy LS export emits every task_evaluation (both task- and
+        # gen-level) into the task's `evaluations` array; mirror that here.
+        te_by_task: dict = {}
+        for te in te_all:
+            te_by_task.setdefault(te.task_id, []).append(te)
+
+        out: list[str] = []
+        for task in task_batch:
+            ls_task = {
+                "id": task.inner_id or task.id,
+                "data": task.data,
+                "annotations": [],
+                "predictions": [],
+                "meta": task.meta or {},
+                "created_at": task.created_at.isoformat() if task.created_at else None,
+                "updated_at": task.updated_at.isoformat() if task.updated_at else None,
+                "is_labeled": task.is_labeled,
+                "project": project_id,
+            }
+            for ann in anns_by_task.get(task.id, []):
+                converted_result = convert_to_label_studio_format(ann.result)
+                ls_ann = {
+                    "id": ann.id,
+                    "completed_by": ann.completed_by,
+                    "result": converted_result,
+                    "was_cancelled": ann.was_cancelled,
+                    "ground_truth": ann.ground_truth,
+                    "created_at": ann.created_at.isoformat() if ann.created_at else None,
+                    "updated_at": ann.updated_at.isoformat() if ann.updated_at else None,
+                    "lead_time": ann.lead_time,
+                    "task": task.inner_id or task.id,
+                    "project": project_id,
+                }
+                if ann.draft:
+                    ls_ann["draft"] = ann.draft
+                if ann.prediction_scores:
+                    ls_ann["prediction"] = ann.prediction_scores
+                qr = qr_by_annotation.get(ann.id)
+                if qr:
+                    ls_ann["questionnaire_response"] = {
+                        "result": qr.result,
+                        "created_at": qr.created_at.isoformat() if qr.created_at else None,
+                    }
+                ls_task["annotations"].append(ls_ann)
+
+            task_gens = gens_by_task.get(task.id, [])
+            if task_gens:
+                ls_task["generations"] = [
+                    {
+                        "id": gen.id,
+                        "model_id": gen.model_id,
+                        "response_content": gen.response_content,
+                        "case_data": gen.case_data,
+                        "created_at": (
+                            gen.created_at.isoformat() if gen.created_at else None
+                        ),
+                        "response_metadata": gen.response_metadata,
+                    }
+                    for gen in task_gens
+                ]
+            task_evals_list = te_by_task.get(task.id, [])
+            if task_evals_list:
+                ls_task["evaluations"] = [
+                    {
+                        "id": te.id,
+                        "evaluation_id": te.evaluation_id,
+                        "generation_id": te.generation_id,
+                        "field_name": te.field_name,
+                        "answer_type": te.answer_type,
+                        "ground_truth": te.ground_truth,
+                        "prediction": te.prediction,
+                        "metrics": te.metrics,
+                        "passed": te.passed,
+                        "confidence_score": te.confidence_score,
+                        "created_at": (
+                            te.created_at.isoformat() if te.created_at else None
+                        ),
+                    }
+                    for te in task_evals_list
+                ]
+            out.append(json.dumps(ls_task, ensure_ascii=False))
+        return out
+
+    for task in task_q.yield_per(LS_BATCH_SIZE):
+        batch.append(task)
+        if len(batch) >= LS_BATCH_SIZE:
+            for chunk in _build_ls_objs(batch):
+                yield ("" if first else ",") + chunk
+                first = False
+            batch = []
+    for chunk in _build_ls_objs(batch):
+        yield ("" if first else ",") + chunk
+        first = False
+
+    yield "]"
+
+
+def stream_export_txt(
+    db: Session,
+    project_id: str,
+    project_title: str,
+    project_description: Optional[str],
+) -> Iterator[str]:
+    """Yield the legacy plain-text export summary as string chunks.
+
+    Header carries project metadata and totals; each task contributes a
+    short section listing its data dict, annotations (with optional
+    questionnaire result), and evaluations. The totals match what
+    `.count()` reports, not what the per-batch stream sees — those are
+    identical for the project-wide export but kept explicit so the txt
+    summary doesn't drift if the helper later gains a task subset.
+    """
+    eval_runs = db.query(EvaluationRun).filter(
+        EvaluationRun.project_id == project_id
+    ).all()
+    eval_run_by_id = {er.id: er for er in eval_runs}
+    judge_model_lookup = build_judge_model_lookup(eval_runs, db)
+
+    task_count = db.query(Task).filter(Task.project_id == project_id).count()
+    annotation_count = (
+        db.query(Annotation).filter(Annotation.project_id == project_id).count()
+    )
+
+    yield f"Project: {project_title}\n"
+    yield f"Description: {project_description or 'None'}\n"
+    yield f"Total Tasks: {task_count}\n"
+    yield f"Total Annotations: {annotation_count}\n"
+    yield "-" * 50 + "\n"
+
+    task_q = db.query(Task).filter(Task.project_id == project_id)
+    batch: list = []
+    for task in task_q.yield_per(BATCH_SIZE):
+        batch.append(task)
+        if len(batch) >= BATCH_SIZE:
+            for obj in build_batch_objs(db, batch, eval_run_by_id, judge_model_lookup):
+                yield _format_task_txt(obj)
+            batch = []
+    for obj in build_batch_objs(db, batch, eval_run_by_id, judge_model_lookup):
+        yield _format_task_txt(obj)
+
+
+def stream_comprehensive_project_data_json(
+    db: Session,
+    project_id: str,
+) -> Iterator[str]:
+    """Streaming sibling of `routers.projects.helpers.get_comprehensive_project_data`.
+
+    Yields the same JSON shape the helper returns (same top-level keys, same
+    per-row field structure) but in chunks, so the full clone payload never
+    lives in RAM simultaneously. Used by POST /bulk-export-full to keep the
+    per-project peak bounded — Benchathon-sized projects (~11k task_evaluations
+    in `mode='full'`) would otherwise OOMKill the API pod the moment the
+    helper finished building its dict.
+
+    Heavy sections (tasks / annotations / generations / task_evaluations) use
+    `yield_per` + per-row `json.dumps` so peak RAM scales with one row, not the
+    set. Small sections (configs, sessions, members, etc.) load with `.all()`
+    and serialize once — they're tiny in practice. `users` is computed at the
+    end from refs collected during the stream, and `statistics` is the
+    running counters.
+    """
+    project = db.query(Project).filter(Project.id == project_id).first()
+    if not project:
+        raise ValueError(f"Project {project_id!r} not found")
+
+    org_row = (
+        db.query(ProjectOrganization.organization_id)
+        .filter(ProjectOrganization.project_id == project.id)
+        .first()
+    )
+    project_data = {
+        "id": project.id,
+        "title": project.title,
+        "description": project.description,
+        "label_config": project.label_config,
+        "expert_instruction": project.expert_instruction,
+        "show_instruction": project.show_instruction,
+        "show_skip_button": project.show_skip_button,
+        "enable_empty_annotation": project.enable_empty_annotation,
+        "created_by": project.created_by,
+        "organization_id": org_row[0] if org_row else None,
+        "min_annotations_per_task": project.min_annotations_per_task,
+        "is_published": project.is_published,
+        "created_at": project.created_at.isoformat() if project.created_at else None,
+        "updated_at": project.updated_at.isoformat() if project.updated_at else None,
+        "generation_config": project.generation_config,
+        "evaluation_config": project.evaluation_config,
+        "label_config_version": project.label_config_version,
+        "label_config_history": project.label_config_history,
+        "maximum_annotations": project.maximum_annotations,
+        "assignment_mode": project.assignment_mode,
+        "show_submit_button": project.show_submit_button,
+        "require_comment_on_skip": project.require_comment_on_skip,
+        "require_confirm_before_submit": project.require_confirm_before_submit,
+        "is_archived": project.is_archived,
+        "questionnaire_enabled": project.questionnaire_enabled,
+        "questionnaire_config": project.questionnaire_config,
+        "randomize_task_order": project.randomize_task_order,
+        "instructions_always_visible": project.instructions_always_visible,
+        "conditional_instructions": project.conditional_instructions,
+        "review_enabled": project.review_enabled,
+        "review_mode": project.review_mode,
+        "allow_self_review": project.allow_self_review,
+        "korrektur_enabled": project.korrektur_enabled,
+        "korrektur_config": project.korrektur_config,
+    }
+
+    user_ids: set[str] = set()
+    if project.created_by:
+        user_ids.add(project.created_by)
+    stats: dict[str, int] = {
+        "total_tasks": 0,
+        "total_annotations": 0,
+        "total_generations": 0,
+        "total_evaluations": 0,
+        "total_evaluation_metrics": 0,
+        "total_task_evaluations": 0,
+        "total_human_evaluation_configs": 0,
+        "total_human_evaluation_sessions": 0,
+        "total_human_evaluation_results": 0,
+        "total_preference_rankings": 0,
+        "total_likert_scale_evaluations": 0,
+        "total_members": 0,
+        "total_assignments": 0,
+        "total_post_annotation_responses": 0,
+    }
+
+    # Per-task generation counts for serialize_task(mode="full", total_generations=...).
+    # task_id_subq is a SELECT used inside IN() filters across this function.
+    gen_counts: dict[str, int] = {}
+    task_id_subq = select(Task.id).where(Task.project_id == project_id)
+    gen_count_rows = (
+        db.query(Generation.task_id, sa_func.count(Generation.id))
+        .filter(Generation.task_id.in_(task_id_subq))
+        .group_by(Generation.task_id)
+        .all()
+    )
+    for tid, n in gen_count_rows:
+        gen_counts[tid] = n
+
+    yield '{"format_version": "1.0.0",'
+    yield '"exported_at": ' + json.dumps(datetime.utcnow().isoformat()) + ','
+    yield '"exported_by": ' + json.dumps(project.created_by) + ','
+    yield '"project": ' + json.dumps(project_data, ensure_ascii=False) + ','
+
+    # --- tasks (heavy) ---
+    yield '"tasks": ['
+    first = True
+    task_q = db.query(Task).filter(Task.project_id == project_id)
+    for task in task_q.yield_per(BATCH_SIZE):
+        if task.created_by:
+            user_ids.add(task.created_by)
+        if task.updated_by:
+            user_ids.add(task.updated_by)
+        td = serialize_task(
+            task, mode="full", total_generations=gen_counts.get(task.id, 0),
+        )
+        yield ("" if first else ",") + json.dumps(td, ensure_ascii=False)
+        first = False
+        stats["total_tasks"] += 1
+    yield "],"
+
+    # --- annotations (heavy) ---
+    yield '"annotations": ['
+    first = True
+    ann_q = db.query(Annotation).filter(Annotation.project_id == project_id)
+    for ann in ann_q.yield_per(BATCH_SIZE):
+        if ann.completed_by:
+            user_ids.add(ann.completed_by)
+        yield ("" if first else ",") + json.dumps(
+            serialize_annotation(ann, mode="full"), ensure_ascii=False
+        )
+        first = False
+        stats["total_annotations"] += 1
+    yield "],"
+
+    # --- predictions (deprecated table; always empty) ---
+    yield '"predictions": [],'
+
+    # --- generations (very heavy: response_content) ---
+    yield '"generations": ['
+    first = True
+    gen_q = db.query(Generation).filter(Generation.task_id.in_(task_id_subq))
+    for gen in gen_q.yield_per(BATCH_SIZE):
+        yield ("" if first else ",") + json.dumps(
+            serialize_generation(gen, mode="full"), ensure_ascii=False
+        )
+        first = False
+        stats["total_generations"] += 1
+    yield "],"
+
+    # --- response_generations (medium) ---
+    yield '"response_generations": ['
+    first = True
+    rg_q = db.query(ResponseGeneration).filter(
+        ResponseGeneration.task_id.in_(task_id_subq)
+    )
+    for rg in rg_q.yield_per(BATCH_SIZE):
+        rg_data = {
+            "id": rg.id,
+            "task_id": rg.task_id,
+            "model_id": rg.model_id,
+            "config_id": rg.config_id,
+            "status": rg.status,
+            "responses_generated": rg.responses_generated,
+            "error_message": rg.error_message,
+            "generation_metadata": rg.generation_metadata,
+            "created_by": rg.created_by,
+            "created_at": rg.created_at.isoformat() if rg.created_at else None,
+            "started_at": rg.started_at.isoformat() if rg.started_at else None,
+            "completed_at": rg.completed_at.isoformat() if rg.completed_at else None,
+        }
+        yield ("" if first else ",") + json.dumps(rg_data, ensure_ascii=False)
+        first = False
+    yield "],"
+
+    # --- project_members (small) ---
+    members = (
+        db.query(ProjectMember).filter(ProjectMember.project_id == project_id).all()
+    )
+    yield '"project_members": ['
+    first = True
+    for member in members:
+        if member.user_id:
+            user_ids.add(member.user_id)
+        m_data = {
+            "id": member.id,
+            "project_id": member.project_id,
+            "user_id": member.user_id,
+            "role": member.role,
+            "is_active": member.is_active,
+            "created_at": member.created_at.isoformat() if member.created_at else None,
+            "updated_at": member.updated_at.isoformat() if member.updated_at else None,
+        }
+        yield ("" if first else ",") + json.dumps(m_data, ensure_ascii=False)
+        first = False
+        stats["total_members"] += 1
+    yield "],"
+
+    # --- task_assignments (medium; join through Task) ---
+    assignments = (
+        db.query(TaskAssignment).join(Task).filter(Task.project_id == project_id).all()
+    )
+    yield '"task_assignments": ['
+    first = True
+    for a in assignments:
+        if a.user_id:
+            user_ids.add(a.user_id)
+        if a.assigned_by:
+            user_ids.add(a.assigned_by)
+        a_data = {
+            "id": a.id,
+            "task_id": a.task_id,
+            "user_id": a.user_id,
+            "assigned_by": a.assigned_by,
+            "status": a.status,
+            "priority": a.priority,
+            "due_date": a.due_date.isoformat() if a.due_date else None,
+            "notes": a.notes,
+            "assigned_at": a.assigned_at.isoformat() if a.assigned_at else None,
+            "started_at": a.started_at.isoformat() if a.started_at else None,
+            "completed_at": a.completed_at.isoformat() if a.completed_at else None,
+        }
+        yield ("" if first else ",") + json.dumps(a_data, ensure_ascii=False)
+        first = False
+        stats["total_assignments"] += 1
+    yield "],"
+
+    # --- evaluations (small: eval_runs themselves) ---
+    eval_runs = (
+        db.query(EvaluationRun).filter(EvaluationRun.project_id == project_id).all()
+    )
+    eval_run_ids = [er.id for er in eval_runs]
+    yield '"evaluations": ['
+    first = True
+    for er in eval_runs:
+        yield ("" if first else ",") + json.dumps(
+            serialize_evaluation_run(er, mode="full"), ensure_ascii=False
+        )
+        first = False
+        stats["total_evaluations"] += 1
+    yield "],"
+
+    # --- evaluation_metrics (medium) ---
+    yield '"evaluation_metrics": ['
+    first = True
+    if eval_run_ids:
+        em_q = db.query(EvaluationRunMetric).filter(
+            EvaluationRunMetric.evaluation_id.in_(eval_run_ids)
+        )
+        for m in em_q.yield_per(BATCH_SIZE):
+            m_data = {
+                "id": m.id,
+                "evaluation_id": m.evaluation_id,
+                "evaluation_type_id": m.evaluation_type_id,
+                "value": m.value,
+                "created_at": m.created_at.isoformat() if m.created_at else None,
+            }
+            yield ("" if first else ",") + json.dumps(m_data, ensure_ascii=False)
+            first = False
+            stats["total_evaluation_metrics"] += 1
+    yield "],"
+
+    # --- task_evaluations (very heavy: thousands of rows) ---
+    yield '"task_evaluations": ['
+    first = True
+    if eval_run_ids:
+        te_q = db.query(TaskEvaluation).filter(
+            TaskEvaluation.evaluation_id.in_(eval_run_ids)
+        )
+        for te in te_q.yield_per(BATCH_SIZE):
+            yield ("" if first else ",") + json.dumps(
+                serialize_task_evaluation(te, mode="full"), ensure_ascii=False
+            )
+            first = False
+            stats["total_task_evaluations"] += 1
+    yield "],"
+
+    # --- human_evaluation_configs (small) ---
+    hec_ids: list[str] = []
+    yield '"human_evaluation_configs": ['
+    first = True
+    hec_q = db.query(HumanEvaluationConfig).filter(
+        HumanEvaluationConfig.task_id.in_(task_id_subq)
+    )
+    for c in hec_q.yield_per(BATCH_SIZE):
+        hec_ids.append(c.id)
+        c_data = {
+            "id": c.id,
+            "task_id": c.task_id,
+            "evaluation_project_id": c.evaluation_project_id,
+            "evaluator_count": c.evaluator_count,
+            "randomization_seed": c.randomization_seed,
+            "blinding_enabled": c.blinding_enabled,
+            "include_human_responses": c.include_human_responses,
+            "status": c.status,
+            "created_at": c.created_at.isoformat() if c.created_at else None,
+            "updated_at": c.updated_at.isoformat() if c.updated_at else None,
+        }
+        yield ("" if first else ",") + json.dumps(c_data, ensure_ascii=False)
+        first = False
+        stats["total_human_evaluation_configs"] += 1
+    yield "],"
+
+    # --- human_evaluation_sessions (small) ---
+    hes_ids: list[str] = []
+    yield '"human_evaluation_sessions": ['
+    first = True
+    hes_q = db.query(HumanEvaluationSession).filter(
+        HumanEvaluationSession.project_id == project_id
+    )
+    for s in hes_q.yield_per(BATCH_SIZE):
+        hes_ids.append(s.id)
+        s_data = {
+            "id": s.id,
+            "project_id": s.project_id,
+            "evaluator_id": s.evaluator_id,
+            "session_type": s.session_type,
+            "items_evaluated": s.items_evaluated,
+            "total_items": s.total_items,
+            "status": s.status,
+            "session_config": s.session_config,
+            "created_at": s.created_at.isoformat() if s.created_at else None,
+            "updated_at": s.updated_at.isoformat() if s.updated_at else None,
+            "completed_at": s.completed_at.isoformat() if s.completed_at else None,
+        }
+        yield ("" if first else ",") + json.dumps(s_data, ensure_ascii=False)
+        first = False
+        stats["total_human_evaluation_sessions"] += 1
+    yield "],"
+
+    # --- human_evaluation_results (medium) ---
+    yield '"human_evaluation_results": ['
+    first = True
+    if hec_ids:
+        her_q = db.query(HumanEvaluationResult).filter(
+            HumanEvaluationResult.config_id.in_(hec_ids)
+        )
+        for r in her_q.yield_per(BATCH_SIZE):
+            r_data = {
+                "id": r.id,
+                "config_id": r.config_id,
+                "task_id": r.task_id,
+                "response_id": r.response_id,
+                "evaluator_id": r.evaluator_id,
+                "correctness_score": r.correctness_score,
+                "completeness_score": r.completeness_score,
+                "style_score": r.style_score,
+                "usability_score": r.usability_score,
+                "comments": r.comments,
+                "evaluation_time_seconds": r.evaluation_time_seconds,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            yield ("" if first else ",") + json.dumps(r_data, ensure_ascii=False)
+            first = False
+            stats["total_human_evaluation_results"] += 1
+    yield "],"
+
+    # --- preference_rankings (medium) ---
+    yield '"preference_rankings": ['
+    first = True
+    if hes_ids:
+        pr_q = db.query(PreferenceRanking).filter(
+            PreferenceRanking.session_id.in_(hes_ids)
+        )
+        for p in pr_q.yield_per(BATCH_SIZE):
+            p_data = {
+                "id": p.id,
+                "session_id": p.session_id,
+                "task_id": p.task_id,
+                "response_a_id": p.response_a_id,
+                "response_b_id": p.response_b_id,
+                "winner": p.winner,
+                "confidence": p.confidence,
+                "reasoning": p.reasoning,
+                "time_spent_seconds": p.time_spent_seconds,
+                "created_at": p.created_at.isoformat() if p.created_at else None,
+            }
+            yield ("" if first else ",") + json.dumps(p_data, ensure_ascii=False)
+            first = False
+            stats["total_preference_rankings"] += 1
+    yield "],"
+
+    # --- likert_scale_evaluations (medium) ---
+    yield '"likert_scale_evaluations": ['
+    first = True
+    if hes_ids:
+        ls_q = db.query(LikertScaleEvaluation).filter(
+            LikertScaleEvaluation.session_id.in_(hes_ids)
+        )
+        for lk in ls_q.yield_per(BATCH_SIZE):
+            lk_data = {
+                "id": lk.id,
+                "session_id": lk.session_id,
+                "task_id": lk.task_id,
+                "response_id": lk.response_id,
+                "dimension": lk.dimension,
+                "rating": lk.rating,
+                "comment": lk.comment,
+                "time_spent_seconds": lk.time_spent_seconds,
+                "created_at": lk.created_at.isoformat() if lk.created_at else None,
+            }
+            yield ("" if first else ",") + json.dumps(lk_data, ensure_ascii=False)
+            first = False
+            stats["total_likert_scale_evaluations"] += 1
+    yield "],"
+
+    # --- korrektur_comments (medium) ---
+    yield '"korrektur_comments": ['
+    first = True
+    kc_q = db.query(KorrekturComment).filter(KorrekturComment.project_id == project_id)
+    for kc in kc_q.yield_per(BATCH_SIZE):
+        yield ("" if first else ",") + json.dumps(
+            serialize_korrektur_comment(kc), ensure_ascii=False
+        )
+        first = False
+    yield "],"
+
+    # --- post_annotation_responses (medium) ---
+    yield '"post_annotation_responses": ['
+    first = True
+    par_q = db.query(PostAnnotationResponse).filter(
+        PostAnnotationResponse.project_id == project_id
+    )
+    for r in par_q.yield_per(BATCH_SIZE):
+        if r.user_id:
+            user_ids.add(r.user_id)
+        r_data = {
+            "id": r.id,
+            "annotation_id": r.annotation_id,
+            "task_id": r.task_id,
+            "project_id": r.project_id,
+            "user_id": r.user_id,
+            "result": r.result,
+            "created_at": r.created_at.isoformat() if r.created_at else None,
+        }
+        yield ("" if first else ",") + json.dumps(r_data, ensure_ascii=False)
+        first = False
+        stats["total_post_annotation_responses"] += 1
+    yield "],"
+
+    # --- users (computed at end from refs collected during the stream) ---
+    yield '"users": ['
+    first = True
+    if user_ids:
+        for u in db.query(User).filter(User.id.in_(user_ids)).all():
+            u_data = {
+                "id": u.id,
+                "email": u.email,
+                "username": u.username,
+                "name": u.name,
+                "is_active": u.is_active,
+                "is_superadmin": u.is_superadmin,
+            }
+            yield ("" if first else ",") + json.dumps(u_data, ensure_ascii=False)
+            first = False
+    yield "],"
+
+    yield '"statistics": ' + json.dumps(stats) + "}"
+
+
+def _format_task_txt(task_obj: dict) -> str:
+    lines: list[str] = []
+    lines.append(f"\nTask {task_obj['id']}:")
+    lines.append(f"Data: {json.dumps(task_obj.get('data'))}")
+    anns = task_obj.get("annotations") or []
+    if anns:
+        lines.append(f"Annotations ({len(anns)}):")
+        for ann in anns:
+            lines.append(f"  - {ann['id']}: {json.dumps(ann['result'])}")
+            qr = ann.get("questionnaire_response")
+            if qr:
+                lines.append(f"    Questionnaire: {json.dumps(qr['result'])}")
+    else:
+        lines.append("No annotations")
+    evals = task_obj.get("evaluations") or []
+    if evals:
+        lines.append(f"Evaluations ({len(evals)}):")
+        for ev in evals:
+            lines.append(
+                f"  - {ev['field_name']}: passed={ev['passed']} metrics={json.dumps(ev['metrics'])}"
+            )
+    return "\n".join(lines) + "\n"

--- a/services/api/routers/projects/import_export.py
+++ b/services/api/routers/projects/import_export.py
@@ -6,10 +6,11 @@ import json
 import logging
 import os
 import tempfile
+import time
 import uuid
 import zipfile
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterator, List, Optional
 
 # Spool incoming import bodies in RAM up to this size; spill to disk above it.
 # Keeps small imports allocation-free (no disk hit, no regression vs the
@@ -18,6 +19,57 @@ from typing import Any, Dict, List
 _IMPORT_SPOOL_THRESHOLD = 4 * 1024 * 1024
 
 logger = logging.getLogger(__name__)
+
+
+def _logged_export_stream(
+    chunk_iter: Iterator[str],
+    *,
+    project_id: str,
+    user_id: str,
+    export_format: str,
+    counts: Optional[dict] = None,
+) -> Iterator[bytes]:
+    """Wrap an export chunk generator to emit start/completion/abort logs.
+
+    Yields UTF-8 *bytes* (encoding once here, so the byte tally is exact and
+    Starlette doesn't re-encode the str). A client disconnect surfaces as
+    GeneratorExit when the response is torn down mid-flight — logged as a
+    distinct WARNING from an internal error so aborted/partial downloads are
+    diagnosable. Before this, the 2026-05-31 Benchathon export OOMKilled the
+    pod and truncated silently with no server-side trace at all.
+    """
+    started = time.monotonic()
+    total_bytes = 0
+    logger.info(
+        "export start project=%s user=%s format=%s counts=%s",
+        project_id, user_id, export_format, counts or {},
+    )
+    try:
+        for chunk in chunk_iter:
+            data = chunk.encode("utf-8")
+            total_bytes += len(data)
+            yield data
+    except GeneratorExit:
+        logger.warning(
+            "export aborted (client disconnect) project=%s user=%s format=%s "
+            "bytes=%d elapsed=%.2fs",
+            project_id, user_id, export_format, total_bytes,
+            time.monotonic() - started,
+        )
+        raise
+    except Exception:
+        logger.exception(
+            "export failed project=%s user=%s format=%s bytes=%d elapsed=%.2fs",
+            project_id, user_id, export_format, total_bytes,
+            time.monotonic() - started,
+        )
+        raise
+    else:
+        logger.info(
+            "export complete project=%s user=%s format=%s bytes=%d elapsed=%.2fs",
+            project_id, user_id, export_format, total_bytes,
+            time.monotonic() - started,
+        )
 
 
 # Issue #964: Span annotation format conversion functions
@@ -810,7 +862,21 @@ async def export_project(
             headers["Content-Disposition"] = f"attachment; filename={filename}"
 
         return StreamingResponse(
-            stream_export_json(db, project_id, task_ids=None, header_fields=header_fields),
+            _logged_export_stream(
+                stream_export_json(
+                    db, project_id, task_ids=None, header_fields=header_fields
+                ),
+                project_id=project_id,
+                user_id=current_user.id,
+                export_format="json",
+                counts={
+                    "tasks": task_count,
+                    "annotations": annotation_count,
+                    "generations": generation_count,
+                    "evaluation_runs": len(eval_run_ids_for_counts),
+                    "task_evaluations": task_evaluation_count,
+                },
+            ),
             media_type="application/json",
             headers=headers,
         )
@@ -824,7 +890,12 @@ async def export_project(
             filename = f"{project.title.replace(' ', '_')}_export.{ext}"
             headers["Content-Disposition"] = f"attachment; filename={filename}"
         return StreamingResponse(
-            stream_export_flat_csv(db, project_id, delimiter=delimiter),
+            _logged_export_stream(
+                stream_export_flat_csv(db, project_id, delimiter=delimiter),
+                project_id=project_id,
+                user_id=current_user.id,
+                export_format=format,
+            ),
             media_type=media_type,
             headers=headers,
         )
@@ -835,7 +906,12 @@ async def export_project(
             filename = f"{project.title.replace(' ', '_')}_label_studio.json"
             headers["Content-Disposition"] = f"attachment; filename={filename}"
         return StreamingResponse(
-            stream_export_label_studio(db, project_id),
+            _logged_export_stream(
+                stream_export_label_studio(db, project_id),
+                project_id=project_id,
+                user_id=current_user.id,
+                export_format="label_studio",
+            ),
             media_type="application/json",
             headers=headers,
         )
@@ -848,7 +924,12 @@ async def export_project(
         filename = f"{project.title.replace(' ', '_')}_export.txt"
         headers["Content-Disposition"] = f"attachment; filename={filename}"
     return StreamingResponse(
-        stream_export_txt(db, project_id, project.title, project.description),
+        _logged_export_stream(
+            stream_export_txt(db, project_id, project.title, project.description),
+            project_id=project_id,
+            user_id=current_user.id,
+            export_format="txt",
+        ),
         media_type="text/plain",
         headers=headers,
     )

--- a/services/api/routers/projects/import_export.py
+++ b/services/api/routers/projects/import_export.py
@@ -4,11 +4,11 @@ import csv
 import io
 import json
 import logging
+import os
 import tempfile
 import uuid
 import zipfile
 from datetime import datetime
-from io import BytesIO
 from typing import Any, Dict, List
 
 # Spool incoming import bodies in RAM up to this size; spill to disk above it.
@@ -133,12 +133,19 @@ def convert_from_label_studio_format(results: List[Dict[str, Any]]) -> List[Dict
 
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile  # noqa: E402
-from fastapi.responses import Response  # noqa: E402
+from fastapi.responses import Response, StreamingResponse  # noqa: E402
 from sqlalchemy.orm import Session  # noqa: E402
 
 from auth_module import require_user  # noqa: E402
 from auth_module.models import User as AuthUser  # noqa: E402
 from database import get_db  # noqa: E402
+from routers.projects._export_stream import (  # noqa: E402
+    stream_comprehensive_project_data_json,
+    stream_export_flat_csv,
+    stream_export_json,
+    stream_export_label_studio,
+    stream_export_txt,
+)
 from routers.projects.serializers import _parse_iso  # noqa: E402
 from models import (  # noqa: E402
     EvaluationJudgeRun,
@@ -168,7 +175,6 @@ from project_schemas import ProjectImportData  # noqa: E402
 from routers.projects.helpers import (  # noqa: E402
     check_project_accessible,
     check_project_write_access,
-    get_comprehensive_project_data,
     get_org_context_from_request,
     get_user_with_memberships,
 )
@@ -739,412 +745,114 @@ async def export_project(
     if not check_project_accessible(db, current_user, project_id, org_context):
         raise HTTPException(status_code=403, detail="Access denied")
 
-    # Get all tasks with annotations and generations
-    tasks = db.query(Task).filter(Task.project_id == project_id).all()
-
-    # Get all annotations for this project
-    annotations = db.query(Annotation).filter(Annotation.project_id == project_id).all()
-
-    # Get all generations for this project's tasks
-    task_ids = [task.id for task in tasks]
-    generations = (
-        db.query(Generation).filter(Generation.task_id.in_(task_ids)).all() if task_ids else []
-    )
-
-    # Get all questionnaire responses for this project
-    questionnaire_responses = (
-        db.query(PostAnnotationResponse)
-        .filter(PostAnnotationResponse.project_id == project_id)
-        .all()
-    )
-    # Build lookup by annotation_id for O(1) access
-    qr_by_annotation = {qr.annotation_id: qr for qr in questionnaire_responses}
-
-    # Get all evaluation runs and per-task evaluations for this project
-    evaluation_runs = (
-        db.query(EvaluationRun)
-        .filter(EvaluationRun.project_id == project_id)
-        .all()
-    )
-    eval_run_ids = [er.id for er in evaluation_runs]
-    task_evaluations = (
-        db.query(TaskEvaluation)
-        .filter(TaskEvaluation.evaluation_id.in_(eval_run_ids))
-        .all()
-        if eval_run_ids
-        else []
-    )
-
-    from routers.projects.serializers import (
-        build_evaluation_indexes,
-        build_judge_model_lookup,
-        serialize_annotation,
-        serialize_evaluation_run,
-        serialize_generation,
-        serialize_task,
-        serialize_task_evaluation,
-    )
-
-    eval_run_by_id = {er.id: er for er in evaluation_runs}
-    judge_model_lookup = build_judge_model_lookup(evaluation_runs, db)
-    te_by_task, te_by_generation = build_evaluation_indexes(task_evaluations)
-
-    # Build export data
-    export_data = {
-        "project": {
-            "id": project.id,
-            "title": project.title,
-            "description": project.description,
-            "created_at": (project.created_at.isoformat() if project.created_at else None),
-            "task_count": len(tasks),
-            "annotation_count": len(annotations),
-            "generation_count": len(generations),
-            "evaluation_run_count": len(evaluation_runs),
-            "task_evaluation_count": len(task_evaluations),
-            "label_config": project.label_config,
-        },
-        "evaluation_runs": [
-            serialize_evaluation_run(er, mode="data") for er in evaluation_runs
-        ],
-        "tasks": [],
-    }
-
-    # Add tasks with annotations and generations
-    for task in tasks:
-        task_data = serialize_task(task, mode="data")
-        task_data["annotations"] = []
-        task_data["generations"] = []
-        task_data["evaluations"] = []
-
-        # Add annotations for this task
-        task_annotations = [a for a in annotations if a.task_id == task.id]
-        for ann in task_annotations:
-            qr = qr_by_annotation.get(ann.id)
-            task_data["annotations"].append(
-                serialize_annotation(ann, mode="data", questionnaire_response=qr)
-            )
-
-        # Add generations for this task (with nested evaluations)
-        task_generations = [g for g in generations if g.task_id == task.id]
-        for gen in task_generations:
-            gen_evals = te_by_generation.get(gen.id, [])
-            eval_dicts = [
-                serialize_task_evaluation(
-                    te, mode="data",
-                    eval_run=eval_run_by_id.get(te.evaluation_id),
-                    judge_model_lookup=judge_model_lookup,
-                )
-                for te in gen_evals
-            ]
-            task_data["generations"].append(
-                serialize_generation(gen, mode="data", evaluations=eval_dicts)
-            )
-
-        # Add task-level evaluations (annotation/ground-truth evals without a generation)
-        for te in te_by_task.get(task.id, []):
-            if te.generation_id != None:  # noqa: E711
-                continue  # Already nested under the generation above
-            task_data["evaluations"].append(
-                serialize_task_evaluation(
-                    te, mode="data",
-                    eval_run=eval_run_by_id.get(te.evaluation_id),
-                    judge_model_lookup=judge_model_lookup,
-                )
-            )
-
-        export_data["tasks"].append(task_data)
-
-    # Top-level human-evaluation + Korrektur blocks so the data path is
-    # round-trip-complete (was previously a clone-only feature).
-    from routers.projects.serializers import (
-        serialize_human_evaluation_data,
-        serialize_korrektur_comment,
-    )
-    from project_models import KorrekturComment
-
-    export_data.update(
-        serialize_human_evaluation_data(db, project_id, task_ids)
-    )
-    export_data["korrektur_comments"] = [
-        serialize_korrektur_comment(c)
-        for c in db.query(KorrekturComment)
-        .filter(KorrekturComment.project_id == project_id)
-        .all()
-    ]
-
-    # Format the data based on requested format
+    # JSON path streams via the shared helper. The legacy in-memory builder
+    # below loaded the entire project (tasks + annotations + generations +
+    # task_evaluations) into one dict and json.dumps()-ed it, which peaked
+    # past the 3Gi API memory limit on the Benchathon project (~8k
+    # task_evaluations, ~400 MB output) and OOMKilled the pod mid-response.
+    # CSV/TSV/TXT/label_studio still use the legacy path — each has a
+    # per-row shape its own tests assert on and a separate refactor.
     if format == "json":
-        content = json.dumps(export_data, indent=2)
-        media_type = "application/json"
-        filename = f"{project.title.replace(' ', '_')}_export.json"
+        # All count queries pass whole-model classes (not column attributes
+        # or joins) so they stay mockable in the existing unit tests and
+        # issue cheap COUNT(*) round-trips. Task / EvaluationRun rows are
+        # small and we need their IDs for the in_() filters anyway, so we
+        # load them; Annotation / Generation / TaskEvaluation use .count()
+        # to avoid pulling row bodies for what is just a header tally.
+        project_tasks_for_counts = (
+            db.query(Task).filter(Task.project_id == project_id).all()
+        )
+        task_id_list = [t.id for t in project_tasks_for_counts]
+        evaluation_runs_for_counts = (
+            db.query(EvaluationRun)
+            .filter(EvaluationRun.project_id == project_id)
+            .all()
+        )
+        eval_run_ids_for_counts = [er.id for er in evaluation_runs_for_counts]
 
-    elif format == "csv":
-        # Flatten data for CSV
-        output = io.StringIO()
-        writer = csv.writer(output)
+        task_count = len(project_tasks_for_counts)
+        annotation_count = (
+            db.query(Annotation).filter(Annotation.project_id == project_id).count()
+        )
+        generation_count = (
+            db.query(Generation).filter(Generation.task_id.in_(task_id_list)).count()
+            if task_id_list
+            else 0
+        )
+        task_evaluation_count = (
+            db.query(TaskEvaluation)
+            .filter(TaskEvaluation.evaluation_id.in_(eval_run_ids_for_counts))
+            .count()
+            if eval_run_ids_for_counts
+            else 0
+        )
 
-        # Header with generation, questionnaire, and evaluation columns
-        csv_headers = [
-            "task_id",
-            "task_data",
-            "annotation_id",
-            "annotation_result",
-            "annotation_completed_by",
-            "annotation_created_at",
-            "questionnaire_response",
-            "generation_id",
-            "generation_model",
-            "generation_content",
-            "generation_created_at",
-            "evaluation_field",
-            "evaluation_metrics",
-            "evaluation_passed",
-        ]
-        writer.writerow(csv_headers)
+        header_fields = {
+            "project": {
+                "id": project.id,
+                "title": project.title,
+                "description": project.description,
+                "created_at": (
+                    project.created_at.isoformat() if project.created_at else None
+                ),
+                "task_count": task_count,
+                "annotation_count": annotation_count,
+                "generation_count": generation_count,
+                "evaluation_run_count": len(eval_run_ids_for_counts),
+                "task_evaluation_count": task_evaluation_count,
+                "label_config": project.label_config,
+            },
+        }
 
-        # Data rows
-        for task in export_data["tasks"]:
-            has_data = task["annotations"] or task["generations"] or task["evaluations"]
-            if has_data:
-                max_items = max(
-                    len(task["annotations"]),
-                    len(task["generations"]),
-                    len(task["evaluations"]),
-                    1,
-                )
-                for i in range(max_items):
-                    ann = task["annotations"][i] if i < len(task["annotations"]) else None
-                    gen = task["generations"][i] if i < len(task["generations"]) else None
-                    ev = task["evaluations"][i] if i < len(task["evaluations"]) else None
+        headers = {}
+        if download:
+            filename = f"{project.title.replace(' ', '_')}_export.json"
+            headers["Content-Disposition"] = f"attachment; filename={filename}"
 
-                    writer.writerow(
-                        [
-                            task["id"],
-                            json.dumps(task["data"]),
-                            ann["id"] if ann else "",
-                            json.dumps(ann["result"]) if ann else "",
-                            ann["completed_by"] if ann else "",
-                            ann["created_at"] if ann else "",
-                            json.dumps(ann["questionnaire_response"]) if ann and ann.get("questionnaire_response") else "",
-                            gen["id"] if gen else "",
-                            gen["model_id"] if gen else "",
-                            gen["response_content"] if gen else "",
-                            gen["created_at"] if gen else "",
-                            ev["field_name"] if ev else "",
-                            json.dumps(ev["metrics"]) if ev else "",
-                            ev["passed"] if ev else "",
-                        ]
-                    )
-            else:
-                # Task with no data
-                writer.writerow(
-                    [task["id"], json.dumps(task["data"])] + [""] * 12
-                )
+        return StreamingResponse(
+            stream_export_json(db, project_id, task_ids=None, header_fields=header_fields),
+            media_type="application/json",
+            headers=headers,
+        )
 
-        content = output.getvalue()
-        media_type = "text/csv"
-        filename = f"{project.title.replace(' ', '_')}_export.csv"
+    if format in ("csv", "tsv"):
+        delimiter = "," if format == "csv" else "\t"
+        media_type = "text/csv" if format == "csv" else "text/tab-separated-values"
+        ext = "csv" if format == "csv" else "tsv"
+        headers = {}
+        if download:
+            filename = f"{project.title.replace(' ', '_')}_export.{ext}"
+            headers["Content-Disposition"] = f"attachment; filename={filename}"
+        return StreamingResponse(
+            stream_export_flat_csv(db, project_id, delimiter=delimiter),
+            media_type=media_type,
+            headers=headers,
+        )
 
-    elif format == "tsv":
-        # Similar to CSV but tab-separated
-        output = io.StringIO()
-        writer = csv.writer(output, delimiter="\t")
+    if format == "label_studio":
+        headers = {}
+        if download:
+            filename = f"{project.title.replace(' ', '_')}_label_studio.json"
+            headers["Content-Disposition"] = f"attachment; filename={filename}"
+        return StreamingResponse(
+            stream_export_label_studio(db, project_id),
+            media_type="application/json",
+            headers=headers,
+        )
 
-        # Header with generation, questionnaire, and evaluation columns
-        tsv_headers = [
-            "task_id",
-            "task_data",
-            "annotation_id",
-            "annotation_result",
-            "annotation_completed_by",
-            "annotation_created_at",
-            "questionnaire_response",
-            "generation_id",
-            "generation_model",
-            "generation_content",
-            "generation_created_at",
-            "evaluation_field",
-            "evaluation_metrics",
-            "evaluation_passed",
-        ]
-        writer.writerow(tsv_headers)
-
-        # Data rows
-        for task in export_data["tasks"]:
-            has_data = task["annotations"] or task["generations"] or task["evaluations"]
-            if has_data:
-                max_items = max(
-                    len(task["annotations"]),
-                    len(task["generations"]),
-                    len(task["evaluations"]),
-                    1,
-                )
-                for i in range(max_items):
-                    ann = task["annotations"][i] if i < len(task["annotations"]) else None
-                    gen = task["generations"][i] if i < len(task["generations"]) else None
-                    ev = task["evaluations"][i] if i < len(task["evaluations"]) else None
-
-                    writer.writerow(
-                        [
-                            task["id"],
-                            json.dumps(task["data"]),
-                            ann["id"] if ann else "",
-                            json.dumps(ann["result"]) if ann else "",
-                            ann["completed_by"] if ann else "",
-                            ann["created_at"] if ann else "",
-                            json.dumps(ann["questionnaire_response"]) if ann and ann.get("questionnaire_response") else "",
-                            gen["id"] if gen else "",
-                            gen["model_id"] if gen else "",
-                            gen["response_content"] if gen else "",
-                            gen["created_at"] if gen else "",
-                            ev["field_name"] if ev else "",
-                            json.dumps(ev["metrics"]) if ev else "",
-                            ev["passed"] if ev else "",
-                        ]
-                    )
-            else:
-                # Task with no data
-                writer.writerow(
-                    [task["id"], json.dumps(task["data"])] + [""] * 12
-                )
-
-        content = output.getvalue()
-        media_type = "text/tab-separated-values"
-        filename = f"{project.title.replace(' ', '_')}_export.tsv"
-
-    elif format == "label_studio":
-        # Label Studio JSON format with BenGER extensions
-        ls_data = []
-
-        for task in tasks:
-            # Get annotations for this task
-            task_annotations = [a for a in annotations if a.task_id == task.id]
-
-            # Get generations for this task
-            task_generations = [g for g in generations if g.task_id == task.id]
-
-            # Build Label Studio compatible task object
-            ls_task = {
-                "id": task.inner_id or task.id,  # Use inner_id for Label Studio compatibility
-                "data": task.data,
-                "annotations": [],
-                "predictions": [],  # Label Studio predictions field
-                "meta": task.meta or {},  # Include metadata
-                "created_at": task.created_at.isoformat() if task.created_at else None,
-                "updated_at": task.updated_at.isoformat() if task.updated_at else None,
-                "is_labeled": task.is_labeled,
-                "project": project_id,
-            }
-
-            # Add annotations in Label Studio format
-            for ann in task_annotations:
-                # Issue #964: Convert span annotations to Label Studio format
-                converted_result = convert_to_label_studio_format(ann.result)
-                ls_annotation = {
-                    "id": ann.id,
-                    "completed_by": ann.completed_by,
-                    "result": converted_result,
-                    "was_cancelled": ann.was_cancelled,
-                    "ground_truth": ann.ground_truth,
-                    "created_at": ann.created_at.isoformat() if ann.created_at else None,
-                    "updated_at": ann.updated_at.isoformat() if ann.updated_at else None,
-                    "lead_time": ann.lead_time,
-                    "task": task.inner_id or task.id,
-                    "project": project_id,
-                }
-
-                # Add optional fields if present
-                if ann.draft:
-                    ls_annotation["draft"] = ann.draft
-                if ann.prediction_scores:
-                    ls_annotation["prediction"] = ann.prediction_scores
-                # Add questionnaire response if present
-                qr = qr_by_annotation.get(ann.id)
-                if qr:
-                    ls_annotation["questionnaire_response"] = {
-                        "result": qr.result,
-                        "created_at": qr.created_at.isoformat() if qr.created_at else None,
-                    }
-
-                ls_task["annotations"].append(ls_annotation)
-
-            # Add generations as a BenGER-specific extension
-            if task_generations:
-                ls_task["generations"] = []
-                for gen in task_generations:
-                    ls_generation = {
-                        "id": gen.id,
-                        "model_id": gen.model_id,
-                        "response_content": gen.response_content,
-                        # prompt_id removed in issue #759 - prompts now in project.generation_config (issue #817)
-                        "case_data": gen.case_data,
-                        "created_at": gen.created_at.isoformat() if gen.created_at else None,
-                        "response_metadata": gen.response_metadata,
-                    }
-                    ls_task["generations"].append(ls_generation)
-
-            # Add evaluations as a BenGER-specific extension
-            task_evals = te_by_task.get(task.id, [])
-            if task_evals:
-                ls_task["evaluations"] = []
-                for te in task_evals:
-                    ls_task["evaluations"].append(
-                        {
-                            "id": te.id,
-                            "evaluation_id": te.evaluation_id,
-                            "generation_id": te.generation_id,
-                            "field_name": te.field_name,
-                            "answer_type": te.answer_type,
-                            "ground_truth": te.ground_truth,
-                            "prediction": te.prediction,
-                            "metrics": te.metrics,
-                            "passed": te.passed,
-                            "confidence_score": te.confidence_score,
-                            "created_at": te.created_at.isoformat() if te.created_at else None,
-                        }
-                    )
-
-            ls_data.append(ls_task)
-
-        content = json.dumps(ls_data, indent=2, ensure_ascii=False)
-        media_type = "application/json"
-        filename = f"{project.title.replace(' ', '_')}_label_studio.json"
-
-    else:
-        # Plain text format
-        lines = []
-        lines.append(f"Project: {project.title}")
-        lines.append(f"Description: {project.description or 'None'}")
-        lines.append(f"Total Tasks: {len(tasks)}")
-        lines.append(f"Total Annotations: {len(annotations)}")
-        lines.append("-" * 50)
-
-        for task in export_data["tasks"]:
-            lines.append(f"\nTask {task['id']}:")
-            lines.append(f"Data: {json.dumps(task['data'])}")
-            if task["annotations"]:
-                lines.append(f"Annotations ({len(task['annotations'])}):")
-                for ann in task["annotations"]:
-                    lines.append(f"  - {ann['id']}: {json.dumps(ann['result'])}")
-                    if ann.get("questionnaire_response"):
-                        lines.append(f"    Questionnaire: {json.dumps(ann['questionnaire_response']['result'])}")
-            else:
-                lines.append("No annotations")
-            if task["evaluations"]:
-                lines.append(f"Evaluations ({len(task['evaluations'])}):")
-                for ev in task["evaluations"]:
-                    lines.append(f"  - {ev['field_name']}: passed={ev['passed']} metrics={json.dumps(ev['metrics'])}")
-
-        content = "\n".join(lines)
-        media_type = "text/plain"
-        filename = f"{project.title.replace(' ', '_')}_export.txt"
-
-    # Return response
+    # txt — the only remaining format (json/csv/tsv/label_studio short-circuit
+    # above). Streamed too so peak memory stays bounded; the Query() pattern
+    # rejects anything else before we ever reach this point.
     headers = {}
     if download:
+        filename = f"{project.title.replace(' ', '_')}_export.txt"
         headers["Content-Disposition"] = f"attachment; filename={filename}"
+    return StreamingResponse(
+        stream_export_txt(db, project_id, project.title, project.description),
+        media_type="text/plain",
+        headers=headers,
+    )
 
-    return Response(content=content, media_type=media_type, headers=headers)
 
 
 @router.post("/bulk-export")
@@ -1313,66 +1021,91 @@ async def bulk_export_full_projects(
         f"[EXPORT DEBUG] Current user: {current_user.email}, is_superadmin: {current_user.is_superadmin}"
     )
 
-    # Create ZIP archive in memory
-    zip_buffer = BytesIO()
-
-    with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zip_file:
-        exported_count = 0
-
-        for project_id in project_ids:
-            try:
-                print(f"[EXPORT DEBUG] Processing project_id: {project_id}")
-
-                # Check if project exists and user has access
-                project = db.query(Project).filter(Project.id == project_id).first()
-                if not project:
-                    print(f"[EXPORT DEBUG] Project {project_id} not found in database")
-                    continue
-
-                # Check access permission via org-context-aware helper
-                if not check_project_accessible(db, current_user, project_id, org_context):
-                    print(f"[EXPORT DEBUG] Access denied for project {project_id}, skipping")
-                    continue
-
-                # Get comprehensive project data
-                print(f"[EXPORT DEBUG] Getting comprehensive data for project {project_id}")
-                project_export_data = get_comprehensive_project_data(db, project_id)
-
-                # Create filename from project title
-                safe_title = "".join(
-                    c for c in project.title if c.isalnum() or c in (' ', '-', '_')
-                ).rstrip()
-                safe_title = safe_title[:50]  # Limit filename length
-                filename = f"{safe_title}_{project_id[:8]}.json"
-
-                # Add to ZIP
-                project_json = json.dumps(project_export_data, indent=2, ensure_ascii=False)
-                zip_file.writestr(filename, project_json)
-
-                exported_count += 1
-
-            except Exception as e:
-                # Log error but continue with other projects
-                print(f"[EXPORT DEBUG] Error exporting project {project_id}: {str(e)}")
-                import traceback
-
-                print(f"[EXPORT DEBUG] Traceback: {traceback.format_exc()}")
-                continue
-
-    if exported_count == 0:
-        raise HTTPException(status_code=404, detail="No projects could be exported")
-
-    # Prepare ZIP for download
-    zip_buffer.seek(0)
-    zip_content = zip_buffer.getvalue()
-
-    # Generate filename
+    # Write the ZIP to a tempfile on disk and stream each project's JSON
+    # directly into its zip entry via `json.dump`, which writes chunks as it
+    # walks the object tree. Previous revisions held the full zip in a
+    # BytesIO AND `json.dumps()`-d each project's dict into a giant string
+    # before adding it — for a Benchathon-sized project that's ~3× the
+    # row-set's RAM and OOMKilled the API pod on 2026-05-31. With the
+    # on-disk zip + incremental writer, peak memory now scales with one
+    # project's Python dict, not with N projects' serialized output.
     timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
     zip_filename = f"benger_projects_export_{timestamp}.zip"
+    zip_fd = tempfile.NamedTemporaryFile(
+        prefix="benger-bulk-export-full-", suffix=".zip", delete=False
+    )
+    zip_path = zip_fd.name
+    zip_fd.close()  # FileResponse opens it; we just needed the path.
 
-    return Response(
-        content=zip_content,
+    exported_count = 0
+    try:
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zip_file:
+            for project_id in project_ids:
+                try:
+                    print(f"[EXPORT DEBUG] Processing project_id: {project_id}")
+
+                    project = db.query(Project).filter(Project.id == project_id).first()
+                    if not project:
+                        print(f"[EXPORT DEBUG] Project {project_id} not found in database")
+                        continue
+
+                    if not check_project_accessible(db, current_user, project_id, org_context):
+                        print(f"[EXPORT DEBUG] Access denied for project {project_id}, skipping")
+                        continue
+
+                    print(f"[EXPORT DEBUG] Streaming comprehensive data for project {project_id}")
+
+                    safe_title = "".join(
+                        c for c in project.title if c.isalnum() or c in (' ', '-', '_')
+                    ).rstrip()
+                    safe_title = safe_title[:50]
+                    entry_name = f"{safe_title}_{project_id[:8]}.json"
+
+                    # Stream each project's JSON straight into its zip entry
+                    # via `stream_comprehensive_project_data_json` — the helper
+                    # yields chunks with `yield_per` so the full clone payload
+                    # (tasks + annotations + generations + task_evaluations
+                    # in mode="full") never lives in RAM as one dict. zip.open(
+                    # ..., 'w') returns a binary writer; we encode each text
+                    # chunk to UTF-8 and write directly so we don't stack a
+                    # TextIOWrapper buffer on top of zip's deflate stream.
+                    with zip_file.open(entry_name, 'w') as raw_entry:
+                        for chunk in stream_comprehensive_project_data_json(
+                            db, project_id
+                        ):
+                            raw_entry.write(chunk.encode("utf-8"))
+
+                    exported_count += 1
+
+                except Exception as e:
+                    print(f"[EXPORT DEBUG] Error exporting project {project_id}: {str(e)}")
+                    import traceback
+
+                    print(f"[EXPORT DEBUG] Traceback: {traceback.format_exc()}")
+                    continue
+    except BaseException:
+        # If anything blows up mid-build, don't leak the tempfile.
+        try:
+            os.unlink(zip_path)
+        except OSError:
+            pass
+        raise
+
+    if exported_count == 0:
+        try:
+            os.unlink(zip_path)
+        except OSError:
+            pass
+        raise HTTPException(status_code=404, detail="No projects could be exported")
+
+    from fastapi.responses import FileResponse
+    from starlette.background import BackgroundTask
+
+    return FileResponse(
+        path=zip_path,
         media_type="application/zip",
+        filename=zip_filename,
+        background=BackgroundTask(os.unlink, zip_path),
         headers={"Content-Disposition": f"attachment; filename={zip_filename}"},
     )
 

--- a/services/api/routers/projects/tasks.py
+++ b/services/api/routers/projects/tasks.py
@@ -1067,90 +1067,17 @@ def bulk_export_tasks(
     exported_at_iso = datetime.now().isoformat()
     filename_ts = datetime.now().strftime("%Y%m%d_%H%M%S")
 
-    from project_models import KorrekturComment as _KC
-    from routers.projects.serializers import (
-        build_evaluation_indexes,
-        build_judge_model_lookup,
-        serialize_annotation,
-        serialize_evaluation_run,
-        serialize_generation,
-        serialize_human_evaluation_data,
-        serialize_korrektur_comment,
-        serialize_task,
-        serialize_task_evaluation,
+    from routers.projects._export_stream import (
+        BATCH_SIZE as _BATCH_SIZE,
+        build_batch_objs as _build_batch_objs_shared,
+        stream_export_json,
     )
+    from routers.projects.serializers import build_judge_model_lookup
 
-    _BATCH_SIZE = 50
-
-    def _build_batch_objs(batch: list, eval_run_by_id: dict, judge_model_lookup: dict) -> list:
-        """Build export dicts for a batch of tasks with 4 batched queries
-        (annotations, questionnaire responses, generations, task_evaluations)
-        instead of 4 queries per task. For a 581-task project this collapses
-        ~2,300 round-trips to ~48 — turns multi-minute exports into seconds.
-        """
-        if not batch:
-            return []
-        batch_ids = [t.id for t in batch]
-
-        anns_all = db.query(Annotation).filter(Annotation.task_id.in_(batch_ids)).all()
-        qrs_all = db.query(PostAnnotationResponse).filter(
-            PostAnnotationResponse.task_id.in_(batch_ids)
-        ).all()
-        gens_all = db.query(Generation).filter(Generation.task_id.in_(batch_ids)).all()
-        if eval_run_by_id:
-            te_all = db.query(TaskEvaluation).filter(
-                TaskEvaluation.task_id.in_(batch_ids),
-                TaskEvaluation.evaluation_id.in_(eval_run_by_id.keys()),
-            ).all()
-        else:
-            te_all = []
-
-        anns_by_task: dict = {}
-        for a in anns_all:
-            anns_by_task.setdefault(a.task_id, []).append(a)
-        qr_by_annotation = {qr.annotation_id: qr for qr in qrs_all}
-        gens_by_task: dict = {}
-        for g in gens_all:
-            gens_by_task.setdefault(g.task_id, []).append(g)
-        te_by_task_id, te_by_gen_id = build_evaluation_indexes(te_all)
-
-        out = []
-        for task in batch:
-            task_data = serialize_task(task, mode="data")
-            task_data["annotations"] = [
-                serialize_annotation(
-                    ann, mode="data", questionnaire_response=qr_by_annotation.get(ann.id)
-                )
-                for ann in anns_by_task.get(task.id, [])
-            ]
-            task_data["generations"] = []
-            for gen in gens_by_task.get(task.id, []):
-                gen_evals = te_by_gen_id.get(gen.id, [])
-                eval_dicts = [
-                    serialize_task_evaluation(
-                        te, mode="data",
-                        eval_run=eval_run_by_id.get(te.evaluation_id),
-                        judge_model_lookup=judge_model_lookup,
-                    )
-                    for te in gen_evals
-                ]
-                task_data["generations"].append(
-                    serialize_generation(gen, mode="data", evaluations=eval_dicts)
-                )
-
-            task_data["evaluations"] = []
-            for te in te_by_task_id.get(task.id, []):
-                if te.generation_id != None:  # noqa: E711
-                    continue
-                task_data["evaluations"].append(
-                    serialize_task_evaluation(
-                        te, mode="data",
-                        eval_run=eval_run_by_id.get(te.evaluation_id),
-                        judge_model_lookup=judge_model_lookup,
-                    )
-                )
-            out.append(task_data)
-        return out
+    # Local closure over `db` so the CSV/TSV path below can keep its
+    # existing 2-arg call signature.
+    def _build_batch_objs(batch, eval_run_by_id, judge_model_lookup):
+        return _build_batch_objs_shared(db, batch, eval_run_by_id, judge_model_lookup)
 
     # The streaming generators below capture the request-scoped `db` via
     # closure. FastAPI keeps the Depends(get_db) session open until the
@@ -1160,58 +1087,16 @@ def bulk_export_tasks(
     # short-lived and continuously query the DB, not idle in transaction.
 
     def _json_stream():
-        eval_runs = db.query(EvaluationRun).filter(
-            EvaluationRun.project_id == project_id
-        ).all()
-        eval_run_by_id = {er.id: er for er in eval_runs}
-        judge_model_lookup = build_judge_model_lookup(eval_runs, db)
-
-        header = {
-            "project_id": project_id,
-            "project_title": project_title,
-            "exported_at": exported_at_iso,
-            "evaluation_runs": [serialize_evaluation_run(er, mode="data") for er in eval_runs],
-        }
-        # Compact, no indent — ~30% smaller than indent=2 and faster.
-        prefix = json.dumps(header)[:-1]  # drop closing `}` so we can append more keys
-        yield prefix + ', "tasks": ['
-
-        first = True
-        task_q = db.query(Task).filter(
-            Task.id.in_(task_ids), Task.project_id == project_id
+        yield from stream_export_json(
+            db,
+            project_id,
+            task_ids,
+            header_fields={
+                "project_id": project_id,
+                "project_title": project_title,
+                "exported_at": exported_at_iso,
+            },
         )
-        batch: list = []
-        for task in task_q.yield_per(_BATCH_SIZE):
-            batch.append(task)
-            if len(batch) >= _BATCH_SIZE:
-                for obj in _build_batch_objs(batch, eval_run_by_id, judge_model_lookup):
-                    yield ("" if first else ",") + json.dumps(obj)
-                    first = False
-                batch = []
-        for obj in _build_batch_objs(batch, eval_run_by_id, judge_model_lookup):
-            yield ("" if first else ",") + json.dumps(obj)
-            first = False
-
-        yield "], "
-
-        # Human-eval block. The helper does its own queries and returns a
-        # dict; serialize each top-level key as its own JSON fragment.
-        human_eval = serialize_human_evaluation_data(db, project_id, task_ids) or {}
-        human_eval_items = list(human_eval.items())
-        for idx, (k, v) in enumerate(human_eval_items):
-            yield json.dumps(k) + ":" + json.dumps(v)
-            if idx < len(human_eval_items) - 1:
-                yield ","
-        if human_eval_items:
-            yield ","
-
-        yield '"korrektur_comments": ['
-        first = True
-        kc_q = db.query(_KC).filter(_KC.project_id == project_id)
-        for kc in kc_q.yield_per(100):
-            yield ("" if first else ",") + json.dumps(serialize_korrektur_comment(kc))
-            first = False
-        yield "]}"
 
     def _csv_or_tsv_stream(delimiter: str):
         """Stream CSV/TSV one task at a time. Each row is `task_id, task_data,

--- a/services/api/tests/unit/test_import_export_coverage.py
+++ b/services/api/tests/unit/test_import_export_coverage.py
@@ -447,16 +447,22 @@ class TestExportProject:
                 q.filter.return_value.first.return_value = _mock_project()
             elif model == Task:
                 q.filter.return_value.all.return_value = tasks
+                q.filter.return_value.count.return_value = len(tasks)
             elif model == Annotation:
                 q.filter.return_value.all.return_value = annotations
+                q.filter.return_value.count.return_value = len(annotations)
             elif model == Generation:
                 q.filter.return_value.all.return_value = generations
+                q.filter.return_value.count.return_value = len(generations)
             elif model == PostAnnotationResponse:
                 q.filter.return_value.all.return_value = []
+                q.filter.return_value.count.return_value = 0
             elif model == EvaluationRun:
                 q.filter.return_value.all.return_value = []
+                q.filter.return_value.count.return_value = 0
             elif model == TaskEvaluation:
                 q.filter.return_value.all.return_value = []
+                q.filter.return_value.count.return_value = 0
             else:
                 q.filter.return_value.all.return_value = []
                 q.filter.return_value.first.return_value = None
@@ -468,18 +474,18 @@ class TestExportProject:
     @pytest.mark.asyncio
     @patch("routers.projects.import_export.check_project_accessible", return_value=True)
     @patch("routers.projects.import_export.get_org_context_from_request", return_value="org-123")
-    @patch("routers.projects.serializers.build_evaluation_indexes", return_value=({}, {}))
-    @patch("routers.projects.serializers.build_judge_model_lookup", return_value={})
-    @patch("routers.projects.serializers.serialize_task")
-    @patch("routers.projects.serializers.serialize_evaluation_run")
-    async def test_export_json_format(self, mock_ser_er, mock_ser_task, mock_judge, mock_eval_idx, mock_org, mock_access, mock_db):
-        """Test JSON format export."""
+    @patch("routers.projects.import_export.stream_export_json")
+    async def test_export_json_format(self, mock_stream, mock_org, mock_access, mock_db):
+        """Test JSON format export. JSON now returns a StreamingResponse so the
+        body must be drained from `body_iterator` rather than read off `.body`,
+        and the helper that emits the per-row JSON is patched in directly —
+        the heavy serialization is exercised by the integration suite at
+        `tests/integration/test_export_formats_coverage.py` instead."""
         from routers.projects.import_export import export_project
 
         task = _mock_task()
         self._setup_export_db(mock_db, tasks=[task])
-
-        mock_ser_task.return_value = {"id": "task-1", "data": {"text": "test"}, "is_labeled": False, "created_at": None}
+        mock_stream.return_value = iter(['{"project": {"id": "x"}, "tasks": []}'])
 
         result = await export_project(
             project_id="project-123",
@@ -491,30 +497,29 @@ class TestExportProject:
         )
 
         assert result.media_type == "application/json"
-        body = json.loads(result.body.decode())
+        chunks = []
+        async for chunk in result.body_iterator:
+            chunks.append(chunk if isinstance(chunk, str) else chunk.decode())
+        body = json.loads("".join(chunks))
         assert "project" in body
         assert "tasks" in body
+        # Streaming helper was actually invoked rather than the legacy
+        # in-memory builder (regression guard for the OOM fix).
+        mock_stream.assert_called_once()
 
     @pytest.mark.asyncio
     @patch("routers.projects.import_export.check_project_accessible", return_value=True)
     @patch("routers.projects.import_export.get_org_context_from_request", return_value="org-123")
-    @patch("routers.projects.serializers.build_evaluation_indexes", return_value=({}, {}))
-    @patch("routers.projects.serializers.build_judge_model_lookup", return_value={})
-    @patch("routers.projects.serializers.serialize_task")
-    @patch("routers.projects.serializers.serialize_evaluation_run")
-    async def test_export_csv_format(self, mock_ser_er, mock_ser_task, mock_judge, mock_eval_idx, mock_org, mock_access, mock_db):
-        """Test CSV format export."""
+    @patch("routers.projects.import_export.stream_export_flat_csv")
+    async def test_export_csv_format(self, mock_stream, mock_org, mock_access, mock_db):
+        """Test CSV format export. CSV streams via stream_export_flat_csv;
+        body must be drained from the iterator. Real row layout is exercised
+        by tests/integration/test_export_formats_coverage.py."""
         from routers.projects.import_export import export_project
 
         task = _mock_task()
         self._setup_export_db(mock_db, tasks=[task])
-
-        mock_ser_task.return_value = {
-            "id": "task-1",
-            "data": {"text": "test"},
-            "is_labeled": False,
-            "created_at": None,
-        }
+        mock_stream.return_value = iter(["task_id,task_data\n", "t1,\"{}\"\n"])
 
         result = await export_project(
             project_id="project-123",
@@ -526,8 +531,12 @@ class TestExportProject:
         )
 
         assert result.media_type == "text/csv"
-        content = result.body.decode()
+        chunks = []
+        async for chunk in result.body_iterator:
+            chunks.append(chunk if isinstance(chunk, str) else chunk.decode())
+        content = "".join(chunks)
         assert "task_id" in content
+        mock_stream.assert_called_once()
 
     @pytest.mark.asyncio
     @patch("routers.projects.import_export.check_project_accessible", return_value=True)
@@ -564,26 +573,16 @@ class TestExportProject:
     @pytest.mark.asyncio
     @patch("routers.projects.import_export.check_project_accessible", return_value=True)
     @patch("routers.projects.import_export.get_org_context_from_request", return_value="org-123")
-    @patch("routers.projects.serializers.build_evaluation_indexes", return_value=({}, {}))
-    @patch("routers.projects.serializers.build_judge_model_lookup", return_value={})
-    @patch("routers.projects.serializers.serialize_task")
-    @patch("routers.projects.serializers.serialize_evaluation_run")
-    async def test_export_txt_format(self, mock_ser_er, mock_ser_task, mock_judge, mock_eval_idx, mock_org, mock_access, mock_db):
-        """Test TXT format export."""
+    @patch("routers.projects.import_export.stream_export_txt")
+    async def test_export_txt_format(self, mock_stream, mock_org, mock_access, mock_db):
+        """Test TXT format export. TXT streams via stream_export_txt; body
+        must be drained from the iterator. Real formatting is exercised by
+        tests/integration/test_export_formats_coverage.py."""
         from routers.projects.import_export import export_project
 
         task = _mock_task()
         self._setup_export_db(mock_db, tasks=[task])
-
-        mock_ser_task.return_value = {
-            "id": "task-1",
-            "data": {"text": "test"},
-            "is_labeled": False,
-            "created_at": None,
-            "annotations": [],
-            "generations": [],
-            "evaluations": [],
-        }
+        mock_stream.return_value = iter(["Project: Test Project\n", "Total Tasks: 1\n"])
 
         result = await export_project(
             project_id="project-123",
@@ -595,23 +594,27 @@ class TestExportProject:
         )
 
         assert result.media_type == "text/plain"
-        content = result.body.decode()
+        chunks = []
+        async for chunk in result.body_iterator:
+            chunks.append(chunk if isinstance(chunk, str) else chunk.decode())
+        content = "".join(chunks)
         assert "Test Project" in content
+        mock_stream.assert_called_once()
 
     @pytest.mark.asyncio
     @patch("routers.projects.import_export.check_project_accessible", return_value=True)
     @patch("routers.projects.import_export.get_org_context_from_request", return_value="org-123")
-    @patch("routers.projects.serializers.build_evaluation_indexes", return_value=({}, {}))
-    @patch("routers.projects.serializers.build_judge_model_lookup", return_value={})
-    @patch("routers.projects.serializers.serialize_evaluation_run")
-    async def test_export_label_studio_format(self, mock_ser_er, mock_judge, mock_eval_idx, mock_org, mock_access, mock_db):
-        """Test Label Studio format export."""
+    @patch("routers.projects.import_export.stream_export_label_studio")
+    async def test_export_label_studio_format(self, mock_stream, mock_org, mock_access, mock_db):
+        """Test Label Studio format export. Now streams via
+        stream_export_label_studio; body must be drained from the iterator.
+        Real LS conversion (including span format) is exercised by
+        tests/unit/test_coverage_push_export_branches.py."""
         from routers.projects.import_export import export_project
 
         task = _mock_task()
-        ann = _mock_annotation()
-        gen = _mock_generation()
-        self._setup_export_db(mock_db, tasks=[task], annotations=[ann], generations=[gen])
+        self._setup_export_db(mock_db, tasks=[task])
+        mock_stream.return_value = iter(["[", "{\"id\": 1, \"data\": {}}", "]"])
 
         result = await export_project(
             project_id="project-123",
@@ -623,8 +626,12 @@ class TestExportProject:
         )
 
         assert result.media_type == "application/json"
-        body = json.loads(result.body.decode())
+        chunks = []
+        async for chunk in result.body_iterator:
+            chunks.append(chunk if isinstance(chunk, str) else chunk.decode())
+        body = json.loads("".join(chunks))
         assert isinstance(body, list)
+        mock_stream.assert_called_once()
 
     @pytest.mark.asyncio
     @patch("routers.projects.import_export.check_project_accessible", return_value=True)
@@ -813,16 +820,23 @@ class TestBulkExportFullProjects:
         assert "No project IDs" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
-    @patch("routers.projects.import_export.get_comprehensive_project_data")
+    @patch("routers.projects.import_export.stream_comprehensive_project_data_json")
     @patch("routers.projects.import_export.check_project_accessible", return_value=True)
     @patch("routers.projects.import_export.get_org_context_from_request", return_value="org-123")
-    async def test_bulk_export_full_success(self, mock_org, mock_access, mock_comprehensive, mock_db):
-        """Test successful full bulk export produces ZIP."""
+    async def test_bulk_export_full_success(self, mock_org, mock_access, mock_stream, mock_db):
+        """Test successful full bulk export produces ZIP.
+
+        The handler now streams each project's comprehensive JSON straight
+        into the zip entry via stream_comprehensive_project_data_json and
+        returns a FileResponse from a tempfile (zip on disk, not BytesIO)
+        — this test only checks the wiring; the real per-row content is
+        exercised by tests/routers/projects/test_export_import_roundtrip.py.
+        """
         from routers.projects.import_export import bulk_export_full_projects
 
         project = _mock_project()
         mock_db.query.return_value.filter.return_value.first.return_value = project
-        mock_comprehensive.return_value = {"project": {"title": "Test"}, "tasks": []}
+        mock_stream.return_value = iter(['{"project":{"title":"Test"},"tasks":[]}'])
 
         result = await bulk_export_full_projects(
             data={"project_ids": ["project-123"]},
@@ -832,10 +846,15 @@ class TestBulkExportFullProjects:
         )
 
         assert result.media_type == "application/zip"
-        # Verify it's a valid ZIP
-        zip_buffer = BytesIO(result.body)
-        with zipfile.ZipFile(zip_buffer, 'r') as zf:
+        # FileResponse exposes the underlying tempfile path; read it back to
+        # verify the zip is well-formed and contains the streamed entry.
+        with zipfile.ZipFile(result.path, 'r') as zf:
             assert len(zf.namelist()) == 1
+        mock_stream.assert_called_once()
+        # The handler schedules an unlink-after-send background task; run it
+        # ourselves here so the tempfile doesn't linger across tests.
+        if result.background:
+            result.background.func(*result.background.args, **result.background.kwargs)
 
     @pytest.mark.asyncio
     @patch("routers.projects.import_export.check_project_accessible", return_value=True)
@@ -856,17 +875,19 @@ class TestBulkExportFullProjects:
         assert "No projects could be exported" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
-    @patch("routers.projects.import_export.get_comprehensive_project_data", side_effect=Exception("export error"))
+    @patch("routers.projects.import_export.stream_comprehensive_project_data_json", side_effect=Exception("export error"))
     @patch("routers.projects.import_export.check_project_accessible", return_value=True)
     @patch("routers.projects.import_export.get_org_context_from_request", return_value="org-123")
-    async def test_bulk_export_full_error_handling(self, mock_org, mock_access, mock_comprehensive, mock_db):
+    async def test_bulk_export_full_error_handling(self, mock_org, mock_access, mock_stream, mock_db):
         """Test that errors in individual project exports are handled gracefully."""
         from routers.projects.import_export import bulk_export_full_projects
 
         project = _mock_project()
         mock_db.query.return_value.filter.return_value.first.return_value = project
 
-        # Should raise 404 because the only project failed to export
+        # Should raise 404 because the only project failed to export. The
+        # handler also cleans up its tempfile on the empty-zip path, so no
+        # file is left behind for the test to chase.
         with pytest.raises(Exception) as exc_info:
             await bulk_export_full_projects(
                 data={"project_ids": ["project-123"]},


### PR DESCRIPTION
## Summary
- Replaces the in-memory `json.dumps(export_data, indent=2)` export builder with a streaming generator (`_export_stream.py`) for **all** project export formats (json/csv/tsv/txt/label_studio). Peak RAM is now bounded by `BATCH_SIZE` instead of the full row-set, eliminating the OOMKill that silently truncated the ~489 MB Benchathon JSON export on the 3 GiB API pod.
- Adds structured logging around every export stream: INFO at start (project, user, format, row counts), INFO at completion (exact bytes streamed + elapsed), WARNING on client disconnect (`GeneratorExit`), and a traceback on internal error. The wrapper encodes each chunk to UTF-8 once and yields bytes so the byte tally is exact and Starlette doesn't re-encode.

## Why
Prod (`main`) still runs the old in-memory builder, which OOMKilled the pod mid-response on the Benchathon project and produced a truncated download with **no server-side trace at all**. The streaming path completes the same export in ~7.6s well under the memory limit; the logging makes any future aborted/partial export diagnosable.

## Test plan
- [x] `tests/unit/test_import_export_coverage.py` — 36 passed (incl. JSON/CSV/LS/TXT stream + OOM regression guard)
- [x] `tests/integration/test_export_formats_coverage.py` — 28 passed (end-to-end through the logging wrapper, all formats)
- [ ] Post-deploy: trigger a Benchathon JSON export in prod and confirm `export start/complete` log lines with byte+elapsed counters