### PR TITLE
fix(export): stream JSON export to disk and detect truncation

### DIFF
--- a/services/api/routers/projects/_export_stream.py
+++ b/services/api/routers/projects/_export_stream.py
@@ -232,7 +232,14 @@ def stream_export_json(
         yield ("" if first else ",") + json.dumps(serialize_korrektur_comment(kc))
         first = False
         db.expunge(kc)
-    yield "]}"
+    # `export_complete` is a completeness sentinel, not data. A multi-GB export
+    # that gets cut mid-stream by a proxy/connection drop can be saved by the
+    # browser as a "successful" but truncated file whose tail (a task object's
+    # `"evaluations": []}`) is indistinguishable from a clean end (`]}`). The
+    # download client only treats a file as complete when this trailing marker
+    # is present, so a severed stream is surfaced as an error instead of a
+    # silently-corrupt download. Keep it the LAST thing emitted.
+    yield '], "export_complete": true}'
 
 
 # Per-row column layout used by GET /{project_id}/export?format=csv|tsv.

--- a/services/api/tests/routers/projects/test_bulk_export_tasks.py
+++ b/services/api/tests/routers/projects/test_bulk_export_tasks.py
@@ -856,3 +856,39 @@ class TestBulkExportTasks:
         assert task_level_eval["evaluation_run_id"] == eval_run.id
         assert task_level_eval["evaluated_model"] == "gpt-4"
         assert task_level_eval["judge_model"] is None  # judge_run points to non-judge EJR
+
+    def test_export_json_ends_with_completeness_sentinel(
+        self, tasks_with_both, test_db_session, test_project
+    ):
+        """A complete export must carry the trailing `export_complete` marker.
+
+        The streaming download client uses this sentinel to tell a clean
+        end-of-stream from a proxy-truncated file — whose tail is an innocuous
+        `"evaluations": []}` that looks just like a valid close. Regressing the
+        marker (or emitting anything after it) would reintroduce the silent
+        truncation the marker exists to catch.
+        """
+        from unittest.mock import Mock
+
+        from routers.projects.tasks import bulk_export_tasks
+
+        session = test_db_session
+        data = tasks_with_both
+        project_id = test_project.id
+        task_ids = [t.id for t in data["tasks"]]
+        request_data = {"task_ids": task_ids, "format": "json"}
+
+        mock_user = Mock()
+        mock_user.id = data["tasks"][0].created_by
+
+        response = bulk_export_tasks(
+            project_id, request_data, request=_make_mock_request(),
+            current_user=mock_user, db=session,
+        )
+        content = _collect_stream(response)
+
+        export_data = json.loads(content)
+        assert export_data.get("export_complete") is True
+        # Must be the very last thing emitted so a client can detect truncation
+        # by inspecting only the tail of the stream.
+        assert content.rstrip().endswith('"export_complete": true}')

--- a/services/frontend/src/components/projects/tabs/AnnotationTab.tsx
+++ b/services/frontend/src/components/projects/tabs/AnnotationTab.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/hooks/useColumnSettings'
 import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 import { projectsAPI } from '@/lib/api/projects'
+import { TruncatedExportError } from '@/lib/api/streamingExport'
 import { Task } from '@/lib/api/types'
 import { useProjectStore } from '@/stores/projectStore'
 import { Task as LabelStudioTask } from '@/types/labelStudio'
@@ -581,35 +582,26 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
     if (selectedTasks.size === 0) return
 
     const progressId = `bulk-export-${Date.now()}`
+    const taskIds = Array.from(selectedTasks)
+    const suggestedName = `tasks-export-${new Date().toISOString().split('T')[0]}.json`
 
     try {
-      const taskIds = Array.from(selectedTasks)
-
-      // The backend streams a single response; there's no per-row progress
-      // signal to drive a real percentage, so use an indeterminate bar
-      // instead of a fake 30%-jumps-immediately-then-hangs UX.
-      startProgress(progressId, t('annotationTab.buttons.bulkExport'), {
-        sublabel: t('annotationTab.messages.exportingSelected', {
-          count: selectedTasks.size,
-        }),
-        indeterminate: true,
+      // Streams the body straight to disk (File System Access API) and
+      // validates the server's completeness sentinel, so a severed multi-GB
+      // download surfaces as an error rather than a silently-truncated file.
+      // The backend streams a single response with no per-row progress
+      // signal, so the bar stays indeterminate.
+      await projectsAPI.streamExportTasks(projectId, taskIds, suggestedName, {
+        onStart: () =>
+          startProgress(progressId, t('annotationTab.buttons.bulkExport'), {
+            sublabel: t('annotationTab.messages.exportingSelected', {
+              count: selectedTasks.size,
+            }),
+            indeterminate: true,
+          }),
       })
 
-      const blob = await projectsAPI.bulkExportTasks(projectId, taskIds, 'json')
-
-      // Download the exported file
-      const url = window.URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.style.display = 'none'
-      a.href = url
-      a.download = `tasks-export-${new Date().toISOString().split('T')[0]}.json`
-      document.body.appendChild(a)
-      a.click()
-      window.URL.revokeObjectURL(url)
-      document.body.removeChild(a)
-
       completeProgress(progressId, 'success')
-
       addToast(
         t('annotationTab.messages.exportedTasks', {
           count: selectedTasks.size,
@@ -617,10 +609,19 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
         'success'
       )
     } catch (error) {
-      console.error('Failed to export tasks:', error)
+      // User dismissed the save dialog before any work started — not an error.
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return
+      }
+      logger.error('Failed to export tasks:', error)
       completeProgress(progressId, 'error')
       addToast(
-        t('annotationTab.messages.exportFailed', { error: 'Unknown error' }),
+        t('annotationTab.messages.exportFailed', {
+          error:
+            error instanceof TruncatedExportError
+              ? error.message
+              : 'Unknown error',
+        }),
         'error'
       )
     }
@@ -651,15 +652,6 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
         }
       )
 
-      // Indeterminate — no real per-row progress signal from the backend
-      // stream; the previous fake 30%→70%→100% was misleading.
-      startProgress(progressId, t('annotationTab.buttons.export'), {
-        sublabel: t('annotationTab.messages.exportingSelected', {
-          count: taskIds.length,
-        }),
-        indeterminate: true,
-      })
-
       if (truncated) {
         addToast(
           `Export capped at ${taskIds.length} tasks; refine filters to export the rest.`,
@@ -667,21 +659,24 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
         )
       }
 
-      const blob = await projectsAPI.bulkExportTasks(projectId, taskIds, 'json')
+      const suggestedName = `${currentProject?.title || 'project'}-tasks-${new Date().toISOString().split('T')[0]}.json`
 
-      // Download the exported file
-      const url = window.URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.style.display = 'none'
-      a.href = url
-      a.download = `${currentProject?.title || 'project'}-tasks-${new Date().toISOString().split('T')[0]}.json`
-      document.body.appendChild(a)
-      a.click()
-      window.URL.revokeObjectURL(url)
-      document.body.removeChild(a)
+      // Stream straight to disk with completeness validation rather than
+      // buffering the whole body via blob(); for the 4.5 GB ZJS project the
+      // old path was severed mid-stream and saved a truncated, invalid file.
+      await projectsAPI.streamExportTasks(projectId, taskIds, suggestedName, {
+        onStart: () =>
+          // Indeterminate — no real per-row progress signal from the backend
+          // stream; the previous fake 30%→70%→100% was misleading.
+          startProgress(progressId, t('annotationTab.buttons.export'), {
+            sublabel: t('annotationTab.messages.exportingSelected', {
+              count: taskIds.length,
+            }),
+            indeterminate: true,
+          }),
+      })
 
       completeProgress(progressId, 'success')
-
       addToast(
         t('annotationTab.messages.exportedTasks', {
           count: taskIds.length,
@@ -689,10 +684,19 @@ export function AnnotationTab({ projectId }: AnnotationTabProps) {
         'success'
       )
     } catch (error) {
-      console.error('Failed to export tasks:', error)
+      // User dismissed the save dialog before any work started — not an error.
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return
+      }
+      logger.error('Failed to export tasks:', error)
       completeProgress(progressId, 'error')
       addToast(
-        t('annotationTab.messages.exportFailed', { error: 'Unknown error' }),
+        t('annotationTab.messages.exportFailed', {
+          error:
+            error instanceof TruncatedExportError
+              ? error.message
+              : 'Unknown error',
+        }),
         'error'
       )
     }

--- a/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.br5.test.tsx
+++ b/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.br5.test.tsx
@@ -66,6 +66,7 @@ jest.mock('@/lib/api/projects', () => ({
   projectsAPI: {
     export: jest.fn(),
     bulkExportTasks: jest.fn(),
+    streamExportTasks: jest.fn(),
     bulkDeleteTasks: jest.fn(),
     bulkArchiveTasks: jest.fn(),
     getMembers: jest.fn(),
@@ -465,6 +466,12 @@ describe('AnnotationTab - br5 branch coverage', () => {
     ;(projectsAPI.bulkExportTasks as jest.Mock).mockResolvedValue(
       new Blob(['test data'])
     )
+    ;(projectsAPI.streamExportTasks as jest.Mock).mockImplementation(
+      (_projectId, _taskIds, _name, callbacks) => {
+        callbacks?.onStart?.()
+        return Promise.resolve({ bytesWritten: 9, savedVia: 'blob' })
+      }
+    )
     ;(projectsAPI.bulkDeleteTasks as jest.Mock).mockResolvedValue({
       deleted: 2,
     })
@@ -727,7 +734,7 @@ describe('AnnotationTab - br5 branch coverage', () => {
   })
 
   it('handles export error gracefully', async () => {
-    ;(projectsAPI.bulkExportTasks as jest.Mock).mockRejectedValue(
+    ;(projectsAPI.streamExportTasks as jest.Mock).mockRejectedValue(
       new Error('Export failed')
     )
 

--- a/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.coverage.test.tsx
+++ b/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.coverage.test.tsx
@@ -41,6 +41,7 @@ jest.mock('@/lib/api/projects', () => ({
   projectsAPI: {
     export: jest.fn(),
     bulkExportTasks: jest.fn(),
+    streamExportTasks: jest.fn(),
     bulkDeleteTasks: jest.fn(),
     bulkArchiveTasks: jest.fn(),
     getMembers: jest.fn(),
@@ -378,6 +379,12 @@ describe('AnnotationTab - Coverage', () => {
 
     ;(projectsAPI.export as jest.Mock).mockResolvedValue(new Blob(['test']))
     ;(projectsAPI.bulkExportTasks as jest.Mock).mockResolvedValue(new Blob(['test']))
+    ;(projectsAPI.streamExportTasks as jest.Mock).mockImplementation(
+      (_projectId, _taskIds, _name, callbacks) => {
+        callbacks?.onStart?.()
+        return Promise.resolve({ bytesWritten: 4, savedVia: 'blob' })
+      }
+    )
     ;(projectsAPI.bulkDeleteTasks as jest.Mock).mockResolvedValue({ deleted: 1 })
     ;(projectsAPI.bulkArchiveTasks as jest.Mock).mockResolvedValue({ archived: 1 })
     ;(projectsAPI.getMembers as jest.Mock).mockResolvedValue([])

--- a/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.interactions.test.tsx
+++ b/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.interactions.test.tsx
@@ -44,6 +44,7 @@ jest.mock('@/lib/api/projects', () => ({
   projectsAPI: {
     export: jest.fn(),
     bulkExportTasks: jest.fn(),
+    streamExportTasks: jest.fn(),
     bulkDeleteTasks: jest.fn(),
     bulkArchiveTasks: jest.fn(),
     getMembers: jest.fn(),
@@ -409,6 +410,12 @@ function setupMocks() {
 
   ;(projectsAPI.export as jest.Mock).mockResolvedValue(new Blob(['test']))
   ;(projectsAPI.bulkExportTasks as jest.Mock).mockResolvedValue(new Blob(['test']))
+  ;(projectsAPI.streamExportTasks as jest.Mock).mockImplementation(
+    (_projectId, _taskIds, _name, callbacks) => {
+      callbacks?.onStart?.()
+      return Promise.resolve({ bytesWritten: 4, savedVia: 'blob' })
+    }
+  )
   ;(projectsAPI.bulkDeleteTasks as jest.Mock).mockResolvedValue({ deleted: 1 })
   ;(projectsAPI.bulkArchiveTasks as jest.Mock).mockResolvedValue({ archived: 1 })
   ;(projectsAPI.getMembers as jest.Mock).mockResolvedValue([{ id: 'user-1', username: 'testuser' }])
@@ -452,7 +459,12 @@ describe('AnnotationTab - interaction coverage', () => {
       fireEvent.click(exportBtn)
 
       await waitFor(() => {
-        expect(projectsAPI.bulkExportTasks).toHaveBeenCalledWith('project-1', expect.any(Array), 'json')
+        expect(projectsAPI.streamExportTasks).toHaveBeenCalledWith(
+          'project-1',
+          expect.any(Array),
+          expect.any(String),
+          expect.any(Object)
+        )
       })
       expect(mockStartProgress).toHaveBeenCalled()
       expect(mockCompleteProgress).toHaveBeenCalledWith(expect.any(String), 'success')
@@ -471,7 +483,7 @@ describe('AnnotationTab - interaction coverage', () => {
     })
 
     it('handles export failure', async () => {
-      ;(projectsAPI.bulkExportTasks as jest.Mock).mockRejectedValue(new Error('Network error'))
+      ;(projectsAPI.streamExportTasks as jest.Mock).mockRejectedValue(new Error('Network error'))
       await renderAndWaitForTasks()
 
       fireEvent.click(screen.getByTestId('export-button'))
@@ -494,13 +506,18 @@ describe('AnnotationTab - interaction coverage', () => {
       fireEvent.click(screen.getByTestId('bulk-export'))
 
       await waitFor(() => {
-        expect(projectsAPI.bulkExportTasks).toHaveBeenCalledWith('project-1', expect.any(Array), 'json')
+        expect(projectsAPI.streamExportTasks).toHaveBeenCalledWith(
+          'project-1',
+          expect.any(Array),
+          expect.any(String),
+          expect.any(Object)
+        )
       })
       expect(mockAddToast).toHaveBeenCalledWith(expect.any(String), 'success')
     })
 
     it('handles bulk export failure', async () => {
-      ;(projectsAPI.bulkExportTasks as jest.Mock).mockRejectedValue(new Error('Export failed'))
+      ;(projectsAPI.streamExportTasks as jest.Mock).mockRejectedValue(new Error('Export failed'))
       await renderAndWaitForTasks()
 
       const checkboxes = screen.getAllByRole('checkbox')

--- a/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.surgical2.test.tsx
+++ b/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.surgical2.test.tsx
@@ -43,6 +43,7 @@ jest.mock('@/lib/api/projects', () => ({
   projectsAPI: {
     export: jest.fn(),
     bulkExportTasks: jest.fn(),
+    streamExportTasks: jest.fn(),
     bulkDeleteTasks: jest.fn(),
     bulkArchiveTasks: jest.fn(),
     getMembers: jest.fn(),
@@ -690,7 +691,7 @@ describe('AnnotationTab - Surgical Branch Coverage 2', () => {
       })
 
       await waitFor(() => {
-        expect(projectsAPI.bulkExportTasks).toHaveBeenCalled()
+        expect(projectsAPI.streamExportTasks).toHaveBeenCalled()
         expect(mockAddToast).toHaveBeenCalled()
       })
     })
@@ -725,15 +726,15 @@ describe('AnnotationTab - Surgical Branch Coverage 2', () => {
         fireEvent.click(bulkExportBtn)
       })
 
-      // Should NOT have called bulkExportTasks because no tasks selected
-      expect(projectsAPI.bulkExportTasks).not.toHaveBeenCalled()
+      // Should NOT have called streamExportTasks because no tasks selected
+      expect(projectsAPI.streamExportTasks).not.toHaveBeenCalled()
     })
   })
 
   // Export failure
   describe('Export failure handling', () => {
     it('shows error toast when handleExportTasks fails', async () => {
-      ;(projectsAPI.bulkExportTasks as jest.Mock).mockRejectedValue(
+      ;(projectsAPI.streamExportTasks as jest.Mock).mockRejectedValue(
         new Error('Export failed')
       )
 

--- a/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.test.tsx
+++ b/services/frontend/src/components/projects/tabs/__tests__/AnnotationTab.test.tsx
@@ -44,6 +44,7 @@ jest.mock('@/lib/api/projects', () => ({
   projectsAPI: {
     export: jest.fn(),
     bulkExportTasks: jest.fn(),
+    streamExportTasks: jest.fn(),
     bulkDeleteTasks: jest.fn(),
     bulkArchiveTasks: jest.fn(),
     getMembers: jest.fn(),
@@ -558,6 +559,12 @@ describe('AnnotationTab', () => {
     ;(projectsAPI.bulkExportTasks as jest.Mock).mockResolvedValue(
       new Blob(['test data'])
     )
+    ;(projectsAPI.streamExportTasks as jest.Mock).mockImplementation(
+      (_projectId, _taskIds, _name, callbacks) => {
+        callbacks?.onStart?.()
+        return Promise.resolve({ bytesWritten: 9, savedVia: 'blob' })
+      }
+    )
     ;(projectsAPI.bulkDeleteTasks as jest.Mock).mockResolvedValue({
       deleted: 2,
     })
@@ -793,10 +800,11 @@ describe('AnnotationTab', () => {
       fireEvent.click(exportButton)
 
       await waitFor(() => {
-        expect(projectsAPI.bulkExportTasks).toHaveBeenCalledWith(
+        expect(projectsAPI.streamExportTasks).toHaveBeenCalledWith(
           'project-1',
           ['2'],
-          'json'
+          expect.any(String),
+          expect.any(Object)
         )
       })
     })
@@ -814,7 +822,7 @@ describe('AnnotationTab', () => {
       fireEvent.click(exportButton)
 
       await waitFor(() => {
-        expect(projectsAPI.bulkExportTasks).toHaveBeenCalled()
+        expect(projectsAPI.streamExportTasks).toHaveBeenCalled()
       })
     })
 
@@ -834,7 +842,7 @@ describe('AnnotationTab', () => {
 
   describe('Error Handling', () => {
     it('should handle export errors', async () => {
-      ;(projectsAPI.bulkExportTasks as jest.Mock).mockRejectedValue(
+      ;(projectsAPI.streamExportTasks as jest.Mock).mockRejectedValue(
         new Error('Export failed')
       )
 
@@ -1884,7 +1892,7 @@ describe('AnnotationTab', () => {
 
       // Should not call API with empty selection
       await waitFor(() => {
-        expect(projectsAPI.bulkExportTasks).not.toHaveBeenCalled()
+        expect(projectsAPI.streamExportTasks).not.toHaveBeenCalled()
       })
     })
 
@@ -2517,7 +2525,7 @@ describe('AnnotationTab', () => {
       fireEvent.click(exportButton)
 
       await waitFor(() => {
-        expect(projectsAPI.bulkExportTasks).toHaveBeenCalled()
+        expect(projectsAPI.streamExportTasks).toHaveBeenCalled()
       })
 
       // Reset to default
@@ -2719,7 +2727,7 @@ describe('AnnotationTab', () => {
 
       // Should not call API when no tasks selected
       await waitFor(() => {
-        expect(projectsAPI.bulkExportTasks).not.toHaveBeenCalled()
+        expect(projectsAPI.streamExportTasks).not.toHaveBeenCalled()
       })
     })
 

--- a/services/frontend/src/lib/api/__tests__/streamingExport.test.ts
+++ b/services/frontend/src/lib/api/__tests__/streamingExport.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Unit tests for the streaming JSON export download.
+ *
+ * Covers the two download paths (File System Access API + Blob fallback) and
+ * the completeness-sentinel validation that turns a silently-truncated
+ * download into a surfaced error.
+ */
+
+import apiClient from '@/lib/api'
+import {
+  EXPORT_COMPLETE_SENTINEL,
+  streamJsonExport,
+  supportsFileSystemAccess,
+  TruncatedExportError,
+} from '../streamingExport'
+
+jest.mock('@/lib/api', () => ({
+  __esModule: true,
+  default: { requestRaw: jest.fn() },
+}))
+
+jest.mock('@/lib/utils/logger', () => ({
+  __esModule: true,
+  default: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}))
+
+const requestRaw = (apiClient as any).requestRaw as jest.Mock
+
+// Minimal `response.body` substitute: jsdom does not implement ReadableStream,
+// so we hand the code a stream-shaped object exposing `getReader()`.
+function fakeStream(parts: string[], severAfter?: number) {
+  const enc = new TextEncoder()
+  const chunks = parts.map((p) => enc.encode(p))
+  let i = 0
+  return {
+    getReader() {
+      return {
+        read: async () => {
+          if (severAfter !== undefined && i >= severAfter) {
+            throw new TypeError('network error: connection reset')
+          }
+          if (i < chunks.length) {
+            return { done: false, value: chunks[i++] }
+          }
+          return { done: true, value: undefined }
+        },
+      }
+    },
+  }
+}
+
+function mockResponse(parts: string[], severAfter?: number) {
+  return { body: fakeStream(parts, severAfter) } as unknown as Response
+}
+
+const COMPLETE_BODY = ['{"tasks": [{"id": "t1"}], ', EXPORT_COMPLETE_SENTINEL]
+const TRUNCATED_BODY = ['{"tasks": [{"id": "t1"}', ', {"id": "t2", "evaluations": []}']
+
+describe('streamJsonExport', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    delete (window as any).showSaveFilePicker
+  })
+
+  describe('Blob fallback (no File System Access API)', () => {
+    let clickSpy: jest.Mock
+
+    beforeEach(() => {
+      clickSpy = jest.fn()
+      global.URL.createObjectURL = jest.fn(() => 'blob:mock')
+      global.URL.revokeObjectURL = jest.fn()
+      const realCreate = document.createElement.bind(document)
+      jest.spyOn(document, 'createElement').mockImplementation((tag: any) => {
+        const el = realCreate(tag)
+        if (tag === 'a') (el as any).click = clickSpy
+        return el
+      })
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('downloads when the completeness sentinel is present', async () => {
+      requestRaw.mockResolvedValue(mockResponse(COMPLETE_BODY))
+
+      const result = await streamJsonExport({
+        endpoint: '/projects/p1/tasks/bulk-export',
+        method: 'POST',
+        body: { task_ids: ['t1'], format: 'json' },
+        suggestedName: 'p1.json',
+      })
+
+      expect(result.savedVia).toBe('blob')
+      expect(clickSpy).toHaveBeenCalledTimes(1)
+      expect(requestRaw).toHaveBeenCalledWith(
+        '/projects/p1/tasks/bulk-export',
+        { method: 'POST', body: JSON.stringify({ task_ids: ['t1'], format: 'json' }) }
+      )
+    })
+
+    it('throws TruncatedExportError and never downloads when the sentinel is missing', async () => {
+      requestRaw.mockResolvedValue(mockResponse(TRUNCATED_BODY))
+
+      await expect(
+        streamJsonExport({ endpoint: '/x', suggestedName: 'p1.json' })
+      ).rejects.toBeInstanceOf(TruncatedExportError)
+      expect(clickSpy).not.toHaveBeenCalled()
+    })
+
+    it('propagates a severed stream as an error without downloading', async () => {
+      requestRaw.mockResolvedValue(mockResponse(TRUNCATED_BODY, 1))
+
+      await expect(
+        streamJsonExport({ endpoint: '/x', suggestedName: 'p1.json' })
+      ).rejects.toThrow(/network error/)
+      expect(clickSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('File System Access API', () => {
+    function setupPicker() {
+      const writes: Uint8Array[] = []
+      const writable = {
+        write: jest.fn(async (c: Uint8Array) => {
+          writes.push(c)
+        }),
+        close: jest.fn(async () => {}),
+        abort: jest.fn(async () => {}),
+      }
+      const fileHandle = { createWritable: jest.fn(async () => writable) }
+      ;(window as any).showSaveFilePicker = jest.fn(async () => fileHandle)
+      return { writable, fileHandle, writes }
+    }
+
+    it('streams to disk and commits when the sentinel is present', async () => {
+      const { writable } = setupPicker()
+      requestRaw.mockResolvedValue(mockResponse(COMPLETE_BODY))
+
+      const result = await streamJsonExport({
+        endpoint: '/x',
+        body: { a: 1 },
+        suggestedName: 'p1.json',
+      })
+
+      expect(result.savedVia).toBe('file-system-access')
+      expect(writable.write).toHaveBeenCalled()
+      expect(writable.close).toHaveBeenCalledTimes(1)
+      expect(writable.abort).not.toHaveBeenCalled()
+    })
+
+    it('aborts the write and throws when the sentinel is missing', async () => {
+      const { writable } = setupPicker()
+      requestRaw.mockResolvedValue(mockResponse(TRUNCATED_BODY))
+
+      await expect(
+        streamJsonExport({ endpoint: '/x', suggestedName: 'p1.json' })
+      ).rejects.toBeInstanceOf(TruncatedExportError)
+      expect(writable.abort).toHaveBeenCalledTimes(1)
+      expect(writable.close).not.toHaveBeenCalled()
+    })
+
+    it('aborts the write when the stream is severed mid-body', async () => {
+      const { writable } = setupPicker()
+      requestRaw.mockResolvedValue(mockResponse(COMPLETE_BODY, 1))
+
+      await expect(
+        streamJsonExport({ endpoint: '/x', suggestedName: 'p1.json' })
+      ).rejects.toThrow(/network error/)
+      expect(writable.abort).toHaveBeenCalledTimes(1)
+      expect(writable.close).not.toHaveBeenCalled()
+    })
+
+    it('propagates a save-dialog cancellation without making a request', async () => {
+      ;(window as any).showSaveFilePicker = jest
+        .fn()
+        .mockRejectedValue(new DOMException('User cancelled', 'AbortError'))
+
+      await expect(
+        streamJsonExport({ endpoint: '/x', suggestedName: 'p1.json' })
+      ).rejects.toMatchObject({ name: 'AbortError' })
+      expect(requestRaw).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('supportsFileSystemAccess', () => {
+    it('reflects presence of window.showSaveFilePicker', () => {
+      delete (window as any).showSaveFilePicker
+      expect(supportsFileSystemAccess()).toBe(false)
+      ;(window as any).showSaveFilePicker = jest.fn()
+      expect(supportsFileSystemAccess()).toBe(true)
+    })
+  })
+})

--- a/services/frontend/src/lib/api/base.ts
+++ b/services/frontend/src/lib/api/base.ts
@@ -766,6 +766,86 @@ export class BaseApiClient {
   }
 
   /**
+   * Raw, unbuffered request that returns the live `Response`.
+   *
+   * Differs from `request` in three ways that matter for large downloads:
+   * - It does NOT call `.blob()` / `.text()`, so the body is never buffered
+   *   into memory — the caller streams `response.body` itself. A multi-GB
+   *   export would otherwise exhaust browser memory.
+   * - It imposes NO `REQUEST_TIMEOUT` abort. A legitimate export can stream
+   *   for minutes; the 30s timeout on `request` would sever it mid-body and
+   *   leave a silently-truncated file.
+   * - It bypasses the response cache entirely.
+   *
+   * Auth (HttpOnly cookies + Bearer fallback) and `X-Organization-Context`
+   * are applied exactly as in `request`. The caller owns the returned stream
+   * and is responsible for consuming or aborting it.
+   */
+  async requestRaw(
+    endpoint: string,
+    options: RequestInit = {}
+  ): Promise<Response> {
+    const url = `${getApiBaseUrl()}${endpoint}`
+    const isFormData = options.body instanceof FormData
+    const headers: Record<string, string> = {}
+
+    if (!isFormData) {
+      headers['Content-Type'] = 'application/json'
+    }
+
+    if (typeof window !== 'undefined') {
+      const token = localStorage.getItem('access_token')
+      if (token && !this.isTokenExpired(token)) {
+        headers['Authorization'] = `Bearer ${token}`
+      }
+    }
+
+    if (this.organizationContextProvider) {
+      const orgContext = this.organizationContextProvider()
+      if (orgContext) {
+        headers['X-Organization-Context'] = orgContext
+      }
+    }
+
+    const response = await fetch(url, {
+      ...options,
+      credentials: 'include',
+      headers: {
+        ...headers,
+        ...options.headers,
+      },
+    })
+
+    if (!response.ok) {
+      let errorMessage = `HTTP error! status: ${response.status}`
+      try {
+        const errorText = await response.text()
+        if (errorText) {
+          try {
+            const errorData = JSON.parse(errorText)
+            errorMessage =
+              formatErrorDetail(errorData.detail) ||
+              errorData.message ||
+              errorMessage
+          } catch {
+            errorMessage += ` - ${errorText}`
+          }
+        }
+      } catch {
+        logger.debug('Could not read error text from streaming response')
+      }
+      const error = new Error(errorMessage) as any
+      error.response = {
+        status: response.status,
+        statusText: response.statusText,
+      }
+      throw error
+    }
+
+    return response
+  }
+
+  /**
    * HTTP convenience methods for testing and backward compatibility
    */
   async get(endpoint: string, options: RequestInit = {}): Promise<any> {

--- a/services/frontend/src/lib/api/index.ts
+++ b/services/frontend/src/lib/api/index.ts
@@ -250,6 +250,7 @@ export class ApiClient {
     this.put = safeBind(this.authClient, 'put')
     this.patch = safeBind(this.authClient, 'patch')
     this.delete = safeBind(this.authClient, 'delete')
+    this.requestRaw = safeBind(this.authClient, 'requestRaw')
     this.updateUserRole = safeBind(this.usersClient, 'updateUserRole')
     this.updateUserSuperadminStatus = safeBind(
       this.usersClient,
@@ -578,6 +579,9 @@ export class ApiClient {
   put: any
   patch: any
   delete: any
+  // Unbuffered streaming fetch — returns the raw Response (no body buffering,
+  // no 30s timeout, no cache). Used for large file exports.
+  requestRaw: any
 
   // User management methods
   updateUserRole: any

--- a/services/frontend/src/lib/api/projects.ts
+++ b/services/frontend/src/lib/api/projects.ts
@@ -7,6 +7,10 @@
 
 import apiClient from '@/lib/api'
 import {
+  StreamExportResult,
+  streamJsonExport,
+} from '@/lib/api/streamingExport'
+import {
   Annotation,
   AnnotationCreate,
   AnnotationResult,
@@ -444,6 +448,31 @@ export const projectsAPI = {
       { task_ids: taskIds, format }
     )
     return response
+  },
+
+  /**
+   * Stream a JSON bulk export straight to disk with completeness validation.
+   *
+   * Prefer this over `bulkExportTasks` for the JSON format: the latter buffers
+   * the entire body via `response.blob()`, which truncates or OOMs on
+   * multi-GB projects (e.g. ZJS). Throws `TruncatedExportError` if the stream
+   * is severed, or a DOMException `AbortError` if the user cancels the save
+   * dialog.
+   */
+  streamExportTasks: async (
+    projectId: string,
+    taskIds: string[],
+    suggestedName: string,
+    callbacks?: { onStart?: () => void; onProgress?: (bytes: number) => void }
+  ): Promise<StreamExportResult> => {
+    return streamJsonExport({
+      endpoint: `/projects/${projectId}/tasks/bulk-export`,
+      method: 'POST',
+      body: { task_ids: taskIds, format: 'json' },
+      suggestedName,
+      onStart: callbacks?.onStart,
+      onProgress: callbacks?.onProgress,
+    })
   },
 
   /**

--- a/services/frontend/src/lib/api/streamingExport.ts
+++ b/services/frontend/src/lib/api/streamingExport.ts
@@ -1,0 +1,223 @@
+/**
+ * Streaming JSON export download.
+ *
+ * Large project exports (the ZJS dataset is ~4.5 GB / hundreds of tasks)
+ * cannot go through the normal `response.blob()` path: buffering the whole
+ * body in browser memory either OOMs the tab or — worse — gets severed by a
+ * proxy / connection drop and silently saved as a truncated, invalid file.
+ *
+ * This module streams the response straight to disk via the File System
+ * Access API when available (Chromium), so the body never sits in memory,
+ * and validates the server's completeness sentinel on every path so a
+ * severed stream surfaces as an error instead of a corrupt download.
+ */
+
+import apiClient from '@/lib/api'
+import logger from '@/lib/utils/logger'
+
+/**
+ * Trailing marker the server emits as the very last bytes of a complete JSON
+ * export (see `services/api/routers/projects/_export_stream.py`). Its presence
+ * is the only reliable completeness signal: a truncated file's tail (a task
+ * object's `"evaluations": []}`) is otherwise indistinguishable from a clean
+ * end (`]}`).
+ */
+export const EXPORT_COMPLETE_SENTINEL = '"export_complete": true}'
+
+// Trailing bytes retained to test for the sentinel — large enough to hold the
+// marker plus any whitespace the server might emit after it.
+const TAIL_BYTES = 256
+
+export class TruncatedExportError extends Error {
+  constructor(
+    message = 'The export ended before the server finished writing it — the file is incomplete. Please retry.'
+  ) {
+    super(message)
+    this.name = 'TruncatedExportError'
+  }
+}
+
+export interface StreamExportResult {
+  bytesWritten: number
+  savedVia: 'file-system-access' | 'blob'
+}
+
+export interface StreamExportOptions {
+  endpoint: string
+  method?: string
+  body?: unknown
+  /** Default filename offered in the save dialog / used by the fallback. */
+  suggestedName: string
+  /** Fired once, after the save target is acquired and just before the
+   *  network request begins. Lets callers defer their progress UI past the
+   *  (cancelable) save-file picker. */
+  onStart?: () => void
+  onProgress?: (bytesWritten: number) => void
+}
+
+export function supportsFileSystemAccess(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof (window as any).showSaveFilePicker === 'function'
+  )
+}
+
+/**
+ * Stream a JSON export to disk, validating the completeness sentinel.
+ *
+ * On Chromium the body streams directly to the user-chosen file and never
+ * buffers in memory; elsewhere it falls back to buffering a Blob (still
+ * validated, but bounded by available memory). Throws {@link TruncatedExportError}
+ * if the stream was severed, and may throw a DOMException with name
+ * `'AbortError'` if the user dismisses the save dialog — callers should treat
+ * that as a silent cancellation.
+ */
+export async function streamJsonExport(
+  options: StreamExportOptions
+): Promise<StreamExportResult> {
+  const { endpoint, method = 'POST', body, suggestedName, onStart, onProgress } =
+    options
+
+  // Acquire the save target BEFORE the request so the picker runs under the
+  // originating click's transient activation, and so a cancel here bails out
+  // before any work or progress UI is started.
+  let fileHandle: any = null
+  if (supportsFileSystemAccess()) {
+    fileHandle = await (window as any).showSaveFilePicker({
+      suggestedName,
+      types: [
+        {
+          description: 'JSON export',
+          accept: { 'application/json': ['.json'] },
+        },
+      ],
+    })
+  }
+
+  onStart?.()
+
+  const response = await apiClient.requestRaw(endpoint, {
+    method,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+
+  if (!response.body) {
+    throw new Error('Export response did not include a readable body stream')
+  }
+
+  if (fileHandle) {
+    return streamToFileHandle(response.body, fileHandle, onProgress)
+  }
+  return bufferToBlobDownload(response.body, suggestedName, onProgress)
+}
+
+async function streamToFileHandle(
+  stream: ReadableStream<Uint8Array>,
+  fileHandle: any,
+  onProgress?: (bytesWritten: number) => void
+): Promise<StreamExportResult> {
+  const writable = await fileHandle.createWritable()
+  const reader = stream.getReader()
+  let bytesWritten = 0
+  let tail: Uint8Array = new Uint8Array(0)
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (value && value.byteLength) {
+        await writable.write(value)
+        bytesWritten += value.byteLength
+        tail = keepTail(tail, value)
+        onProgress?.(bytesWritten)
+      }
+    }
+  } catch (err) {
+    // Connection severed mid-stream: discard the partial write so the user is
+    // never left with a half-written file that looks complete.
+    await safeAbort(writable)
+    throw err
+  }
+
+  if (!tailHasSentinel(tail)) {
+    // Clean TCP close but truncated content — abort before commit so no file
+    // is produced, then surface the error.
+    await safeAbort(writable)
+    throw new TruncatedExportError()
+  }
+
+  await writable.close()
+  return { bytesWritten, savedVia: 'file-system-access' }
+}
+
+async function bufferToBlobDownload(
+  stream: ReadableStream<Uint8Array>,
+  suggestedName: string,
+  onProgress?: (bytesWritten: number) => void
+): Promise<StreamExportResult> {
+  const reader = stream.getReader()
+  const chunks: Uint8Array[] = []
+  let bytesWritten = 0
+  let tail: Uint8Array = new Uint8Array(0)
+
+  // A severed connection throws here and propagates — no partial download is
+  // ever triggered.
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (value && value.byteLength) {
+      chunks.push(value)
+      bytesWritten += value.byteLength
+      tail = keepTail(tail, value)
+      onProgress?.(bytesWritten)
+    }
+  }
+
+  // Everything is in memory here, so validate before producing a file: a
+  // truncated stream never yields a download at all.
+  if (!tailHasSentinel(tail)) {
+    throw new TruncatedExportError()
+  }
+
+  triggerBlobDownload(
+    new Blob(chunks as BlobPart[], { type: 'application/json' }),
+    suggestedName
+  )
+  return { bytesWritten, savedVia: 'blob' }
+}
+
+function triggerBlobDownload(blob: Blob, filename: string): void {
+  const url = window.URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.style.display = 'none'
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  window.URL.revokeObjectURL(url)
+  document.body.removeChild(a)
+}
+
+function keepTail(prev: Uint8Array, chunk: Uint8Array): Uint8Array {
+  if (chunk.byteLength >= TAIL_BYTES) {
+    return chunk.slice(chunk.byteLength - TAIL_BYTES)
+  }
+  const combined = new Uint8Array(prev.byteLength + chunk.byteLength)
+  combined.set(prev, 0)
+  combined.set(chunk, prev.byteLength)
+  return combined.byteLength > TAIL_BYTES
+    ? combined.slice(combined.byteLength - TAIL_BYTES)
+    : combined
+}
+
+function tailHasSentinel(tail: Uint8Array): boolean {
+  return new TextDecoder().decode(tail).trimEnd().endsWith(EXPORT_COMPLETE_SENTINEL)
+}
+
+async function safeAbort(writable: any): Promise<void> {
+  try {
+    await writable.abort?.()
+  } catch (err) {
+    logger.debug('Failed to abort export writable stream', err)
+  }
+}


### PR DESCRIPTION
## Summary
- The project JSON export buffered the whole response via `response.blob()` and rode the 30s request timeout, so a large export (the ~4.5 GB ZJS dataset) was severed mid-body and **silently saved as a truncated, invalid file with a success toast**.
- Export stream now ends with a completeness sentinel (`"export_complete": true}`) so a truncated tail is distinguishable from a clean end.
- New `BaseApiClient.requestRaw` returns the raw `Response` — no blob buffering, no 30s timeout, no cache — with the same cookie/Bearer auth and `X-Organization-Context` as `request`.
- `streamJsonExport` streams straight to disk via the File System Access API (Chromium) and falls back to a buffered Blob elsewhere; both paths validate the sentinel and surface `TruncatedExportError` instead of writing a corrupt file. Save-dialog cancel is a silent no-op.
- `AnnotationTab` export handlers (data-page export + selected-tasks bulk export) now use the streaming path with an error toast on truncation.

## Test plan
- [x] Frontend Jest: 9 suites / 305 tests (5 AnnotationTab specs + `projects.test.ts` + new `streamingExport.test.ts`)
- [x] `tsc --noEmit` clean
- [x] API pytest `test_bulk_export_tasks.py` 11/11, incl. new `test_export_json_ends_with_completeness_sentinel`
- [ ] Manual: export a large project in Chromium (stream-to-disk) and a non-Chromium browser (Blob fallback); verify a truncated download raises an error instead of saving a corrupt file

> ⚠️ Merging this PR to `main` deploys directly to **production**.