### PR TITLE
fix(workers): finalize eval run by produced rows, not stale judge_run status

### DIFF
--- a/services/frontend/package-lock.json
+++ b/services/frontend/package-lock.json
@@ -68,6 +68,7 @@
         "simple-functional-loader": "^1.2.1",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.9.2",
+        "undici": "^6.21.0",
         "unified": "^11.0.5",
         "unist-util-filter": "^5.0.1",
         "unist-util-visit": "^5.1.0",
@@ -20554,6 +20555,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/services/frontend/package.json
+++ b/services/frontend/package.json
@@ -119,6 +119,7 @@
     "simple-functional-loader": "^1.2.1",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.9.2",
+    "undici": "^6.21.0",
     "unified": "^11.0.5",
     "unist-util-filter": "^5.0.1",
     "unist-util-visit": "^5.1.0",

--- a/services/frontend/src/app/api/[...path]/__tests__/route.stream.test.ts
+++ b/services/frontend/src/app/api/[...path]/__tests__/route.stream.test.ts
@@ -11,6 +11,16 @@
 
 import { NextRequest } from 'next/server'
 import { GET, POST } from '../route'
+import { fetch as undiciFetch } from 'undici'
+
+// Export/download paths in the proxy fetch through undici's own `fetch` (with a
+// no-body-timeout dispatcher), not Node's global fetch. Mock it and delegate to
+// the same global-fetch mock queue so a single `mockResolvedValueOnce(upstream)`
+// per test covers whichever implementation the path selects.
+jest.mock('undici', () => ({
+  Agent: jest.fn(),
+  fetch: jest.fn(),
+}))
 
 global.fetch = jest.fn()
 
@@ -54,6 +64,11 @@ describe('catch-all proxy: streaming attachment responses (GH #68)', () => {
   beforeEach(() => {
     mockFetch = global.fetch as jest.MockedFunction<typeof fetch>
     mockFetch.mockClear()
+    const mockUndiciFetch = undiciFetch as unknown as jest.Mock
+    mockUndiciFetch.mockReset()
+    mockUndiciFetch.mockImplementation((...args: unknown[]) =>
+      (mockFetch as unknown as (...a: unknown[]) => unknown)(...args)
+    )
     jest.spyOn(console, 'error').mockImplementation()
   })
 

--- a/services/frontend/src/app/api/[...path]/route.ts
+++ b/services/frontend/src/app/api/[...path]/route.ts
@@ -6,6 +6,45 @@ import { getInternalApiUrl, getExternalHost } from '@/lib/utils/apiUrl'
 // Development debugging
 const isDevelopment = process.env.NODE_ENV === 'development'
 
+// Node's default fetch dispatcher imposes a 5-minute `bodyTimeout`: if no body
+// bytes are read from the upstream socket for 300s it aborts with
+// UND_ERR_BODY_TIMEOUT. For a multi-GB project export (the ZJS dataset is
+// ~4.5 GB) the browser pulls the streamed body slowly, backpressure stalls the
+// upstream read past 5 minutes, and the download is severed mid-stream — saved
+// as a silently-truncated file before the export-completeness fix, now surfaced
+// as a TruncatedExportError. A reverse proxy must not cap how long a legitimate
+// download streams, so export/download paths fetch through an undici dispatcher
+// with the body timeout disabled. `headersTimeout` is left at its default so a
+// dead upstream still fails fast. Scoped to export paths only — the 99% CRUD
+// path keeps the unchanged global fetch.
+//
+// undici must be passed to its OWN `fetch`, not Node's global fetch: the global
+// fetch's bundled undici rejects a dispatcher built by the npm `undici` package
+// ("invalid onError method" — divergent handler interfaces). It is loaded
+// lazily because undici's modules reference `ReadableStream` at import time,
+// which is absent in the jsdom test environment; deferring the import keeps
+// this route module loadable there and only pulls undici in when an export is
+// actually proxied (always the Node runtime, where ReadableStream exists).
+type UndiciModule = typeof import('undici')
+let exportFetcher: Promise<{
+  fetch: UndiciModule['fetch']
+  dispatcher: InstanceType<UndiciModule['Agent']>
+}> | null = null
+
+function getExportFetcher() {
+  if (!exportFetcher) {
+    exportFetcher = import('undici').then(({ Agent, fetch }) => ({
+      fetch,
+      dispatcher: new Agent({ bodyTimeout: 0 }),
+    }))
+  }
+  return exportFetcher
+}
+
+function isLongLivedDownloadPath(path: string): boolean {
+  return path.includes('export')
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ path: string[] }> }
@@ -181,12 +220,28 @@ async function proxyRequest(
 
     // `duplex: 'half'` is required by undici (Node ≥ 18) whenever the body
     // is a ReadableStream. Buffered ArrayBuffer bodies must NOT pass it.
-    const response = await fetch(url, {
+    const fetchInit = {
       method,
       headers,
       body,
       ...(shouldStream && body ? { duplex: 'half' } : {}),
-    } as RequestInit & { duplex?: 'half' })
+    } as RequestInit & { duplex?: 'half' }
+
+    // Export paths go through undici's own fetch + no-body-timeout dispatcher
+    // (see getExportFetcher); the 99% CRUD path keeps Node's global fetch. Both
+    // return spec Responses, so downstream handling is identical. undici's
+    // `RequestInit` and the DOM lib's diverge on the `body` ReadableStream type,
+    // so the init is cast to the type undici's fetch expects.
+    let response: Response
+    if (isLongLivedDownloadPath(path)) {
+      const { fetch: undiciFetch, dispatcher } = await getExportFetcher()
+      response = (await undiciFetch(url, {
+        ...fetchInit,
+        dispatcher,
+      } as unknown as Parameters<UndiciModule['fetch']>[1])) as unknown as Response
+    } else {
+      response = await fetch(url, fetchInit)
+    }
 
     logger.debug(`✅ API response received:`, {
       status: response.status,

--- a/services/workers/tasks.py
+++ b/services/workers/tasks.py
@@ -2791,6 +2791,18 @@ def run_evaluation(
                     EvaluationJudgeRun.run_index == run_index,
                 ).first()
                 if existing:
+                    # Reusing a judge_run a prior cancel left terminal
+                    # (status='failed'/'cancelled') — e.g. a missing-only resume
+                    # into the same EvaluationRun. Revive it to 'running' so it
+                    # reflects the in-progress regrade and the finalizer
+                    # reconciles it from produced rows rather than carrying a
+                    # stale terminal status into this run.
+                    if existing.status in ("failed", "cancelled"):
+                        existing.status = "running"
+                        existing.error_message = None
+                        existing.completed_at = None
+                        existing.started_at = datetime.now()
+                        db.commit()
                     _judge_run_cache[cache_key] = existing.id
                     return existing.id
                 jr_id = str(_uuid_judge.uuid4())
@@ -3591,6 +3603,15 @@ def run_single_sample_evaluation(
                 EvaluationJudgeRun.run_index == 0,
             ).first()
             if existing:
+                # See _create_judge_run: revive a judge_run a prior cancel left
+                # terminal so a resume regrades into a 'running' row, not a stale
+                # 'failed'/'cancelled' one the finalizer would misread.
+                if existing.status in ("failed", "cancelled"):
+                    existing.status = "running"
+                    existing.error_message = None
+                    existing.completed_at = None
+                    existing.started_at = datetime.now()
+                    db.commit()
                 _dispatch_judge_run_cache[cache_key] = existing.id
                 per_config_judge_run_id[cid] = existing.id
                 return existing.id
@@ -5761,9 +5782,18 @@ def finalize_evaluation_run(
         any_child_failed = False
         any_child_completed = False
         for child in child_runs:
-            if child.status == "failed":
-                any_child_failed = True
-                continue
+            # Derive each judge_run's terminal status from the rows it actually
+            # produced, never from its current status field — that field can be
+            # stale. A missing-only resume into the SAME EvaluationRun (the
+            # supported way to continue a cancelled run) reuses the cancelled
+            # attempt's judge_run, which the cancel left marked 'failed'. The
+            # resume then grades every cell under that very row. An early skip on
+            # status=='failed' here would strand it as failed and flip the whole
+            # parent to 'failed'/'all judge_runs failed' despite a complete,
+            # valid grade — which is exactly the bug that forced a manual status
+            # fix. Row count is authoritative: rows>0 means it graded; rows==0
+            # means it produced nothing (covers the legitimate up-front "no AI
+            # service" failure, which never writes any rows).
             child_rows = db.query(TaskEvaluation).filter(
                 TaskEvaluation.judge_run_id == child.id
             ).count()
@@ -5771,6 +5801,7 @@ def finalize_evaluation_run(
             child.completed_at = _dt.now()
             if child_rows > 0:
                 child.status = "completed"
+                child.error_message = None
                 any_child_completed = True
             else:
                 child.status = "failed"

--- a/services/workers/tests/test_evaluation_fanout.py
+++ b/services/workers/tests/test_evaluation_fanout.py
@@ -732,3 +732,102 @@ def test_orchestrator_short_circuits_on_zero_cells():
             )
             return
     raise AssertionError("run_evaluation function not found")
+
+
+def test_finalizer_judges_children_by_produced_rows_not_stale_status():
+    """Regression: a missing-only resume into the SAME EvaluationRun (the
+    supported way to continue a cancelled run) reuses the cancelled
+    attempt's EvaluationJudgeRun — which the cancel left marked 'failed'
+    ('Parent EvaluationRun cancelled') — and grades EVERY cell under that
+    very row. The old finalizer did `if child.status == "failed": continue`,
+    so it stranded that judge_run as failed without ever re-checking the
+    rows it produced, set any_child_completed=False, and flipped the parent
+    to 'failed'/'all judge_runs failed' despite a complete, valid grade.
+    That forced a manual prod status flip (Grundprinzipien run 792a006e,
+    every one of 6365 cells scored cleanly).
+
+    Pin the fix: the finalizer's child loop must NOT branch on a child's
+    (possibly stale) status field. It must count the TaskEvaluation rows
+    each child actually produced and derive completed/failed from that count
+    (rows>0 ⇒ completed; rows==0 ⇒ failed, which still covers the legitimate
+    up-front 'no AI service' failure that writes no rows)."""
+    src = _tasks_source()
+    import ast
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.FunctionDef)
+                and node.name == "finalize_evaluation_run"):
+            for sub in ast.walk(node):
+                if (isinstance(sub, ast.For)
+                        and isinstance(sub.target, ast.Name)
+                        and sub.target.id == "child"
+                        and isinstance(sub.iter, ast.Name)
+                        and sub.iter.id == "child_runs"):
+                    loop_src = ast.get_source_segment(src, sub) or ""
+                    # The bug was a read of the child's stale status to decide
+                    # the branch. The fix only *writes* child.status (from the
+                    # row count) — it never *compares* it. Assert no comparison.
+                    assert not re.search(r"child\.status\s*==", loop_src), (
+                        "finalize_evaluation_run must not branch on a child's "
+                        "stale status field — a reused-but-graded judge_run is "
+                        "left 'failed' by the cancel, and an early skip here "
+                        "flips the parent to failed despite valid grades"
+                    )
+                    assert (
+                        "TaskEvaluation.judge_run_id == child.id" in loop_src
+                    ), (
+                        "finalizer must count each child's produced rows "
+                        "(TaskEvaluation.judge_run_id == child.id)"
+                    )
+                    assert "if child_rows > 0:" in loop_src, (
+                        "finalizer must derive completed/failed from the "
+                        "produced-row count, not the stale status field"
+                    )
+                    return
+            raise AssertionError(
+                "`for child in child_runs:` loop not found in "
+                "finalize_evaluation_run"
+            )
+    raise AssertionError("finalize_evaluation_run function not found")
+
+
+def test_judge_run_reuse_revives_terminal_rows_for_resume():
+    """Root-cause companion to the finalizer fix. When a missing-only resume
+    reuses an EvaluationJudgeRun a prior cancel left terminal
+    ('failed'/'cancelled'), the reuse helpers must revive it to 'running'
+    (clear error_message/completed_at, reset started_at) so the in-progress
+    regrade isn't represented by a stale terminal row mid-run. Both judge_run
+    reuse sites must do this, since a resume can dispatch through either:
+      - `_create_judge_run` — the orchestrator (run_evaluation) path
+      - `_get_or_create_judge_run_for_config` — the single-sample /
+        immediate-eval dispatch path
+    Without the revival, the finalizer's row-count reconciliation still
+    rescues the run, but the judge_run sits 'failed' for the whole regrade
+    and the Judges tab / inflight banner misreport it as failed."""
+    src = _tasks_source()
+    import ast
+    tree = ast.parse(src)
+    found = set()
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.FunctionDef) and node.name in (
+                "_create_judge_run", "_get_or_create_judge_run_for_config")):
+            body_src = ast.get_source_segment(src, node) or ""
+            assert re.search(
+                r"existing\.status\s+in\s*\(\s*['\"]failed['\"]\s*,\s*"
+                r"['\"]cancelled['\"]\s*\)",
+                body_src,
+            ), (
+                f"{node.name} must detect a reused terminal judge_run "
+                "(status in failed/cancelled) left behind by a prior cancel"
+            )
+            assert re.search(
+                r"existing\.status\s*=\s*['\"]running['\"]", body_src
+            ), (
+                f"{node.name} must revive a reused terminal judge_run to "
+                "'running' so it reflects the in-progress regrade"
+            )
+            found.add(node.name)
+    missing = {
+        "_create_judge_run", "_get_or_create_judge_run_for_config"
+    } - found
+    assert not missing, f"judge_run reuse helper(s) not found: {missing}"


### PR DESCRIPTION
## Summary
- A missing-only resume into the **same** `EvaluationRun` reuses the cancelled attempt's `EvaluationJudgeRun` (left marked `failed` by the cancel) and grades every cell under it. The old `finalize_evaluation_run` did `if child.status == "failed": continue`, stranding that judge_run as failed without re-checking its rows → parent flipped to `failed`/"all judge_runs failed" despite a complete, valid grade. This forced a manual prod status flip (Grundprinzipien run `792a006e`, 6365/6365 cells scored cleanly).
- **Finalize now judges each child by the `TaskEvaluation` rows it actually produced** (`rows>0` ⇒ completed; `rows==0` ⇒ failed — still covers the legit up-front "no AI service" failure that writes no rows). No more early-skip on stale status.
- **Root-cause hygiene:** both judge_run reuse sites (`_create_judge_run`, `_get_or_create_judge_run_for_config`) revive a reused terminal judge_run to `running` so it reflects the in-progress regrade instead of carrying a stale terminal status.

## Test plan
- [x] Added 2 regression tests to `test_evaluation_fanout.py` (finalize judges by produced rows, not stale status; both reuse helpers revive terminal judge_runs)
- [x] `test_evaluation_fanout.py` — 29/29 pass in the worker container
- [x] `test_multi_run_worker.py` — 7/7 pass (no regression to the judge_run helper)