### PR TITLE
fix(import): correct project-created notification; tidy export logging (#158)

### DIFF
--- a/services/api/routers/projects/import_export.py
+++ b/services/api/routers/projects/import_export.py
@@ -250,13 +250,12 @@ async def export_project(
     if not check_project_accessible(db, current_user, project_id, org_context):
         raise HTTPException(status_code=403, detail="Access denied")
 
-    # JSON path streams via the shared helper. The legacy in-memory builder
-    # below loaded the entire project (tasks + annotations + generations +
-    # task_evaluations) into one dict and json.dumps()-ed it, which peaked
-    # past the 3Gi API memory limit on the Benchathon project (~8k
-    # task_evaluations, ~400 MB output) and OOMKilled the pod mid-response.
-    # CSV/TSV/TXT/label_studio still use the legacy path — each has a
-    # per-row shape its own tests assert on and a separate refactor.
+    # Every format streams via a per-format generator in export_stream. The
+    # legacy in-memory builder that loaded the whole project (tasks +
+    # annotations + generations + task_evaluations) into one dict and
+    # json.dumps()-ed it is gone — it peaked past the 3Gi API memory limit on
+    # the Benchathon project (~8k task_evaluations, ~400 MB output) and
+    # OOMKilled the pod mid-response (#158).
     if format == "json":
         # Header (project metadata + count tallies) is built by the shared
         # helper so the async worker export emits a byte-identical header.
@@ -857,9 +856,10 @@ async def bulk_export_full_projects(
 
     org_context = get_org_context_from_request(request)
 
-    print(f"[EXPORT DEBUG] Received project_ids: {project_ids}")
-    print(
-        f"[EXPORT DEBUG] Current user: {current_user.email}, is_superadmin: {current_user.is_superadmin}"
+    logger.info(
+        "bulk-export-full: %d project(s) requested by %s",
+        len(project_ids),
+        current_user.email,
     )
 
     # Write the ZIP to a tempfile on disk and stream each project's JSON
@@ -883,18 +883,20 @@ async def bulk_export_full_projects(
         with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zip_file:
             for project_id in project_ids:
                 try:
-                    print(f"[EXPORT DEBUG] Processing project_id: {project_id}")
-
                     project = db.query(Project).filter(Project.id == project_id).first()
                     if not project:
-                        print(f"[EXPORT DEBUG] Project {project_id} not found in database")
+                        logger.warning(
+                            "bulk-export-full: project %s not found, skipping",
+                            project_id,
+                        )
                         continue
 
                     if not check_project_accessible(db, current_user, project_id, org_context):
-                        print(f"[EXPORT DEBUG] Access denied for project {project_id}, skipping")
+                        logger.warning(
+                            "bulk-export-full: access denied for project %s, skipping",
+                            project_id,
+                        )
                         continue
-
-                    print(f"[EXPORT DEBUG] Streaming comprehensive data for project {project_id}")
 
                     safe_title = "".join(
                         c for c in project.title if c.isalnum() or c in (' ', '-', '_')
@@ -919,10 +921,12 @@ async def bulk_export_full_projects(
                     exported_count += 1
 
                 except Exception as e:
-                    print(f"[EXPORT DEBUG] Error exporting project {project_id}: {str(e)}")
-                    import traceback
-
-                    print(f"[EXPORT DEBUG] Traceback: {traceback.format_exc()}")
+                    logger.error(
+                        "bulk-export-full: error exporting project %s: %s",
+                        project_id,
+                        e,
+                        exc_info=True,
+                    )
                     continue
     except BaseException:
         # If anything blows up mid-build, don't leak the tempfile.

--- a/services/shared/import_stream.py
+++ b/services/shared/import_stream.py
@@ -1528,6 +1528,38 @@ def _create_imported_project(
     ctx.new_project_id = new_project_id
 
 
+def _notify_project_imported(ctx: "_FullImportContext", new_title: str) -> None:
+    """Best-effort 'project created' notification for a freshly-imported project.
+
+    Lazy-imports notification_service so a worker that can't import it still
+    finishes the import, and swallows every error so a notification failure can
+    never fail an otherwise-successful import. Resolves the creator name and the
+    owning organization (always set by _create_imported_project) to satisfy the
+    notify_project_created(db, project_id, title, creator_name, org_id) signature
+    — the previous 2-arg call raised TypeError and silently dropped the notice.
+    """
+    try:
+        from notification_service import notify_project_created
+
+        creator = ctx.db.query(User).filter(User.id == ctx.user_id).first()
+        project_org = (
+            ctx.db.query(ProjectOrganization)
+            .filter(ProjectOrganization.project_id == ctx.new_project_id)
+            .first()
+        )
+        if project_org is None:
+            return
+        notify_project_created(
+            db=ctx.db,
+            project_id=ctx.new_project_id,
+            project_title=new_title,
+            creator_name=creator.name if creator else "",
+            organization_id=project_org.organization_id,
+        )
+    except Exception as e:
+        logger.warning(f"Failed to send project import notification: {e}")
+
+
 def _build_full_import_stats(
     ctx: _FullImportContext,
     *,
@@ -1769,14 +1801,7 @@ def run_ndjson_import(db, fileobj, user_id: str) -> dict:
 
     db.commit()
 
-    # Send notification. Best-effort: lazy-import so a worker that can't import
-    # notification_service still finishes the import.
-    try:
-        from notification_service import notify_project_created
-
-        notify_project_created(ctx.new_project_id, user_id)
-    except Exception as e:
-        logger.warning(f"Failed to send project import notification: {e}")
+    _notify_project_imported(ctx, new_title)
 
     import_stats = _build_full_import_stats(
         ctx,
@@ -1934,15 +1959,7 @@ def run_full_project_import(db, fileobj, user_id: str) -> dict:
     # Commit all changes
     db.commit()
 
-    # Send notification. Best-effort: lazy-import so a worker that can't import
-    # notification_service still finishes the import.
-    try:
-        from notification_service import notify_project_created
-
-        notify_project_created(ctx.new_project_id, user_id)
-    except Exception as e:
-        # Don't fail import if notification fails
-        logger.warning(f"Failed to send project import notification: {e}")
+    _notify_project_imported(ctx, new_title)
 
     import_stats = _build_full_import_stats(
         ctx,


### PR DESCRIPTION
## Summary
Polish fixes on top of the now-complete #158 async export/import work:

- **Import notification bug:** `run_ndjson_import` / `run_full_project_import` called `notify_project_created(project_id, user_id)` with two positional args, but the function requires five (`db, project_id, title, creator_name, organization_id`). The call raised `TypeError` on every successful import; the surrounding `except` swallowed it, so the "project created" notice was silently dropped. Both paths now go through a shared `_notify_project_imported` helper that resolves the creator + owning org and passes the full signature (still best-effort / swallowing).
- **Export logging:** replaced the leftover `[EXPORT DEBUG] print()` statements in `bulk-export-full` with `logger` calls.
- **Stale comment:** `GET /export` had a comment claiming CSV/TSV/TXT/label_studio still used the removed in-memory builder; all formats stream via per-format generators now.

No new dependencies, no schema changes, no behavior change to the async export/import endpoints.

## Test plan
- [x] API import-path tests pass (64/64)
- [x] Worker export/import task tests pass (14/14)
- [ ] Platform CI green on this PR
- [ ] Post-deploy: confirm import still succeeds and a "project created" notification is now emitted