### PR TITLE
fix(users): make user deletion self-clean all users.id FK references

### DIFF
--- a/services/api/alembic/versions/059_user_delete_fk_ondelete.py
+++ b/services/api/alembic/versions/059_user_delete_fk_ondelete.py
@@ -1,0 +1,95 @@
+"""add ON DELETE rules to user FK constraints so user deletion self-cleans
+
+Deleting a user 500'd with a ForeignKeyViolation because most FKs referencing
+``users.id`` were created with no ``ON DELETE`` action (RESTRICT). The reported
+case was ``korrektur_comments`` (constraint still named ``feedback_comments_*``
+from before the table rename), but ~30 FKs were RESTRICT.
+
+This migration only converts the cases where the DB can safely self-clean:
+  - nullable reference columns          -> ``SET NULL``
+  - per-user ephemeral data             -> ``CASCADE``
+
+NOT-NULL ownership/audit columns (projects.created_by, korrektur_comments.
+created_by, templates, etc.) intentionally stay RESTRICT — a user delete must
+never silently destroy authored content. Those are reassigned to a fallback
+superadmin in application code (``auth_module/user_service.py:delete_user``).
+
+Defensive by design: the actual constraint name is looked up per (table,
+column) instead of hardcoded (legacy ``feedback_comments_*`` / ``annotation_
+timer_sessions_*`` names exist), and tables absent from a ``create_all``-built
+schema are skipped. Re-running is a no-op.
+
+Revision ID: 059_user_delete_fk_ondelete
+Revises: 058_add_export_import_jobs
+Create Date: 2026-06-03
+"""
+
+from sqlalchemy import inspect
+
+from alembic import op
+
+
+revision = "059_user_delete_fk_ondelete"
+down_revision = "058_add_export_import_jobs"
+branch_labels = None
+depends_on = None
+
+
+# Nullable reference columns -> NULL the reference when the user is deleted.
+SET_NULL_FKS = [
+    ("annotations", "reviewed_by"),
+    ("default_evaluation_configs", "updated_by"),
+    ("default_prompts", "updated_by"),
+    ("korrektur_comments", "resolved_by"),
+    ("project_reports", "published_by"),
+    ("tags", "created_by"),
+    ("users", "email_verified_by_id"),  # self-referential (verifier)
+]
+
+# Per-user ephemeral data -> delete with the user.
+CASCADE_FKS = [
+    ("notifications", "user_id"),
+    ("notification_preferences", "user_id"),
+    ("user_column_preferences", "user_id"),
+    ("refresh_tokens", "user_id"),
+]
+
+
+def _existing_users_fk(insp, table: str, column: str):
+    """Return the name of the FK on table.column referencing users, or None."""
+    for fk in insp.get_foreign_keys(table):
+        if fk.get("referred_table") == "users" and column in fk.get(
+            "constrained_columns", []
+        ):
+            return fk.get("name")
+    return None
+
+
+def _set_ondelete(table: str, column: str, ondelete) -> None:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    if table not in insp.get_table_names():
+        return
+    existing = _existing_users_fk(insp, table, column)
+    if existing:
+        op.drop_constraint(existing, table, type_="foreignkey")
+    op.create_foreign_key(
+        f"{table}_{column}_fkey",
+        table,
+        "users",
+        [column],
+        ["id"],
+        ondelete=ondelete,
+    )
+
+
+def upgrade() -> None:
+    for table, column in SET_NULL_FKS:
+        _set_ondelete(table, column, "SET NULL")
+    for table, column in CASCADE_FKS:
+        _set_ondelete(table, column, "CASCADE")
+
+
+def downgrade() -> None:
+    for table, column in SET_NULL_FKS + CASCADE_FKS:
+        _set_ondelete(table, column, None)

--- a/services/api/auth_module/user_service.py
+++ b/services/api/auth_module/user_service.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 
 import bcrypt
 from fastapi import HTTPException, status
-from sqlalchemy import or_
+from sqlalchemy import inspect, or_, text
 from sqlalchemy.orm import Session
 
 from models import User
@@ -517,53 +517,73 @@ def delete_user(db: Session, user_id: str) -> bool:
             {"created_by": FALLBACK_SUPERADMIN_ID}, synchronize_session=False
         )
 
-        try:
-            from project_models import (
-                Annotation,
-                ExportLog,
-                GeneratedResult,
-                ImportJob,
-                Project,
-                ProjectCollaborator,
-                Task,
-                TaskAssignment,
-            )
+        # Cleanup Phase 3: every users.id reference with no ON DELETE rule
+        # (RESTRICT) that the working per-class blocks above don't already cover.
+        # Driven by curated (table, column) lists rather than ORM classes so a
+        # newly added table is one list entry, not another import that can
+        # silently slip through. This previously lived in a
+        # `from project_models import (...)` block guarded by `except ImportError:
+        # pass`; four of the imported names (ExportLog, GeneratedResult, ImportJob,
+        # ProjectCollaborator) no longer exist after the model consolidation, so
+        # the whole block — including the projects.created_by reassignment — was
+        # silently skipped, leaving user deletion broken for anyone who authored a
+        # project. Table and column names are constants (no injection); the user id
+        # is bound. The existence guard covers the test schema, which is built from
+        # /shared models via create_all and omits migration-only tables (prompts,
+        # default_prompts, flexible_annotations).
+        existing_tables = set(inspect(db.get_bind()).get_table_names())
 
-            db.query(Project).filter(Project.created_by == user_id).update(
-                {"created_by": FALLBACK_SUPERADMIN_ID}, synchronize_session=False
-            )
-            db.query(ProjectCollaborator).filter(ProjectCollaborator.user_id == user_id).delete(
-                synchronize_session=False
-            )
-            db.query(TaskAssignment).filter(TaskAssignment.assigned_by == user_id).update(
-                {"assigned_by": FALLBACK_SUPERADMIN_ID}, synchronize_session=False
-            )
-            db.query(TaskAssignment).filter(TaskAssignment.user_id == user_id).delete(
-                synchronize_session=False
-            )
-            db.query(Task).filter(Task.assigned_to == user_id).update(
-                {"assigned_to": None}, synchronize_session=False
-            )
-            db.query(Task).filter(Task.created_by == user_id).update(
-                {"created_by": FALLBACK_SUPERADMIN_ID}, synchronize_session=False
-            )
-            db.query(Task).filter(Task.updated_by == user_id).update(
-                {"updated_by": FALLBACK_SUPERADMIN_ID}, synchronize_session=False
-            )
-            db.query(Annotation).filter(Annotation.completed_by == user_id).update(
-                {"completed_by": FALLBACK_SUPERADMIN_ID}, synchronize_session=False
-            )
-            db.query(GeneratedResult).filter(GeneratedResult.created_by == user_id).update(
-                {"created_by": FALLBACK_SUPERADMIN_ID}, synchronize_session=False
-            )
-            db.query(ExportLog).filter(ExportLog.exported_by == user_id).update(
-                {"exported_by": FALLBACK_SUPERADMIN_ID}, synchronize_session=False
-            )
-            db.query(ImportJob).filter(ImportJob.imported_by == user_id).update(
-                {"imported_by": FALLBACK_SUPERADMIN_ID}, synchronize_session=False
-            )
-        except ImportError:
-            pass
+        reassign_to_fallback = [
+            ("projects", "created_by"),
+            ("annotations", "completed_by"),
+            ("task_assignments", "assigned_by"),
+            ("data_exports", "exported_by"),
+            ("data_imports", "imported_by"),
+            ("default_config_history", "changed_by"),
+            ("export_jobs", "requested_by"),
+            ("flexible_annotations", "created_by"),
+            ("import_jobs", "requested_by"),
+            ("korrektur_comments", "created_by"),
+            ("organization_api_keys", "created_by"),
+            ("project_organizations", "assigned_by"),
+            ("project_reports", "created_by"),
+            ("prompts", "created_by"),
+            ("task_templates", "created_by"),
+            ("template_sharing", "shared_by"),
+            ("template_versions", "created_by"),
+        ]
+        nullify = [
+            ("annotations", "reviewed_by"),
+            ("default_evaluation_configs", "updated_by"),
+            ("default_prompts", "updated_by"),
+            ("korrektur_comments", "resolved_by"),
+            ("project_reports", "published_by"),
+            ("tags", "created_by"),
+            ("users", "email_verified_by_id"),
+        ]
+        delete_rows = [
+            ("notifications", "user_id"),
+            ("user_column_preferences", "user_id"),
+        ]
+
+        for table, column in reassign_to_fallback:
+            if table in existing_tables:
+                db.execute(
+                    text(f"UPDATE {table} SET {column} = :fb WHERE {column} = :uid"),
+                    {"fb": FALLBACK_SUPERADMIN_ID, "uid": user_id},
+                )
+        for table, column in nullify:
+            if table in existing_tables:
+                db.execute(
+                    text(f"UPDATE {table} SET {column} = NULL WHERE {column} = :uid"),
+                    {"uid": user_id},
+                )
+        for table, column in delete_rows:
+            if table in existing_tables:
+                db.execute(
+                    text(f"DELETE FROM {table} WHERE {column} = :uid"),
+                    {"uid": user_id},
+                )
 
         db.flush()
         db.delete(user)

--- a/services/api/tests/integration/test_delete_user_fk_cleanup.py
+++ b/services/api/tests/integration/test_delete_user_fk_cleanup.py
@@ -1,0 +1,100 @@
+"""Regression test for delete_user FK cleanup against a real database.
+
+Deleting a user used to 500 with a ForeignKeyViolation when the user had
+authored rows in tables whose ``users.id`` FK had no ON DELETE rule — the
+reported case was ``korrektur_comments`` (constraint still named
+``feedback_comments_*``). The mock-based unit tests in
+``tests/unit/test_user_service_uncovered.py`` cannot catch this because they
+never hit Postgres. This test exercises the real FK constraints.
+"""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from auth_module.user_service import delete_user
+from models import Notification, NotificationType, Tag, User
+from project_models import KorrekturComment, Project, Task
+
+
+@pytest.fixture
+def target_with_authored_rows(test_db: Session, test_users):
+    """A non-superadmin user with rows across the three cleanup strategies.
+
+    Returns a dict of ids so the test can re-fetch the authored rows after
+    deletion. The fallback superadmin that ``delete_user`` reassigns to is not
+    pinned here — the shared test DB may carry other superadmins, so the test
+    asserts reassignment to *a* surviving superadmin rather than a fixed id.
+    """
+    target = next(u for u in test_users if not u.is_superadmin)
+
+    project = Project(id="del-fk-project", title="Delete FK Project", created_by=target.id)
+    task = Task(id="del-fk-task", project_id=project.id, inner_id=1, data={"text": "x"})
+    # REASSIGN (created_by NOT NULL) + NULLIFY (resolved_by nullable) in one row.
+    comment = KorrekturComment(
+        id="del-fk-comment",
+        project_id=project.id,
+        task_id=task.id,
+        target_type="annotation",
+        target_id="del-fk-target",
+        text="needs review",
+        is_resolved=True,
+        resolved_by=target.id,
+        created_by=target.id,
+    )
+    tag = Tag(name="del-fk-tag", normalized_name="del-fk-tag", created_by=target.id)
+    notification = Notification(
+        id="del-fk-notif",
+        user_id=target.id,
+        type=NotificationType.PROJECT_CREATED,
+        title="hi",
+        message="hi",
+    )
+
+    test_db.add_all([project, task, comment, tag, notification])
+    test_db.commit()
+
+    return {
+        "target_id": target.id,
+        "comment_id": comment.id,
+        "tag_id": tag.id,
+        "notification_id": notification.id,
+        "project_id": project.id,
+    }
+
+
+def test_delete_user_cleans_all_fk_references(test_db: Session, target_with_authored_rows):
+    ids = target_with_authored_rows
+
+    result = delete_user(test_db, ids["target_id"])
+
+    assert result is True
+    test_db.expire_all()
+
+    # User row is gone.
+    assert test_db.query(User).filter(User.id == ids["target_id"]).first() is None
+
+    # korrektur_comments.created_by (NOT NULL) reassigned to a surviving fallback
+    # superadmin; resolved_by (nullable) nulled. The comment itself is preserved.
+    comment = test_db.query(KorrekturComment).filter_by(id=ids["comment_id"]).first()
+    assert comment is not None
+    fallback_id = comment.created_by
+    assert fallback_id != ids["target_id"]
+    fallback = test_db.query(User).filter_by(id=fallback_id).first()
+    assert fallback is not None and fallback.is_superadmin
+    assert comment.resolved_by is None
+
+    # tags.created_by (nullable) nulled, row preserved.
+    tag = test_db.query(Tag).filter_by(id=ids["tag_id"]).first()
+    assert tag is not None
+    assert tag.created_by is None
+
+    # notifications belong to the deleted user → row removed.
+    assert (
+        test_db.query(Notification).filter_by(id=ids["notification_id"]).first() is None
+    )
+
+    # Existing behaviour: project ownership reassigned to the same fallback, not
+    # destroyed.
+    project = test_db.query(Project).filter_by(id=ids["project_id"]).first()
+    assert project is not None
+    assert project.created_by == fallback_id

--- a/services/shared/models.py
+++ b/services/shared/models.py
@@ -158,7 +158,7 @@ class User(Base):
 
     # Admin verification tracking fields
     email_verified_by_id = Column(
-        String, ForeignKey("users.id"), nullable=True
+        String, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
     )  # User who verified the email (for admin verification)
     email_verified_at = Column(
         DateTime(timezone=True), nullable=True
@@ -328,7 +328,7 @@ class RefreshToken(Base):
 
     id = Column(String, primary_key=True, index=True)
     token_hash = Column(String, nullable=False, unique=True, index=True)  # Hashed refresh token
-    user_id = Column(String, ForeignKey("users.id"), nullable=False)
+    user_id = Column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     expires_at = Column(DateTime(timezone=True), nullable=False)
     is_active = Column(Boolean, default=True, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
@@ -496,7 +496,7 @@ class Tag(Base):
     usage_count = Column(Integer, default=0, nullable=False)  # Track usage frequency
 
     # Metadata
-    created_by = Column(String, ForeignKey("users.id"), nullable=True)
+    created_by = Column(String, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
@@ -1120,7 +1120,7 @@ class UserColumnPreferences(Base):
     __tablename__ = "user_column_preferences"
 
     id = Column(String, primary_key=True, index=True)
-    user_id = Column(String, ForeignKey("users.id"), nullable=False)
+    user_id = Column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     task_id = Column(String, nullable=True)
     # JSON object with column visibility settings
     column_settings = Column(JSON, nullable=False)
@@ -1208,7 +1208,7 @@ class Notification(Base):
     __tablename__ = "notifications"
 
     id = Column(String, primary_key=True, index=True)
-    user_id = Column(String, ForeignKey("users.id"), nullable=False)
+    user_id = Column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     organization_id = Column(String, ForeignKey("organizations.id"), nullable=True)
     type = Column(
         SQLEnum(NotificationType, values_callable=lambda obj: [e.value for e in obj]),
@@ -1235,7 +1235,7 @@ class UserNotificationPreference(Base):
     __tablename__ = "notification_preferences"
 
     id = Column(String, primary_key=True, index=True)
-    user_id = Column(String, ForeignKey("users.id"), nullable=False)
+    user_id = Column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     notification_type = Column(String, nullable=False)
     email_enabled = Column(Boolean, nullable=False, default=False)
     in_app_enabled = Column(Boolean, nullable=False, default=True)
@@ -1558,7 +1558,7 @@ class DefaultEvaluationConfig(Base):
         server_default=func.now(),
         nullable=False,
     )
-    updated_by = Column(String, ForeignKey("users.id"), nullable=True)
+    updated_by = Column(String, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
 
     # Relationships
     updater = relationship("User", foreign_keys=[updated_by])

--- a/services/shared/project_models.py
+++ b/services/shared/project_models.py
@@ -273,7 +273,7 @@ class Annotation(Base):
     prediction_scores = Column(JSONB, nullable=True)
 
     # Review
-    reviewed_by = Column(String, ForeignKey("users.id"), nullable=True)
+    reviewed_by = Column(String, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
     reviewed_at = Column(DateTime(timezone=True), nullable=True)
     review_result = Column(String, nullable=True)  # approved, rejected, fixed
     review_annotation = Column(JSONB, nullable=True)  # Reviewer's independent annotation
@@ -750,7 +750,7 @@ class KorrekturComment(Base):
     # Resolution tracking
     is_resolved = Column(Boolean, default=False, nullable=False)
     resolved_at = Column(DateTime(timezone=True), nullable=True)
-    resolved_by = Column(String, ForeignKey("users.id"), nullable=True)
+    resolved_by = Column(String, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
 
     # Audit
     created_by = Column(String, ForeignKey("users.id"), nullable=False)

--- a/services/shared/report_models.py
+++ b/services/shared/report_models.py
@@ -108,7 +108,7 @@ class ProjectReport(Base):
     # Publication status
     is_published = Column(Boolean, default=False, nullable=False, index=True)
     published_at = Column(DateTime(timezone=True), nullable=True)
-    published_by = Column(String, ForeignKey("users.id"), nullable=True)
+    published_by = Column(String, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
 
     # Audit fields
     created_by = Column(String, ForeignKey("users.id"), nullable=False)


### PR DESCRIPTION
## Summary

Deleting a user 500'd in the global-users admin page with
`ForeignKeyViolation: ... constraint "feedback_comments_created_by_fkey" on table "korrektur_comments"`.

Two compounding bugs:
- `delete_user` cleaned FK references to `users.id` table-by-table but missed **21 of 30** RESTRICT FKs (including both `korrektur_comments` columns — the reported case).
- The project/task/annotation reassignment lived inside a `from project_models import (...)` block whose four names `ExportLog`, `GeneratedResult`, `ImportJob`, `ProjectCollaborator` no longer exist after the model consolidation. The import always raised `ImportError`, which `except ImportError: pass` swallowed — so even `projects.created_by` was never reassigned. Deletion was broken for anyone who authored a project; Postgres just reported `korrektur_comments` first.

## Changes
- **`auth_module/user_service.py`** — replace the dead import block with curated `(table, column)` passes: reassign NOT-NULL ownership columns to a fallback superadmin, NULL nullable references, delete per-user ephemeral rows. Identifiers are constants (no injection); the user id is a bound param. A table-existence guard keeps it safe on the `create_all`-built test schema.
- **`alembic/versions/059_user_delete_fk_ondelete.py`** — give nullable refs `ON DELETE SET NULL` and per-user ephemeral tables `ON DELETE CASCADE` so the DB self-cleans. NOT-NULL ownership/audit columns intentionally stay RESTRICT (reassigned in app, never silently destroyed). Constraint names are introspected to handle the legacy `feedback_comments_*` / `annotation_timer_sessions_*` naming; absent tables are skipped; re-running is a no-op.
- **`/shared` models** (`models.py`, `project_models.py`, `report_models.py`) — sync the matching `ondelete=` so fresh / `create_all` DBs match prod.
- **`tests/integration/test_delete_user_fk_cleanup.py`** — regression test against real Postgres covering reassign + nullify + delete strategies in one delete.

## Test plan
- [x] `make test-api FILE=tests/integration/test_delete_user_fk_cleanup.py` — passes
- [x] `make test-api FILE=tests/unit/test_user_service_uncovered.py` — 41 passed (mock-based delete_user)
- [x] `make test-api FILE=tests/unit/test_users_router.py` — 15 passed (HTTP delete path)
- [x] Migration round-trip in dev container: `upgrade head` -> `downgrade -1` -> `upgrade head` clean
- [x] Verified resulting `ON DELETE` rules in the dev DB (SET NULL / CASCADE on the changed FKs; NOT-NULL ownership columns remain NO ACTION)

## Deploy note
Platform-only change. Migration runs at API startup under the advisory lock; prod scale is tiny so the constraint swaps are sub-second. Part 1 (app fix) is the load-bearing fix and resolves the incident on its own.