### PR TITLE
fix(users): route admin user-delete through canonical cleanup

### DIFF
--- a/services/api/routers/organizations.py
+++ b/services/api/routers/organizations.py
@@ -12,6 +12,7 @@ from sqlalchemy import func, text
 from sqlalchemy.orm import Session
 
 from auth_module import get_current_user, require_user
+from auth_module.user_service import delete_user as delete_user_service
 from database import get_db
 from models import Organization, OrganizationMembership, OrganizationRole, User
 
@@ -822,7 +823,6 @@ async def delete_user(
         if not result:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-        user_email = result.email
         is_superadmin = result.is_superadmin
 
         # Don't allow deleting yourself
@@ -843,108 +843,20 @@ async def delete_user(
                     detail="Cannot delete last superadmin",
                 )
 
-        # Build a list of tables that reference the users table
-        # IMPORTANT: User deletion is handled separately to ensure it succeeds
-        related_deletion_queries = [
-            # Clear email verifier references
-            f"UPDATE users SET email_verified_by_id = NULL WHERE email_verified_by_id = '{user_id}'",
-            # Delete from tables with foreign keys to users
-            f"DELETE FROM annotation_comments WHERE author_id = '{user_id}' OR resolved_by = '{user_id}'",
-            f"DELETE FROM annotation_activities WHERE user_id = '{user_id}'",
-            f"DELETE FROM annotation_assignments WHERE user_id = '{user_id}' OR assigned_by = '{user_id}'",
-            f"DELETE FROM annotation_versions WHERE changed_by = '{user_id}'",
-            f"DELETE FROM annotations WHERE completed_by = '{user_id}'",
-            f"DELETE FROM native_annotations WHERE annotator_id = '{user_id}' OR reviewer_id = '{user_id}'",
-            f"DELETE FROM task_assignments WHERE user_id = '{user_id}' OR assigned_by = '{user_id}'",
-            f"DELETE FROM project_members WHERE user_id = '{user_id}' OR added_by = '{user_id}'",
-            f"DELETE FROM organization_memberships WHERE user_id = '{user_id}'",
-            f"DELETE FROM invitations WHERE invited_by = '{user_id}' OR pending_user_id = '{user_id}' OR email = '{user_email}'",
-            f"DELETE FROM notifications WHERE user_id = '{user_id}'",
-            f"DELETE FROM notification_preferences WHERE user_id = '{user_id}'",
-            f"DELETE FROM user_column_preferences WHERE user_id = '{user_id}'",
-            f"DELETE FROM user_feature_flags WHERE user_id = '{user_id}' OR created_by = '{user_id}'",
-            f"DELETE FROM refresh_tokens WHERE user_id = '{user_id}'",
-            f"DELETE FROM template_ratings WHERE user_id = '{user_id}'",
-            f"DELETE FROM template_sharing WHERE shared_by = '{user_id}'",
-            f"DELETE FROM template_versions WHERE created_by = '{user_id}'",
-            f"DELETE FROM prompts WHERE created_by = '{user_id}'",
-            f"DELETE FROM task_evaluation_configs WHERE created_by = '{user_id}'",
-            f"DELETE FROM task_templates WHERE created_by = '{user_id}'",
-            f"DELETE FROM tags WHERE created_by = '{user_id}'",
-            f"DELETE FROM data_imports WHERE imported_by = '{user_id}'",
-            f"DELETE FROM data_exports WHERE exported_by = '{user_id}'",
-            f"DELETE FROM annotator_agreement_matrix WHERE annotator_1_id = '{user_id}' OR annotator_2_id = '{user_id}'",
-            f"DELETE FROM agreement_thresholds WHERE created_by = '{user_id}'",
-            f"DELETE FROM default_evaluation_configs WHERE updated_by = '{user_id}'",
-            f"DELETE FROM default_config_history WHERE changed_by = '{user_id}'",
-            f"DELETE FROM organization_api_keys WHERE created_by = '{user_id}'",
-            f"DELETE FROM feature_flags WHERE created_by = '{user_id}'",
-            f"DELETE FROM organization_feature_flags WHERE created_by = '{user_id}'",
-            f"DELETE FROM project_organizations WHERE assigned_by = '{user_id}'",
-            f"UPDATE evaluation_runs SET created_by = '{current_user.id}' WHERE created_by = '{user_id}'",
-            f"DELETE FROM projects WHERE created_by = '{user_id}'",
-        ]
+        # Delegate to the canonical cleanup in auth_module.user_service. It is the
+        # single source of truth for user deletion: it reassigns authored content
+        # (projects, korrektur comments, templates, …) to a fallback superadmin
+        # and clears/cascades the per-user rows, covering every users.id FK. The
+        # hand-rolled raw-SQL block that used to live here had drifted out of sync
+        # — it omitted korrektur_comments (the FK that 500'd), destroyed content
+        # instead of reassigning it, and interpolated user_id into SQL strings.
+        if not delete_user_service(db, user_id):
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-        # First, delete from all related tables
-        # Use savepoints to handle failures gracefully without aborting the transaction
         import logging
 
-        for query in related_deletion_queries:
-            try:
-                # Create a savepoint before each query
-                db.execute(text("SAVEPOINT sp_delete"))
-                result = db.execute(text(query))
-                # Release the savepoint if successful
-                db.execute(text("RELEASE SAVEPOINT sp_delete"))
-                if result.rowcount > 0:
-                    logging.debug(f"Deleted {result.rowcount} rows: {query[:50]}...")
-            except Exception as query_error:
-                # Rollback to the savepoint if the query fails
-                db.execute(text("ROLLBACK TO SAVEPOINT sp_delete"))
-                # Release the savepoint
-                db.execute(text("RELEASE SAVEPOINT sp_delete"))
-                # Log but continue - some tables might not exist
-                logging.debug(
-                    f"Non-critical query failed (table may not exist): {query[:50]}... - {str(query_error)}"
-                )
-
-        # Now attempt the critical user deletion
-        # This MUST succeed or we rollback everything
-        try:
-            user_delete_result = db.execute(
-                text("DELETE FROM users WHERE id = :user_id RETURNING id"),
-                {"user_id": user_id},
-            )
-            deleted_user_id = user_delete_result.fetchone()
-
-            if not deleted_user_id:
-                # User was not deleted - this is critical!
-                raise Exception(
-                    f"Failed to delete user {user_id} - user may not exist or deletion was blocked by constraints"
-                )
-
-            # Verify the user is actually gone
-            verification = db.execute(
-                text("SELECT id FROM users WHERE id = :user_id"), {"user_id": user_id}
-            ).fetchone()
-
-            if verification:
-                # User still exists - critical failure!
-                raise Exception(f"User {user_id} still exists after deletion attempt")
-
-            # All good - commit the transaction
-            db.commit()
-            logging.info(f"Successfully deleted user {user_id}")
-            return {"message": "User deleted successfully"}
-
-        except Exception as e:
-            # Critical failure - rollback everything
-            db.rollback()
-            logging.error(f"CRITICAL: Failed to delete user {user_id}: {str(e)}")
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Failed to delete user: {str(e)}",
-            )
+        logging.info(f"Successfully deleted user {user_id}")
+        return {"message": "User deleted successfully"}
 
     except HTTPException:
         db.rollback()

--- a/services/api/tests/unit/test_orgs_router_uncovered.py
+++ b/services/api/tests/unit/test_orgs_router_uncovered.py
@@ -403,67 +403,61 @@ class TestUpdateSuperadminStatusSuccess:
 class TestDeleteUserSuccess:
     @pytest.mark.asyncio
     async def test_delete_regular_user(self):
-        """Cover lines 819-909: successful user deletion."""
+        """The endpoint delegates to the canonical user_service.delete_user."""
         from routers.organizations import delete_user
 
         db = MagicMock()
         admin = Mock(is_superadmin=True, id="admin-1")
 
         user_result = Mock(email="target@test.com", is_superadmin=False)
+        db.execute.return_value.first.return_value = user_result
 
-        call_count = [0]
+        with patch(
+            "routers.organizations.delete_user_service", return_value=True
+        ) as svc:
+            result = await delete_user(user_id="user-2", current_user=admin, db=db)
 
-        def execute_side_effect(*args, **kwargs):
-            call_count[0] += 1
-            mock_result = MagicMock()
-            if call_count[0] == 1:
-                # First call: user lookup
-                mock_result.first.return_value = user_result
-            else:
-                mock_result.rowcount = 0
-                arg_str = str(args[0]) if args else ""
-                if "SELECT id FROM users" in arg_str:
-                    mock_result.fetchone.return_value = None  # User is gone
-                else:
-                    mock_result.fetchone.return_value = ("user-2",)
-            return mock_result
-
-        db.execute.side_effect = execute_side_effect
-
-        result = await delete_user(user_id="user-2", current_user=admin, db=db)
+        svc.assert_called_once_with(db, "user-2")
         assert result["message"] == "User deleted successfully"
 
     @pytest.mark.asyncio
-    async def test_delete_user_critical_failure(self):
-        """Cover lines 911-918: critical failure during user deletion."""
+    async def test_delete_user_service_reports_not_found(self):
+        """A False return from the canonical service surfaces as a 404."""
         from routers.organizations import delete_user
 
         db = MagicMock()
         admin = Mock(is_superadmin=True, id="admin-1")
+        db.execute.return_value.first.return_value = Mock(
+            email="target@test.com", is_superadmin=False
+        )
 
-        user_result = Mock(email="target@test.com", is_superadmin=False)
+        with patch("routers.organizations.delete_user_service", return_value=False):
+            with pytest.raises(HTTPException) as exc_info:
+                await delete_user(user_id="user-2", current_user=admin, db=db)
+        assert exc_info.value.status_code == 404
 
-        call_count = [0]
+    @pytest.mark.asyncio
+    async def test_delete_user_critical_failure(self):
+        """An unexpected error inside the service bubbles up as a 500."""
+        from routers.organizations import delete_user
 
-        def execute_side_effect(*args, **kwargs):
-            call_count[0] += 1
-            mock_result = MagicMock()
-            if call_count[0] == 1:
-                mock_result.first.return_value = user_result
-            else:
-                mock_result.rowcount = 0
-                mock_result.fetchone.return_value = None
-            return mock_result
+        db = MagicMock()
+        admin = Mock(is_superadmin=True, id="admin-1")
+        db.execute.return_value.first.return_value = Mock(
+            email="target@test.com", is_superadmin=False
+        )
 
-        db.execute.side_effect = execute_side_effect
-
-        with pytest.raises(HTTPException) as exc_info:
-            await delete_user(user_id="user-2", current_user=admin, db=db)
+        with patch(
+            "routers.organizations.delete_user_service",
+            side_effect=RuntimeError("boom"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await delete_user(user_id="user-2", current_user=admin, db=db)
         assert exc_info.value.status_code == 500
 
     @pytest.mark.asyncio
     async def test_delete_user_outer_exception(self):
-        """Cover lines 923-929: unexpected outer exception."""
+        """An error during the pre-delegation user lookup surfaces as a 500."""
         from routers.organizations import delete_user
 
         db = MagicMock()


### PR DESCRIPTION
## Summary
- The admin `DELETE /manage/users/{id}` endpoint (what the global-users admin UI actually calls) kept its own hand-rolled raw-SQL cleanup that had drifted out of sync. It omitted `korrektur_comments` (the FK that 500'd in prod), destroyed authored content instead of reassigning it, and interpolated `user_id` into SQL strings.
- Result: user deletion still failed with `ForeignKeyViolation` on `feedback_comments_created_by_fkey` even after #162 fixed `user_service.delete_user` — because #162 fixed the service, not this endpoint.
- This change delegates the endpoint to `auth_module.user_service.delete_user`, so there is a single, tested source of truth for user deletion (reassign authored content to the fallback superadmin, clear/cascade per-user rows, covering every `users.id` FK).

## Verification
- Confirmed against live prod `pg_constraint`: all 19 remaining `NO ACTION` FKs to `users.id` are covered by canonical `delete_user` (17 via the reassign list, `feature_flags.created_by` + `organization_memberships.user_id` via the ORM blocks).
- Migration 059 (from #162) already applied in prod — the 7 SET NULL + 4 CASCADE columns no longer appear as `NO ACTION`.

## Test plan
- [x] `make test-api FILE=tests/integration/test_delete_user_fk_cleanup.py` — 1 passed
- [x] `make test-api FILE="tests/unit/test_orgs_router_uncovered.py tests/unit/test_organizations_coverage_extended.py" GREP="DeleteUser or delete_user"` — 8 passed (rewrote endpoint unit tests to exercise the delegation)
- [ ] Post-deploy: retry deleting a user with korrektur comments via the admin UI