### PR TITLE
fix(storage): cover presigned-POST meta fields in policy conditions

### DIFF
--- a/infra/helm/benger/values-staging.yaml
+++ b/infra/helm/benger/values-staging.yaml
@@ -11,7 +11,7 @@ api:
   resources:
     limits:
       cpu: 1
-      memory: 1Gi
+      memory: 2Gi
     requests:
       cpu: 200m
       memory: 512Mi

--- a/services/api/tests/unit/test_object_storage_extended.py
+++ b/services/api/tests/unit/test_object_storage_extended.py
@@ -631,6 +631,53 @@ class TestGetUploadUrl:
         call_kwargs = mock_client.generate_presigned_post.call_args[1]
         assert call_kwargs["ExpiresIn"] == 7200
 
+    def test_s3_meta_fields_are_covered_by_policy_conditions(self):
+        """Every form field sent with the POST must be covered by a policy
+        condition, or S3/MinIO rejects the upload with AccessDenied
+        ("...not specified in the policy"). The x-amz-meta-* fields are added to
+        Fields, so a matching exact-match condition must be present for each —
+        regression for the prod import-upload 403 (issue #158 follow-up)."""
+        service, mock_client = _make_s3_service()
+        mock_client.generate_presigned_post.return_value = {
+            "url": "https://s3.example.com",
+            "fields": {},
+        }
+
+        service.get_upload_url("report.json", file_type="imports", user_id="user-42")
+
+        call_kwargs = mock_client.generate_presigned_post.call_args[1]
+        fields = call_kwargs["Fields"]
+        conditions = call_kwargs["Conditions"]
+
+        # Collect the field names the policy pins via exact-match dict conditions.
+        exact_match_keys = {
+            k for c in conditions if isinstance(c, dict) for k in c
+        }
+        starts_with_keys = {
+            c[1].lstrip("$") for c in conditions
+            if isinstance(c, list) and c and c[0] == "starts-with"
+        }
+        covered = exact_match_keys | starts_with_keys
+
+        # Sanity: the meta fields are actually being sent in the form.
+        assert "x-amz-meta-original-filename" in fields
+        assert "x-amz-meta-user-id" in fields
+
+        # Each non-signing form field must be covered by a condition.
+        signing_fields = {"key", "policy", "x-amz-algorithm", "x-amz-credential",
+                          "x-amz-date", "x-amz-signature"}
+        for field_name in fields:
+            if field_name in signing_fields:
+                continue
+            assert field_name in covered, (
+                f"form field {field_name!r} is sent but not covered by any "
+                f"policy condition; S3/MinIO will reject the POST"
+            )
+
+        # And the exact values must match what the client echoes back.
+        assert {"x-amz-meta-original-filename": "report.json"} in conditions
+        assert {"x-amz-meta-user-id": "user-42"} in conditions
+
     def test_s3_default_expires_in(self):
         """Default expiration is used when not specified."""
         service, mock_client = _make_s3_service()

--- a/services/shared/storage/object_storage.py
+++ b/services/shared/storage/object_storage.py
@@ -434,11 +434,17 @@ class ObjectStorageService:
         if not expires_in:
             expires_in = self.EXPIRATION_TIMES["upload"]
 
-        # Prepare conditions for the presigned POST
+        # Prepare conditions for the presigned POST. Every form field sent with
+        # the upload must be covered by a policy condition, or S3/MinIO rejects
+        # the POST with AccessDenied ("...not specified in the policy"). The
+        # x-amz-meta-* fields below are echoed back verbatim by the client, so
+        # pin them with exact-match conditions to match the Fields dict.
         conditions = [
             {"bucket": self.bucket_name},
             ["starts-with", "$key", os.path.dirname(file_key)],
             {"Content-Type": content_type},
+            {"x-amz-meta-original-filename": filename},
+            {"x-amz-meta-user-id": user_id or ""},
         ]
 
         if max_size:


### PR DESCRIPTION
## Summary
- Fixes the prod import-upload `403 AccessDenied`: `get_upload_url` sent `x-amz-meta-original-filename` and `x-amz-meta-user-id` as presigned-POST form fields but omitted them from the policy conditions, so MinIO/S3 rejected every upload ("...not specified in the policy"). Both are now pinned with exact-match conditions.
- Adds a regression test asserting every non-signing form field is covered by a policy condition.
- Also carries a pre-existing dev commit bumping the **staging** API memory limit to 2Gi (`values-staging.yaml` only — no effect on the prod deploy).

## Context
Follow-up to #158 (object storage is the only import/export transport). Verified live against prod MinIO: corrected policy returns **204** on upload and **200** on presigned download. Unit suite green (99 passed).

## Test plan
- [x] `make test-api FILE=tests/unit/test_object_storage_extended.py` → 99 passed
- [x] Live prod probe: presigned POST upload → 204; presigned GET download → 200 byte-equal
- [ ] Post-deploy: import a project from the UI on prod → new project appears