### PR TITLE
fix(staging): raise API memory limit to 2Gi

### DIFF
--- a/infra/helm/benger/values-staging.yaml
+++ b/infra/helm/benger/values-staging.yaml
@@ -11,7 +11,7 @@ api:
   resources:
     limits:
       cpu: 1
-      memory: 1Gi
+      memory: 2Gi
     requests:
       cpu: 200m
       memory: 512Mi


### PR DESCRIPTION
## Summary
The staging API container OOMKilled at boot under the 1Gi memory limit, so `helm upgrade --wait` timed out and staging deploys got stuck on the previous replica (the failure surfaced on benger-extended PR #36's staging gate).

Real API memory use is ~1.0–1.25Gi steady state (prod runs at ~1250Mi with a 3Gi limit); 1Gi leaves no headroom for boot-time spikes. This raises the **staging** API limit to 2Gi (request unchanged at 512Mi; only the limit changes, and node memory *requests* have ample headroom). Workers/frontend limits are untouched.

This was already applied live to the server-local staging values to unblock the deploy; this PR brings platform git in sync so the change survives a checkout reset.

## Test plan
- [x] Staging deploy re-run after the live bump: new API pod `1/1 Running`, 0 restarts, no OOM.
- [ ] Confirm on next staging deploy the rendered limit is 2Gi.