### PR TITLE
fix(projects): prevent duplicate projects on repeated wizard submit

### DIFF
--- a/services/frontend/src/components/projects/ProjectCreationWizard.tsx
+++ b/services/frontend/src/components/projects/ProjectCreationWizard.tsx
@@ -19,7 +19,7 @@ import { extractFieldsFromLabelConfig } from '@/lib/labelConfig/fieldExtractor'
 import { useProjectStore } from '@/stores/projectStore'
 import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/24/outline'
 import { useRouter } from 'next/navigation'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useToast } from '@/components/shared/Toast'
 import { StepAnnotationInstructions } from './wizard/StepAnnotationInstructions'
 import { StepDataImport } from './wizard/StepDataImport'
@@ -46,6 +46,14 @@ export function ProjectCreationWizard() {
   const [wizardData, setWizardData] = useState<WizardData>(INITIAL_WIZARD_DATA)
   const [currentStepIndex, setCurrentStepIndex] = useState(0)
   const [errors, setErrors] = useState<Record<string, string>>({})
+  // Re-entrancy guard for the final "Create Project" action. The global store
+  // `loading` flag only covers the createProject/fetchProject calls and flips
+  // back to false mid-flight (during import + the settings PATCH/PUTs), which
+  // would otherwise re-enable the button and let a second click create a
+  // duplicate project. The ref blocks re-entry synchronously (state updates are
+  // async); the state drives the disabled UI.
+  const isFinishingRef = useRef(false)
+  const [isFinishing, setIsFinishing] = useState(false)
 
   const nlpTemplates: LabelingTemplate[] = useMemo(
     () => [
@@ -344,7 +352,11 @@ export function ProjectCreationWizard() {
   }
 
   const handleFinish = async () => {
+    if (isFinishingRef.current) return
     if (!validateStep()) return
+
+    isFinishingRef.current = true
+    setIsFinishing(true)
 
     try {
       // 1. Create project with basic info + label config
@@ -614,6 +626,11 @@ export function ProjectCreationWizard() {
           : t('projects.wizard.createFailed'),
         'error'
       )
+      // Re-enable the button so the user can retry. On the success path we
+      // navigate away (router.push) and the component unmounts, so the guard
+      // intentionally stays set there to keep the button disabled.
+      isFinishingRef.current = false
+      setIsFinishing(false)
     }
   }
 
@@ -784,10 +801,10 @@ export function ProjectCreationWizard() {
           {isLastStep ? (
             <Button
               onClick={handleFinish}
-              disabled={loading}
+              disabled={loading || isFinishing}
               data-testid="project-create-submit-button"
             >
-              {loading
+              {loading || isFinishing
                 ? t('projects.creation.wizard.navigation.creating')
                 : t('projects.creation.wizard.navigation.create')}
             </Button>

--- a/services/frontend/src/components/projects/__tests__/ProjectCreationWizard.test.tsx
+++ b/services/frontend/src/components/projects/__tests__/ProjectCreationWizard.test.tsx
@@ -821,6 +821,52 @@ describe('ProjectCreationWizard', () => {
       })
     })
 
+    it('ignores repeated submit clicks and creates the project only once', async () => {
+      const user = userEvent.setup()
+      // Hold createProject pending so the finish flow stays in flight while we
+      // fire extra clicks — this is the window where the global store `loading`
+      // flag would otherwise have flipped back to false and re-enabled the button.
+      let resolveCreate: (value: { id: string }) => void = () => {}
+      mockCreateProject.mockImplementation(
+        () =>
+          new Promise<{ id: string }>((resolve) => {
+            resolveCreate = resolve
+          })
+      )
+      mockFetchProject.mockResolvedValue({})
+
+      render(<ProjectCreationWizard />)
+
+      await user.type(
+        screen.getByTestId('project-create-name-input'),
+        'Dup Guard'
+      )
+      await user.click(screen.getByTestId('project-create-next-button'))
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('project-create-submit-button')
+        ).toBeInTheDocument()
+      })
+
+      const submit = screen.getByTestId('project-create-submit-button')
+
+      // First click starts the flow; createProject is now pending.
+      await user.click(submit)
+      await waitFor(() => expect(submit).toBeDisabled())
+
+      // Spam more clicks while the flow is mid-flight — these must be no-ops.
+      await user.click(submit)
+      await user.click(submit)
+
+      // Let the in-flight create resolve and the flow run to navigation.
+      resolveCreate({ id: 'project-123' })
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/projects/project-123')
+      })
+
+      expect(mockCreateProject).toHaveBeenCalledTimes(1)
+    })
+
     it('creates project with all configuration when all features are set', async () => {
       const user = userEvent.setup()
       mockCreateProject.mockResolvedValue({ id: 'project-full' })


### PR DESCRIPTION
## Summary
- The project-creation wizard's final **Create Project** step only disabled its submit button via the global store `loading` flag. `createProject` flips that flag back to `false` the instant it returns, even though `handleFinish` keeps running (data import + its poll loop, settings PATCH, eval/prompt PUTs). For that whole window the button was re-enabled with **no re-entrancy guard**, so a second click re-ran the flow from the top and created a **duplicate project**.
- Added a `useRef` re-entrancy guard (blocks re-entry synchronously) plus a local `isFinishing` state that keeps the button disabled — and showing "Creating…" — for the entire operation, not just during `createProject`.

## Test plan
- [x] New unit test: holds `createProject` pending, clicks submit, asserts the button disables, fires two more clicks, resolves — asserts `createProject` is called exactly once and navigation happens once (fails without the guard).
- [x] `ProjectCreationWizard` suite green (45/45).