### PR TITLE
Add BenGER dataset & benchmark release news entry

### DIFF
--- a/services/frontend/src/locales/de/common.json
+++ b/services/frontend/src/locales/de/common.json
@@ -2960,6 +2960,13 @@
       "readMore": "Weiterlesen",
       "items": [
         {
+          "title": "BenGER: Datensatz & Benchmark veröffentlicht",
+          "description": "Unser erster offener, großangelegter Benchmark für subsumtionsbasiertes Reasoning im deutschen Recht — 12 LLM-Systeme, echtes Human-Baseline, Co-Creation-Daten und ein gegen sieben menschliche Bewerter validierter LLM-Judge. Offen unter CC BY 4.0.",
+          "date": "2026-06-07",
+          "type": "publication",
+          "url": "https://legalplusplus.net/articles/benchmark-release"
+        },
+        {
           "title": "BenGER Plattform-Release",
           "description": "Die BenGER-Plattform ist nun öffentlich verfügbar. Der Beitrag erläutert das Open-Core-Release, den Funktionsumfang und wie Sie Ihre eigenen Legal-KI-Benchmarks erstellen.",
           "date": "2026-05-03",

--- a/services/frontend/src/locales/en/common.json
+++ b/services/frontend/src/locales/en/common.json
@@ -2978,6 +2978,13 @@
       "readMore": "Read more",
       "items": [
         {
+          "title": "BenGER: Dataset & Benchmark Released",
+          "description": "Our first open, large-scale benchmark for subsumption-based reasoning in German law — 12 LLM systems, a real human baseline, human-AI co-creation data, and an LLM judge validated against seven human reviewers. Open under CC BY 4.0.",
+          "date": "2026-06-07",
+          "type": "publication",
+          "url": "https://legalplusplus.net/articles/benchmark-release"
+        },
+        {
           "title": "BenGER Platform Release",
           "description": "The BenGER platform is now publicly available. Read the announcement covering the open-core release, what's included, and how to get started running your own legal-AI benchmarks.",
           "date": "2026-05-03",


### PR DESCRIPTION
## Summary
- Add a "BenGER: Dataset & Benchmark Released" card to the landing-page News & Publications section (EN + DE locales), linking to the new legalplusplus article at https://legalplusplus.net/articles/benchmark-release.
- Also includes the previously-committed `c2774e4` fix (prevent duplicate projects on repeated wizard submit) that was already on dev.

## Notes
- Content-only change to `services/frontend/src/locales/{en,de}/common.json`.
- Companion article shipped separately in the legalplusplus repo.