### PR TITLE
chore(deps): bump @tailwindcss/typography 0.5.19 to 0.5.20 (#176)

### DIFF
--- a/services/frontend/package-lock.json
+++ b/services/frontend/package-lock.json
@@ -24,7 +24,7 @@
         "@milkdown/utils": "^7.21.2",
         "@sindresorhus/slugify": "^2.1.1",
         "@tailwindcss/postcss": "^4.3.0",
-        "@tailwindcss/typography": "^0.5.19",
+        "@tailwindcss/typography": "^0.5.20",
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.14.2",
@@ -5162,15 +5162,15 @@
       "license": "MIT"
     },
     "node_modules/@tailwindcss/typography": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
-      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+      "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
       "license": "MIT",
       "dependencies": {
         "postcss-selector-parser": "6.0.10"
       },
       "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+        "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
       }
     },
     "node_modules/@tanstack/query-core": {

--- a/services/frontend/package.json
+++ b/services/frontend/package.json
@@ -75,7 +75,7 @@
     "@milkdown/utils": "^7.21.2",
     "@sindresorhus/slugify": "^2.1.1",
     "@tailwindcss/postcss": "^4.3.0",
-    "@tailwindcss/typography": "^0.5.19",
+    "@tailwindcss/typography": "^0.5.20",
     "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.14.2",


### PR DESCRIPTION
## Summary
Folds the last residual dependabot PR (#176) for a clean slate: `@tailwindcss/typography` ^0.5.19 → ^0.5.20. Frontend-only, no python/worker changes.

Supersedes #176 (auto-closes once detected on main).

## Test plan
- [ ] PR CI green (Frontend Tests + Python Lint)
- [ ] Post-merge: extended deploy-prod succeeds; frontend renders