### PR TITLE
Show open-mode annotated tasks and their evaluation in Meine Aufgaben

### DIFF
--- a/services/api/alembic/versions/062_annotator_full_visibility_after_submit.py
+++ b/services/api/alembic/versions/062_annotator_full_visibility_after_submit.py
@@ -1,0 +1,54 @@
+"""add projects.annotator_full_visibility_after_submit
+
+Per-project toggle controlling what an annotator sees when reviewing their own
+submitted work in "Meine Aufgaben". When False (default) the post-submission
+view is filtered to only the fields the annotator saw while labeling, so the
+reference solution (Musterlösung) and raw ground_truth are never exposed —
+preventing leaks to peers who still have to sit the same exam. When True,
+annotators see all task fields after submission to compare and learn.
+
+Idempotent — guards on column existence; safe to re-run.
+
+Revision ID: 062_annotator_full_visibility_after_submit
+Revises: 061_korrektur_custom_human_run_singleton
+Create Date: 2026-06-17
+"""
+
+from sqlalchemy import inspect
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "062_annotator_full_visibility_after_submit"
+down_revision = "061_korrektur_custom_human_run_singleton"
+branch_labels = None
+depends_on = None
+
+
+TABLE_NAME = "projects"
+COLUMN_NAME = "annotator_full_visibility_after_submit"
+
+
+def _column_exists(table: str, column: str) -> bool:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    return column in {c["name"] for c in insp.get_columns(table)}
+
+
+def upgrade() -> None:
+    if not _column_exists(TABLE_NAME, COLUMN_NAME):
+        op.add_column(
+            TABLE_NAME,
+            sa.Column(
+                COLUMN_NAME,
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+
+
+def downgrade() -> None:
+    if _column_exists(TABLE_NAME, COLUMN_NAME):
+        op.drop_column(TABLE_NAME, COLUMN_NAME)

--- a/services/api/extensions.py
+++ b/services/api/extensions.py
@@ -180,3 +180,26 @@ def tasks_with_feedback_for_user(db, project_id, user_id, task_ids):
             result = hook(db, project_id, user_id, list(task_ids))
             return set(result or ())
     return set()
+
+
+def tasks_with_evaluation_for_user(db, project_id, user_id, task_ids):
+    """Return the subset of task_ids on which the user has any evaluation.
+
+    "Evaluation" = at least one TaskEvaluation row on one of the user's
+    annotations — immediate-eval, LLM-judge, or deterministic metric. Broader
+    than `tasks_with_feedback_for_user` (which is human-Korrektur only). Used by
+    `/my-tasks` to render an "evaluation available" badge and let the row open
+    the submission+scores modal.
+
+    Returns an empty set when extended is not loaded — community edition has no
+    evaluation-on-own-annotation workflow surfaced in Meine Aufgaben.
+    """
+    if not task_ids:
+        return set()
+    if _extended and hasattr(_extended, "get_hooks"):
+        hooks = _extended.get_hooks()
+        hook = hooks.get("tasks_with_evaluation_for_user")
+        if hook:
+            result = hook(db, project_id, user_id, list(task_ids))
+            return set(result or ())
+    return set()

--- a/services/api/project_schemas.py
+++ b/services/api/project_schemas.py
@@ -234,6 +234,10 @@ class ProjectUpdate(BaseModel):
     korrektur_enabled: Optional[bool] = None
     korrektur_config: Optional[List[Dict[str, Any]]] = None
     immediate_evaluation_enabled: Optional[bool] = None
+    # When True, annotators see all task fields (incl. the reference solution)
+    # when reviewing their own submitted work in Meine Aufgaben; when False
+    # (default) that view is filtered to only the fields they saw while labeling.
+    annotator_full_visibility_after_submit: Optional[bool] = None
     # Per-project feature visibility (controls which configuration cards
     # render on the project detail page; pure UI gate)
     enable_annotation: Optional[bool] = None
@@ -349,6 +353,7 @@ class ProjectResponse(ProjectBase):
     korrektur_enabled: bool = False
     korrektur_config: Optional[List[Dict[str, Any]]] = None
     immediate_evaluation_enabled: bool = False
+    annotator_full_visibility_after_submit: bool = False
     enable_annotation: bool = True
     enable_generation: bool = True
     enable_evaluation: bool = True

--- a/services/api/routers/projects/assignments.py
+++ b/services/api/routers/projects/assignments.py
@@ -13,7 +13,14 @@ from auth_module.models import User as AuthUser
 from database import get_db
 from models import NotificationType, OrganizationMembership, User
 from notification_service import NotificationService
-from project_models import Project, ProjectMember, ProjectOrganization, Task, TaskAssignment
+from project_models import (
+    Annotation,
+    Project,
+    ProjectMember,
+    ProjectOrganization,
+    Task,
+    TaskAssignment,
+)
 from routers.projects.helpers import check_project_accessible, get_org_context_from_request, get_user_with_memberships
 
 router = APIRouter()
@@ -535,12 +542,33 @@ async def get_my_tasks(
     if not check_project_accessible(db, current_user, project_id, org_context):
         raise HTTPException(status_code=403, detail="Access denied")
 
+    from sqlalchemy import exists as sa_exists, or_ as sa_or
+
+    # A task belongs in "Meine Aufgaben" if the user is assigned to it OR has
+    # annotated it themselves. The second arm is what surfaces open-mode work:
+    # open-mode annotation never writes a TaskAssignment, so the only user->task
+    # link is the annotation's `completed_by`. LEFT-join the assignment (scoped
+    # to this user, task-level only) so annotation-only rows survive but still
+    # carry assignment ordering/metadata when present.
+    annotation_exists = sa_exists().where(
+        (Annotation.task_id == Task.id)
+        & (Annotation.completed_by == current_user.id)
+        & (Annotation.was_cancelled == False)  # noqa: E712 — SQLAlchemy
+    )
     query = (
         db.query(Task)
-        .join(TaskAssignment)
-        .filter(Task.project_id == project_id, TaskAssignment.user_id == current_user.id)
+        .outerjoin(
+            TaskAssignment,
+            (TaskAssignment.task_id == Task.id)
+            & (TaskAssignment.user_id == current_user.id)
+            & (TaskAssignment.target_type == "task"),
+        )
+        .filter(Task.project_id == project_id)
+        .filter(sa_or(TaskAssignment.id.isnot(None), annotation_exists))
     )
 
+    # The status filter is on the assignment; selecting one naturally drops
+    # annotation-only (un-assigned) tasks, which have no assignment status.
     if status:
         query = query.filter(TaskAssignment.status == status)
 
@@ -555,9 +583,15 @@ async def get_my_tasks(
             )
         )
 
-    # Order by priority and due date
+    # Assigned tasks rank first by priority/due-date; annotation-only tasks
+    # (null assignment) fall after, ordered by inner_id for stable paging.
+    # No DISTINCT needed: the assignment join is scoped to target_type='task',
+    # whose partial unique (task_id, user_id) index yields at most one row per
+    # task, and annotation membership is an EXISTS subquery that never fans out.
     query = query.order_by(
-        TaskAssignment.priority.desc(), TaskAssignment.due_date.asc().nullsfirst()
+        TaskAssignment.priority.desc().nullslast(),
+        TaskAssignment.due_date.asc().nullsfirst(),
+        Task.inner_id.asc(),
     )
 
     # Pagination
@@ -569,6 +603,12 @@ async def get_my_tasks(
     # has no human-feedback workflow.
     task_ids = [t.id for t in tasks]
     feedback_task_ids = extensions.tasks_with_feedback_for_user(
+        db, project_id, current_user.id, task_ids
+    )
+    # Bulk-resolve which tasks have any evaluation (immediate-eval, LLM-judge,
+    # deterministic, …) on this user's annotations — drives a separate badge and
+    # lets the row open the submission+scores modal. Empty set without extended.
+    evaluation_task_ids = extensions.tasks_with_evaluation_for_user(
         db, project_id, current_user.id, task_ids
     )
 
@@ -596,6 +636,7 @@ async def get_my_tasks(
             "inner_id": task.inner_id,
             "is_labeled": task.is_labeled,
             "has_feedback": task.id in feedback_task_ids,
+            "has_evaluation": task.id in evaluation_task_ids,
             "assignment": (
                 {
                     "id": assignment.id,

--- a/services/api/tests/integration/test_assignments_integration.py
+++ b/services/api/tests/integration/test_assignments_integration.py
@@ -10,6 +10,7 @@ import uuid
 import pytest
 
 from project_models import (
+    Annotation,
     Project,
     ProjectOrganization,
     Task,
@@ -279,3 +280,107 @@ class TestMyTasks:
             headers=auth_headers["admin"],
         )
         assert resp.status_code == 404
+
+    def _open_project_with_task(self, db, admin, org, inner_id=1):
+        project = Project(
+            id=_uid(),
+            title=f"Open {uuid.uuid4().hex[:6]}",
+            created_by=admin.id,
+            label_config='<View><Text name="text" value="$text"/></View>',
+            assignment_mode="open",
+        )
+        db.add(project)
+        db.flush()
+        db.add(
+            ProjectOrganization(
+                id=_uid(),
+                project_id=project.id,
+                organization_id=org.id,
+                assigned_by=admin.id,
+            )
+        )
+        db.flush()
+        task = Task(
+            id=_uid(),
+            project_id=project.id,
+            data={"text": "open task"},
+            inner_id=inner_id,
+            created_by=admin.id,
+        )
+        db.add(task)
+        db.commit()
+        return project, task
+
+    def test_open_mode_annotated_task_appears(
+        self, client, test_db, test_users, auth_headers, test_org
+    ):
+        """Open mode: a task the user annotated (no TaskAssignment) is listed,
+        with a null assignment. This is the core of surfacing open-mode work."""
+        admin = test_users[0]
+        project, task = self._open_project_with_task(test_db, admin, test_org)
+        test_db.add(
+            Annotation(
+                id=_uid(),
+                task_id=task.id,
+                project_id=project.id,
+                completed_by=admin.id,
+                result=[],
+                was_cancelled=False,
+            )
+        )
+        test_db.commit()
+
+        resp = client.get(
+            f"/api/projects/{project.id}/my-tasks",
+            headers={**auth_headers["admin"], "X-Organization-Context": test_org.id},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        row = next((t for t in data["tasks"] if t["id"] == task.id), None)
+        assert row is not None, "annotated open-mode task missing from my-tasks"
+        assert row["assignment"] is None
+        # Community edition has no extended hook -> badge flags are False.
+        assert row["has_evaluation"] is False
+        assert row["has_feedback"] is False
+
+    def test_open_mode_untouched_task_absent(
+        self, client, test_db, test_users, auth_headers, test_org
+    ):
+        """A task that's neither assigned nor annotated by the user is NOT listed."""
+        admin = test_users[0]
+        project, task = self._open_project_with_task(test_db, admin, test_org)
+
+        resp = client.get(
+            f"/api/projects/{project.id}/my-tasks",
+            headers={**auth_headers["admin"], "X-Organization-Context": test_org.id},
+        )
+        assert resp.status_code == 200, resp.text
+        ids = [t["id"] for t in resp.json()["tasks"]]
+        assert task.id not in ids
+
+    def test_status_filter_excludes_annotation_only_tasks(
+        self, client, test_db, test_users, auth_headers, test_org
+    ):
+        """A status filter targets the assignment; annotation-only (un-assigned)
+        tasks have no status and drop out when a status is selected."""
+        admin = test_users[0]
+        project, task = self._open_project_with_task(test_db, admin, test_org)
+        test_db.add(
+            Annotation(
+                id=_uid(),
+                task_id=task.id,
+                project_id=project.id,
+                completed_by=admin.id,
+                result=[],
+                was_cancelled=False,
+            )
+        )
+        test_db.commit()
+
+        resp = client.get(
+            f"/api/projects/{project.id}/my-tasks?status=assigned",
+            headers={**auth_headers["admin"], "X-Organization-Context": test_org.id},
+        )
+        assert resp.status_code == 200, resp.text
+        ids = [t["id"] for t in resp.json()["tasks"]]
+        assert task.id not in ids

--- a/services/api/tests/unit/test_extensions.py
+++ b/services/api/tests/unit/test_extensions.py
@@ -59,3 +59,17 @@ class TestExtensionLoader:
 
         assert isinstance(CORE_API_VERSION, str)
         assert CORE_API_VERSION == "2.1"
+
+    def test_tasks_with_feedback_for_user_empty_without_package(self):
+        """Community edition: no human-feedback workflow -> empty set."""
+        from extensions import tasks_with_feedback_for_user
+
+        assert tasks_with_feedback_for_user(None, "p", "u", ["t1"]) == set()
+        assert tasks_with_feedback_for_user(None, "p", "u", []) == set()
+
+    def test_tasks_with_evaluation_for_user_empty_without_package(self):
+        """Community edition: no evaluation-on-own-annotation badge -> empty set."""
+        from extensions import tasks_with_evaluation_for_user
+
+        assert tasks_with_evaluation_for_user(None, "p", "u", ["t1"]) == set()
+        assert tasks_with_evaluation_for_user(None, "p", "u", []) == set()

--- a/services/api/tests/unit/test_project_schemas_extended.py
+++ b/services/api/tests/unit/test_project_schemas_extended.py
@@ -74,6 +74,26 @@ class TestProjectUpdate:
         assert data["title"] == "Updated"
         assert data["show_skip_button"] == True  # noqa: E712
 
+    def test_annotator_full_visibility_flag(self):
+        """The post-submission visibility toggle round-trips through update +
+        defaults False on the response schema."""
+        from project_schemas import ProjectResponse, ProjectUpdate
+
+        update = ProjectUpdate(annotator_full_visibility_after_submit=True)
+        data = update.dict(exclude_unset=True)
+        assert data["annotator_full_visibility_after_submit"] is True
+        # Unset -> not emitted, so a partial PATCH never clobbers it.
+        assert "annotator_full_visibility_after_submit" not in ProjectUpdate().dict(
+            exclude_unset=True
+        )
+        # Response model carries the field with a safe default.
+        assert (
+            ProjectResponse.model_fields[
+                "annotator_full_visibility_after_submit"
+            ].default
+            is False
+        )
+
 
 class TestPaginatedResponse:
     def test_empty_response(self):

--- a/services/frontend/src/app/projects/[id]/my-tasks/__tests__/page.test.tsx
+++ b/services/frontend/src/app/projects/[id]/my-tasks/__tests__/page.test.tsx
@@ -253,6 +253,8 @@ const translations: Record<string, string> = {
   'tasks.myTasks.taskPrefix': 'Task',
   'tasks.myTasks.labeled': 'Labeled',
   'tasks.myTasks.due': 'Due',
+  'tasks.myTasks.feedbackAvailable': 'Feedback',
+  'tasks.myTasks.evaluationAvailable': 'Evaluation',
 }
 
 describe('MyTasksPage', () => {
@@ -441,6 +443,38 @@ describe('MyTasksPage', () => {
       expect(screen.getByText('Task #1')).toBeInTheDocument()
       expect(screen.getByText('Task #2')).toBeInTheDocument()
       expect(screen.getByText('Task #3')).toBeInTheDocument()
+    })
+  })
+
+  it('shows the evaluation badge for an annotated open-mode task', async () => {
+    // An open-mode annotated task: no assignment, has_evaluation flagged.
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          tasks: [
+            {
+              id: 'open-1',
+              inner_id: 7,
+              data: { text: 'open task' },
+              is_labeled: true,
+              has_feedback: false,
+              has_evaluation: true,
+              assignment: null,
+            },
+          ],
+          total: 1,
+          page: 1,
+          page_size: 20,
+          pages: 1,
+        }),
+    })
+
+    render(<MyTasksPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Task #7')).toBeInTheDocument()
+      expect(screen.getByText('Evaluation')).toBeInTheDocument()
     })
   })
 

--- a/services/frontend/src/app/projects/[id]/my-tasks/page.tsx
+++ b/services/frontend/src/app/projects/[id]/my-tasks/page.tsx
@@ -22,10 +22,12 @@ import {
 import { useToast } from '@/components/shared/Toast'
 import { useAuth } from '@/contexts/AuthContext'
 import { useI18n } from '@/contexts/I18nContext'
+import { useSlot } from '@/lib/extensions/slots'
 import { useProjectStore } from '@/stores/projectStore'
 import { Task, TaskAssignment } from '@/types/labelStudio'
 import {
   CalendarIcon,
+  ChartBarIcon,
   ChatBubbleLeftRightIcon,
   CheckCircleIcon,
   ChevronRightIcon,
@@ -41,6 +43,7 @@ import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 interface MyTask extends Task {
   assignment?: TaskAssignment
   has_feedback?: boolean
+  has_evaluation?: boolean
 }
 
 interface MyTasksResponse {
@@ -72,6 +75,10 @@ export default function MyTasksPage() {
   const [page, setPage] = useState(1)
   const [totalPages, setTotalPages] = useState(1)
   const [totalTasks, setTotalTasks] = useState(0)
+  // The submission+scores modal is contributed by the extended package. When
+  // absent (community edition) the row falls back to navigation.
+  const ReviewModal = useSlot('MyTaskEvaluationModal')
+  const [reviewTaskId, setReviewTaskId] = useState<string | null>(null)
 
   // Debounce search so per-keystroke typing doesn't burst /my-tasks.
   const debouncedSearch = useDebouncedValue(searchQuery, 300)
@@ -130,6 +137,15 @@ export default function MyTasksPage() {
   }, [loadMyTasks])
 
   const startAnnotating = (task: MyTask) => {
+    // A task the user has already worked (feedback or any evaluation) opens the
+    // read-only submission+scores modal when the extended slot is mounted.
+    const canReview = task.has_feedback || task.has_evaluation
+    if (canReview && ReviewModal) {
+      setReviewTaskId(task.id)
+      return
+    }
+    // Legacy fallback when the modal slot isn't available: Korrektur feedback
+    // still has its own read-only page.
     if (task.has_feedback) {
       router.push(`/projects/${projectId}/my-korrektur/${task.id}`)
       return
@@ -302,6 +318,12 @@ export default function MyTasksPage() {
                         {t('tasks.myTasks.feedbackAvailable')}
                       </Badge>
                     )}
+                    {task.has_evaluation && (
+                      <Badge className="bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300">
+                        <ChartBarIcon className="mr-1 h-3 w-3" />
+                        {t('tasks.myTasks.evaluationAvailable')}
+                      </Badge>
+                    )}
                   </div>
 
                   {task.assignment && (
@@ -366,6 +388,20 @@ export default function MyTasksPage() {
             {t('common.next')}
           </Button>
         </div>
+      )}
+
+      {/* Read-only submission + scores modal (extended slot). Refreshes the
+          list on close so any newly-arrived evaluation badge appears. */}
+      {ReviewModal && reviewTaskId && (
+        // eslint-disable-next-line react-hooks/static-components
+        <ReviewModal
+          projectId={projectId}
+          taskId={reviewTaskId}
+          onClose={() => {
+            setReviewTaskId(null)
+            loadMyTasks()
+          }}
+        />
       )}
     </div>
   )

--- a/services/frontend/src/app/projects/[id]/page.tsx
+++ b/services/frontend/src/app/projects/[id]/page.tsx
@@ -352,6 +352,7 @@ export default function ProjectDetailPage({ params }: ProjectDetailPageProps) {
     min_annotations_per_task: 1,
     assignment_mode: 'open' as 'open' | 'manual' | 'auto',
     randomize_task_order: false,
+    annotator_full_visibility_after_submit: false,
     review_enabled: false,
     review_mode: 'in_place' as 'in_place' | 'independent' | 'both',
     allow_self_review: false,
@@ -664,6 +665,8 @@ export default function ProjectDetailPage({ params }: ProjectDetailPageProps) {
         min_annotations_per_task: currentProject.min_annotations_per_task || 1,
         assignment_mode: currentProject.assignment_mode || 'open',
         randomize_task_order: currentProject.randomize_task_order || false,
+        annotator_full_visibility_after_submit:
+          (currentProject as any).annotator_full_visibility_after_submit || false,
         review_enabled: currentProject.review_enabled || false,
         review_mode: currentProject.review_mode || 'in_place',
         allow_self_review: currentProject.allow_self_review || false,
@@ -2200,6 +2203,29 @@ export default function ProjectDetailPage({ params }: ProjectDetailPageProps) {
                           setAdvancedSettings((prev: any) => ({
                             ...prev,
                             randomize_task_order: e.target.checked,
+                          }))
+                        }
+                        disabled={!editing}
+                        className="h-4 w-4 rounded border-zinc-300 text-emerald-600 focus:ring-emerald-500 dark:border-zinc-600"
+                      />
+                    </div>
+
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <Label>
+                          {t('project.settings.annotationBehavior.annotatorFullVisibility', 'Reveal all fields after submission')}
+                        </Label>
+                        <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                          {t('project.settings.annotationBehavior.annotatorFullVisibilityHelp', 'When on, annotators reviewing their own submitted work see all task fields including the reference solution. When off, that view is filtered to only the fields they saw while labeling, keeping the reference hidden.')}
+                        </p>
+                      </div>
+                      <input
+                        type="checkbox"
+                        checked={advancedSettings.annotator_full_visibility_after_submit}
+                        onChange={(e) =>
+                          setAdvancedSettings((prev: any) => ({
+                            ...prev,
+                            annotator_full_visibility_after_submit: e.target.checked,
                           }))
                         }
                         disabled={!editing}

--- a/services/frontend/src/locales/de/common.json
+++ b/services/frontend/src/locales/de/common.json
@@ -1057,6 +1057,8 @@
         "assignmentModeHelp": "Steuert, wie Aufgaben an Annotatoren verteilt werden. Im Manuell/Auto-Modus sehen Annotatoren nur ihnen zugewiesene Aufgaben.",
         "randomizeTaskOrder": "Zufällige Aufgabenreihenfolge",
         "randomizeTaskOrderHelp": "Jeder Annotator sieht Aufgaben in einer anderen zufälligen Reihenfolge für eine gleichmäßige Annotationsverteilung",
+        "annotatorFullVisibility": "Alle Felder nach Abgabe anzeigen",
+        "annotatorFullVisibilityHelp": "Wenn aktiviert, sehen Annotatoren beim Ansehen ihrer eigenen abgegebenen Arbeit alle Aufgabenfelder einschließlich der Musterlösung. Wenn deaktiviert, ist diese Ansicht auf die Felder beschränkt, die sie beim Annotieren gesehen haben – die Musterlösung bleibt verborgen.",
         "samplingMethod": "Aufgaben-Sampling-Methode",
         "samplingMethodHelp": "Wie Aufgaben den Annotatoren präsentiert werden",
         "modes": {
@@ -1422,6 +1424,7 @@
       "taskPrefix": "Aufgabe",
       "labeled": "Beschriftet",
       "feedbackAvailable": "Feedback",
+      "evaluationAvailable": "Bewertung",
       "due": "Fällig"
     },
     "review": {

--- a/services/frontend/src/locales/en/common.json
+++ b/services/frontend/src/locales/en/common.json
@@ -1057,6 +1057,8 @@
         "assignmentModeHelp": "Controls how tasks are distributed to annotators. In Manual/Auto mode, annotators only see tasks assigned to them.",
         "randomizeTaskOrder": "Randomize task order",
         "randomizeTaskOrderHelp": "Each annotator sees tasks in a different random order for even annotation distribution",
+        "annotatorFullVisibility": "Reveal all fields after submission",
+        "annotatorFullVisibilityHelp": "When on, annotators reviewing their own submitted work see all task fields including the reference solution. When off, that view is filtered to only the fields they saw while labeling, keeping the reference hidden.",
         "samplingMethod": "Task Sampling Method",
         "samplingMethodHelp": "How tasks are presented to annotators",
         "modes": {
@@ -1422,6 +1424,7 @@
       "taskPrefix": "Task",
       "labeled": "Labeled",
       "feedbackAvailable": "Feedback",
+      "evaluationAvailable": "Evaluation",
       "due": "Due"
     },
     "review": {

--- a/services/shared/project_models.py
+++ b/services/shared/project_models.py
@@ -81,6 +81,16 @@ class Project(Base):
     # Immediate evaluation feedback (Issue #998)
     immediate_evaluation_enabled = Column(Boolean, default=False, nullable=False)
 
+    # When True, annotators reviewing their own submitted work in "Meine
+    # Aufgaben" see ALL task fields after submission (incl. the reference
+    # solution / Musterlösung and raw ground_truth) so they can compare and
+    # learn. When False (default) the post-submission view is filtered to only
+    # the fields the annotator saw while labeling — protecting the reference
+    # from being leaked to peers who still have to sit the same exam.
+    annotator_full_visibility_after_submit = Column(
+        Boolean, default=False, server_default="false", nullable=False
+    )
+
     # Annotation time limit (Issue #1043)
     annotation_time_limit_enabled = Column(Boolean, default=False, nullable=False)
     annotation_time_limit_seconds = Column(


### PR DESCRIPTION
## Why
"Meine Aufgaben" (`GET /my-tasks`) was assignment-only. In **open mode** no `TaskAssignment` row is ever created, so an annotator could label hundreds of tasks and see none of their work — or its scores — there.

## What
- **`assignments.py`** — `get_my_tasks` LEFT-joins the user's *task-level* assignment and also includes any task the user has a non-cancelled annotation on. Assigned tasks still rank first by priority/due-date; annotation-only tasks follow by `inner_id`. Status filter naturally targets the assignment.
- **`extensions.py`** — new `tasks_with_evaluation_for_user` extension point (empty set in the community edition) feeding a `has_evaluation` flag per task.
- **`project_models.py` + migration `062`** — `annotator_full_visibility_after_submit` boolean (default `false`). When off, the post-submission review is filtered to only the fields the annotator saw while labeling, keeping the reference solution hidden; when on, all fields are shown for comparison/learning. The proprietary view logic lives in extended; this PR owns the column, schema, and UI per the open-core split.
- **`project_schemas.py`** — setting wired into the update + response schemas.
- **project detail page** — checkbox in the annotation-settings collapsible (+ de/en i18n).
- **my-tasks page** — "evaluation available" badge; a worked task opens the extended review-modal slot, falling back to navigation in the community edition.

## Test plan
- `tests/unit/test_extensions.py` — both feedback/evaluation hooks return an empty set without the extended package.
- `tests/integration/test_assignments_integration.py::TestMyTasks` — open-mode annotated task appears with a null assignment; untouched task absent; status filter excludes annotation-only tasks. (Run locally against PostgreSQL: 6/6 pass.)
- `tests/unit/test_project_schemas_extended.py` — setting round-trips through update; defaults `False` on the response.
- my-tasks page Jest — evaluation badge renders; 13/13 pass.

The reference-leak protection that consumes the new column ships in the corresponding **benger-extended** PR, which must merge after this one.