### PR TITLE
fix(workers): count immediate-eval grades in missing-only re-runs

### DIFF
--- a/services/api/scripts/backfill_immediate_eval_config_id.py
+++ b/services/api/scripts/backfill_immediate_eval_config_id.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Backfill `evaluation_config_id` on legacy immediate-eval task_evaluations.
+
+Immediate eval persists a BARE ``field_name`` (e.g. ``"human:loesung"``, the
+config's prediction field) and — since Issue #111 / migration 057 — also the
+discrete ``evaluation_config_id`` column. The batch missing-only matcher
+(`workers/tasks.py::run_evaluation`) recognizes bare-field_name immediate rows
+as "already done" *via* that column. Rows written before #111 carry
+``evaluation_config_id = NULL`` and a bare field_name, so the matcher can't see
+them and would re-grade those annotations on the next missing-only run (wasted
+LLM budget + parallel/duplicate grades).
+
+This backfills the column on those legacy rows by mapping each row's metric +
+bare prediction field to the project's *current* evaluation config carrying that
+metric. Only rows with an UNAMBIGUOUS single match are touched; rows that match
+zero or multiple configs are skipped and logged — we never guess. This also
+satisfies the Issue #111 goal of a discretely-populated config-id for clean
+downstream aggregation.
+
+Scope (the candidate predicate):
+  * row's EvaluationRun has ``model_id = 'immediate'`` (the immediate lane)
+  * ``evaluation_config_id IS NULL``
+  * ``field_name`` is bare (contains no ``'|'`` — 3-part rows already carry/derive
+    the id and are handled by ``_normalize_field_key``)
+
+Idempotent: assigned rows drop out of the predicate, so re-running finds fewer
+(eventually zero) candidates.
+
+Usage (inside the api container):
+  python /app/scripts/backfill_immediate_eval_config_id.py --dry-run   # default
+  python /app/scripts/backfill_immediate_eval_config_id.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections import Counter, defaultdict
+
+# Make the api source (database.py) and /shared (models) importable whether run
+# from /app in the container or from the repo locally.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+for _p in (
+    "/shared",
+    "/app",
+    os.path.dirname(_HERE),  # services/api when run from the repo
+    os.path.join(os.path.dirname(os.path.dirname(_HERE)), "shared"),  # services/shared
+):
+    if os.path.isdir(_p) and _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import models  # noqa: E402,F401  — register User/Notification/... before relationships
+import project_models  # noqa: E402,F401
+from database import SessionLocal  # noqa: E402
+from models import EvaluationRun, TaskEvaluation  # noqa: E402
+from project_models import Task  # noqa: E402
+
+_WILDCARDS = ("__all_human__", "__all_model__")
+
+
+def _strip_role(s: str) -> str:
+    if s in _WILDCARDS:
+        return s
+    if s.startswith("human:") or s.startswith("model:"):
+        return s.split(":", 1)[1]
+    return s
+
+
+def _field_matches(field_name: str | None, pred_field: str) -> bool:
+    """Bare field_name vs a config prediction field, tolerating the
+    human:/model: role prefix. Mirrors workers/tasks.py::_pred_field_matches."""
+    if not field_name or "|" in field_name:
+        return False
+    if pred_field in _WILDCARDS:
+        return False
+    return field_name == pred_field or _strip_role(field_name) == _strip_role(pred_field)
+
+
+def _project_configs(project) -> list[dict]:
+    cfg = project.evaluation_config or {}
+    return cfg.get("evaluation_configs") or cfg.get("multi_field_evaluations") or []
+
+
+def resolve_config_id(metrics, field_name: str | None, configs: list[dict]):
+    """Return (config_id, reason). reason ∈ {ok, no_metric, no_field, ambiguous}.
+
+    Match a row to exactly one config by (metric present in the row) AND (the
+    config has a prediction field matching the bare field_name).
+    """
+    if not isinstance(metrics, dict):
+        return None, "no_metric"
+    config_metrics = {c.get("metric") for c in configs}
+    row_metrics = set(metrics.keys()) & config_metrics
+    if not row_metrics:
+        return None, "no_metric"
+    match_ids = set()
+    for c in configs:
+        if c.get("metric") not in row_metrics:
+            continue
+        if any(_field_matches(field_name, pf) for pf in c.get("prediction_fields", [])):
+            match_ids.add(c.get("id"))
+    match_ids.discard(None)
+    if len(match_ids) == 1:
+        return next(iter(match_ids)), "ok"
+    if not match_ids:
+        return None, "no_field"
+    return None, "ambiguous"
+
+
+def _candidates(db):
+    return (
+        db.query(TaskEvaluation)
+        .join(EvaluationRun, TaskEvaluation.evaluation_id == EvaluationRun.id)
+        .filter(
+            EvaluationRun.model_id == "immediate",
+            TaskEvaluation.evaluation_config_id.is_(None),
+            TaskEvaluation.field_name.isnot(None),
+            ~TaskEvaluation.field_name.like("%|%"),
+        )
+        .all()
+    )
+
+
+def _plan(db):
+    """Compute the (row -> config_id) assignment plan + skip reasons."""
+    rows = _candidates(db)
+    # project_id per task, configs per project (one query each).
+    task_ids = {r.task_id for r in rows if r.task_id}
+    project_by_task = dict(
+        db.query(Task.id, Task.project_id).filter(Task.id.in_(task_ids)).all()
+    ) if task_ids else {}
+    project_ids = set(project_by_task.values())
+    projects = (
+        {p.id: p for p in db.query(project_models.Project).filter(project_models.Project.id.in_(project_ids)).all()}
+        if project_ids
+        else {}
+    )
+
+    assign = []  # (row, project_id, config_id)
+    skips = []   # (row, project_id, reason)
+    for r in rows:
+        pid = project_by_task.get(r.task_id)
+        project = projects.get(pid)
+        if project is None:
+            skips.append((r, pid, "no_project"))
+            continue
+        cid, reason = resolve_config_id(r.metrics, r.field_name, _project_configs(project))
+        if reason == "ok":
+            assign.append((r, pid, cid))
+        else:
+            skips.append((r, pid, reason))
+    return rows, assign, skips
+
+
+def _print_summary(rows, assign, skips):
+    print(f"candidates (immediate, NULL config-id, bare field_name): {len(rows)}")
+    print(f"  resolvable (unambiguous single match): {len(assign)}")
+    print(f"  skipped:                               {len(skips)}")
+    if assign:
+        print("\nassignments per (project_id, config_id, field_name):")
+        by = Counter((pid, cid, r.field_name) for r, pid, cid in assign)
+        for (pid, cid, fn), n in sorted(by.items(), key=lambda kv: -kv[1]):
+            print(f"  {n:>5}  project={pid}  -> config={cid}  field={fn}")
+    if skips:
+        print("\nskips per reason:")
+        by_reason = Counter(reason for _, _, reason in skips)
+        for reason, n in by_reason.most_common():
+            print(f"  {n:>5}  {reason}")
+        print("\nskipped rows (up to 30):")
+        for r, pid, reason in skips[:30]:
+            mkeys = sorted((r.metrics or {}).keys()) if isinstance(r.metrics, dict) else r.metrics
+            print(f"  te={r.id}  project={pid}  field={r.field_name}  reason={reason}  metric_keys={mkeys}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", default=True,
+                      help="print the plan, do not commit (default)")
+    mode.add_argument("--apply", action="store_true",
+                      help="commit the backfill")
+    args = parser.parse_args()
+    apply_mode = bool(args.apply)
+
+    db = SessionLocal()
+    try:
+        rows, assign, skips = _plan(db)
+        if not apply_mode:
+            print("=== DRY RUN (no changes will be committed) ===")
+            _print_summary(rows, assign, skips)
+            return 0
+
+        _print_summary(rows, assign, skips)
+        for r, _pid, cid in assign:
+            r.evaluation_config_id = cid
+        db.commit()
+        print(f"\napplied: set evaluation_config_id on {len(assign)} rows.")
+        # Re-check idempotency.
+        remaining = len(_candidates(db))
+        print(f"remaining candidates after apply: {remaining} (expected: {len(skips)})")
+        if remaining != len(skips):
+            print("WARNING: remaining candidate count does not match expected skip count.")
+            return 1
+        print("done.")
+        return 0
+    except Exception as e:  # noqa: BLE001
+        db.rollback()
+        print(f"ERROR: {e}")
+        return 2
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/api/scripts/recover_missing_immediate_evals.py
+++ b/services/api/scripts/recover_missing_immediate_evals.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Recover LOST immediate-eval votes (KI-Votum) — additive, never overwrites.
+
+Immediate evaluation is fired CLIENT-side: the labeling page POSTs
+``/immediate`` after a successful annotation submit, then polls. There is no
+server-side fallback (``on_annotation_created`` only closes the timer + clears
+drafts). So if that POST never lands — tab closed right after submit, transient
+network blip — the annotation gets NO vote and nothing ever retries it. (This
+is exactly what happened to one Göttingen exam submission on 2026-06-17.)
+
+This tool finds those orphans and re-dispatches the SAME immediate-eval task
+the endpoint would (``tasks.run_single_sample_evaluation``), so the missing
+vote gets produced.
+
+SAFETY (the hard constraint): this script is strictly ADDITIVE.
+  * It only targets annotations that have ZERO existing immediate-eligible
+    ``TaskEvaluation`` rows (a real score for ANY eligible metric counts as
+    "has a vote" → skipped). It never re-grades an annotation that already
+    carries a vote, so no existing grade can be overwritten or duplicated.
+  * Partially-graded annotations (some eligible metrics present, some missing)
+    are REPORTED but never acted on — re-dispatching them risks a duplicate for
+    the already-present metric. Handle those by hand if they ever appear.
+  * It only INSERTs a new ``EvaluationRun`` + dispatches a task. It issues no
+    UPDATE/DELETE against ``task_evaluations`` or ``evaluation_runs``.
+  * ``--min-age-minutes`` (default 15) skips very recent submits so an
+    in-flight client eval isn't raced into a duplicate.
+
+Scope: projects with ``immediate_evaluation_enabled`` AND at least one enabled
+immediate-eligible config. Use ``--project-id`` for one project or ``--all``.
+
+Usage (inside the api container):
+  python /app/scripts/recover_missing_immediate_evals.py --project-id <id>            # dry-run
+  python /app/scripts/recover_missing_immediate_evals.py --project-id <id> --apply
+  python /app/scripts/recover_missing_immediate_evals.py --all                        # dry-run, all projects
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+for _p in (
+    "/shared",
+    "/app",
+    os.path.dirname(_HERE),
+    os.path.join(os.path.dirname(os.path.dirname(_HERE)), "shared"),
+):
+    if os.path.isdir(_p) and _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import models  # noqa: E402,F401
+import project_models  # noqa: E402,F401
+from database import SessionLocal  # noqa: E402
+from metric_filters import is_immediate_eligible  # noqa: E402
+from models import EvaluationRun, OrganizationMembership, TaskEvaluation, User  # noqa: E402
+from project_models import Annotation, Project, Task  # noqa: E402
+
+try:
+    from celery_client import send_task_safe
+except Exception:  # pragma: no cover - only needed for --apply
+    send_task_safe = None
+
+
+def _eligible_configs(project) -> list[dict]:
+    cfg = project.evaluation_config or {}
+    configs = cfg.get("evaluation_configs") or cfg.get("multi_field_evaluations") or []
+    return [
+        c
+        for c in configs
+        if c.get("enabled", True) and is_immediate_eligible(c.get("metric", ""))
+    ]
+
+
+def _eligible_metrics(eligible_configs) -> set:
+    return {c.get("metric", "") for c in eligible_configs}
+
+
+def _row_has_real_score_for(metrics, eligible_metrics: set) -> bool:
+    """True if the row carries a non-error score for any eligible metric."""
+    if not isinstance(metrics, dict):
+        return False
+    for m in eligible_metrics:
+        if m not in metrics:
+            continue
+        v = metrics[m]
+        if isinstance(v, dict):
+            if v.get("error"):
+                continue
+            if v.get("value") is not None:
+                return True
+        elif isinstance(v, (int, float)) and not isinstance(v, bool):
+            return True
+    return False
+
+
+def _parse_annotation_results(annotation) -> dict:
+    """Replicate the immediate-eval endpoint's annotation.result -> dict parse
+    (keyed by ``from_name``). Generic Label-Studio shape handling."""
+    out: dict = {}
+    res = annotation.result
+    if not (res and isinstance(res, list)):
+        return out
+    for region in res:
+        if not isinstance(region, dict):
+            continue
+        from_name = region.get("from_name")
+        if not from_name:
+            continue
+        value = region.get("value", {})
+        region_type = region.get("type", "")
+        if isinstance(value, str):
+            out[from_name] = value
+            continue
+        if isinstance(value, dict) and "markdown" in value:
+            out[from_name] = value["markdown"]
+            continue
+        if region_type == "textarea":
+            texts = value.get("text", [])
+            out[from_name] = "\n".join(texts) if isinstance(texts, list) else str(texts)
+        elif region_type == "choices":
+            choices = value.get("choices", [])
+            out[from_name] = choices[0] if len(choices) == 1 else choices
+        elif region_type == "rating":
+            out[from_name] = value.get("rating")
+        elif "text" in value:
+            texts = value["text"]
+            out[from_name] = "\n".join(texts) if isinstance(texts, list) else str(texts)
+        else:
+            for v in value.values():
+                if v:
+                    out[from_name] = v if isinstance(v, str) else str(v)
+                    break
+    return out
+
+
+def _resolve_org(db, project, user_id):
+    """Mirror routers.evaluations.helpers.resolve_user_org_for_project without
+    importing the router module."""
+    if not project.organizations:
+        return None
+    org_ids = {str(o.id) for o in project.organizations}
+    m = (
+        db.query(OrganizationMembership)
+        .filter(
+            OrganizationMembership.user_id == user_id,
+            OrganizationMembership.is_active == True,  # noqa: E712
+            OrganizationMembership.organization_id.in_(org_ids),
+        )
+        .first()
+    )
+    if m:
+        return str(m.organization_id)
+    return str(project.organizations[0].id)
+
+
+def _scan_project(db, project, cutoff):
+    """Return (candidates, partials) for one project.
+
+    candidate = (annotation, task) with ZERO eligible real-score rows.
+    partial   = (annotation, present_metrics, missing_metrics) — reported only.
+    """
+    eligible = _eligible_configs(project)
+    if not eligible:
+        return [], [], eligible
+    elig_metrics = _eligible_metrics(eligible)
+
+    anns = (
+        db.query(Annotation)
+        .filter(
+            Annotation.project_id == project.id,
+            Annotation.was_cancelled == False,  # noqa: E712
+            Annotation.result.isnot(None),
+            Annotation.created_at < cutoff,
+        )
+        .all()
+    )
+    if not anns:
+        return [], [], eligible
+
+    tasks_by_id = {
+        t.id: t
+        for t in db.query(Task).filter(Task.id.in_({a.task_id for a in anns})).all()
+    }
+
+    candidates, partials = [], []
+    for a in anns:
+        rows = (
+            db.query(TaskEvaluation.metrics)
+            .filter(TaskEvaluation.annotation_id == a.id)
+            .all()
+        )
+        present = set()
+        for (m,) in rows:
+            if _row_has_real_score_for(m, elig_metrics):
+                if isinstance(m, dict):
+                    present |= {k for k in m.keys() if k in elig_metrics}
+        if not present:
+            task = tasks_by_id.get(a.task_id)
+            if task is not None:
+                candidates.append((a, task))
+        elif present < elig_metrics:
+            partials.append((a, present, elig_metrics - present))
+    return candidates, partials, eligible
+
+
+def _dispatch(db, project, eligible, annotation, task, apply: bool) -> str:
+    """Pre-create the immediate EvaluationRun + dispatch the worker task — the
+    exact shape the endpoint uses. Returns the new eval_record_id."""
+    eval_record_id = str(uuid.uuid4())
+    if not apply:
+        return eval_record_id
+    annotation_results = _parse_annotation_results(annotation)
+    org = _resolve_org(db, project, annotation.completed_by)
+    meta = {
+        "evaluation_type": "immediate",
+        "trigger": "recover_missing_immediate_evals",
+        "expected_config_count": len(eligible),
+        "configs": [
+            {
+                "id": c.get("id", c.get("metric", "")),
+                "metric": c.get("metric", ""),
+                "display_name": c.get("display_name", c.get("metric", "")),
+            }
+            for c in eligible
+        ],
+    }
+    db.add(
+        EvaluationRun(
+            id=eval_record_id,
+            project_id=str(project.id),
+            model_id="immediate",
+            evaluation_type_ids=[c.get("metric", "") for c in eligible],
+            status="running",
+            created_by=str(annotation.completed_by),
+            eval_metadata=meta,
+            metrics={},
+        )
+    )
+    db.commit()
+    send_task_safe(
+        "tasks.run_single_sample_evaluation",
+        kwargs={
+            "evaluation_record_id": eval_record_id,
+            "project_id": str(project.id),
+            "task_id": str(task.id),
+            "annotation_id": str(annotation.id),
+            "evaluation_configs": [dict(c) for c in eligible],
+            "annotation_results": annotation_results,
+            "task_data": task.data or {},
+            "organization_id": org,
+            "user_id": str(annotation.completed_by),
+        },
+        queue="celery",
+    )
+    return eval_record_id
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    scope = parser.add_mutually_exclusive_group(required=True)
+    scope.add_argument("--project-id", help="recover one project")
+    scope.add_argument("--all", action="store_true",
+                       help="recover all immediate-eval-enabled projects")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", default=True,
+                      help="report only, dispatch nothing (default)")
+    mode.add_argument("--apply", action="store_true", help="dispatch recoveries")
+    parser.add_argument("--min-age-minutes", type=int, default=15,
+                        help="skip submits newer than this (avoid racing in-flight "
+                             "client evals); default 15")
+    args = parser.parse_args()
+    apply_mode = bool(args.apply)
+    if apply_mode and send_task_safe is None:
+        print("ERROR: celery_client.send_task_safe unavailable; cannot --apply.")
+        return 2
+
+    # NOTE: new()/utcnow() are fine here — this is a CLI one-shot, not a workflow.
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=args.min_age_minutes)
+
+    db = SessionLocal()
+    try:
+        q = db.query(Project).filter(Project.immediate_evaluation_enabled == True)  # noqa: E712
+        if args.project_id:
+            q = q.filter(Project.id == args.project_id)
+        projects = q.all()
+
+        if not apply_mode:
+            print("=== DRY RUN (nothing dispatched) ===")
+        print(f"scanning {len(projects)} immediate-eval project(s); "
+              f"min-age={args.min_age_minutes}m (cutoff {cutoff.isoformat()})\n")
+
+        total_candidates = total_dispatched = total_partials = 0
+        for p in projects:
+            candidates, partials, eligible = _scan_project(db, p, cutoff)
+            if not eligible:
+                continue
+            if not candidates and not partials:
+                continue
+            print(f"PROJECT {str(p.id)[:8]}  {p.title!r}")
+            print(f"   eligible metrics: {sorted(_eligible_metrics(eligible))}")
+            print(f"   missing-vote annotations: {len(candidates)}  "
+                  f"partial (reported only): {len(partials)}")
+            for a, task in candidates:
+                u = db.query(User).filter(User.id == a.completed_by).first()
+                uname = u.username if u else str(a.completed_by)[:8]
+                rid = _dispatch(db, p, eligible, a, task, apply_mode)
+                verb = "DISPATCHED" if apply_mode else "would dispatch"
+                print(f"      {verb}  ann={a.id}  user={uname}  submitted={a.created_at}  run={rid}")
+                total_candidates += 1
+                total_dispatched += 1 if apply_mode else 0
+            for a, present, missing in partials:
+                print(f"      PARTIAL (skipped) ann={a.id}  present={sorted(present)}  "
+                      f"missing={sorted(missing)}")
+                total_partials += 1
+            print()
+
+        print(f"missing-vote annotations: {total_candidates}")
+        print(f"partial annotations (skipped, manual review): {total_partials}")
+        if apply_mode:
+            print(f"dispatched: {total_dispatched}")
+        else:
+            print("dry-run: nothing dispatched. Re-run with --apply to recover.")
+        return 0
+    except Exception as e:  # noqa: BLE001
+        db.rollback()
+        print(f"ERROR: {e}")
+        return 2
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/api/tests/unit/test_evaluation_config_kills.py
+++ b/services/api/tests/unit/test_evaluation_config_kills.py
@@ -1,0 +1,633 @@
+"""
+Mutation-kill tests for the evaluation-config resolution layer
+(services/evaluation/config.py).
+
+This module decides WHICH metrics run for WHICH answer type and how a
+project's metric-config is validated / normalized / defaulted. A bug here
+silently computes the wrong metric set for a benchmark, drops a metric, or
+inverts the project-config-vs-defaults precedence. None of those surface as
+crashes, so they are exactly the class of fault a mutation test must pin.
+
+Every assertion below is an EXACT set / value, hand-reasoned from the source
+(the literal ANSWER_TYPE_TO_METRICS table, the {**defaults, **user} merge in
+normalize_metric_selection, and the get_metric_defaults dict). A flipped
+mapping, a dropped/added metric, an inverted precedence, or a broken
+default therefore fails a specific test rather than passing silently.
+
+Pure functions are called directly — no DB is needed for any of this layer.
+The only stateful seam is register_extended_metrics(), which mutates a
+module-global; those tests save/restore the global so they never leak into
+sibling tests.
+"""
+
+import copy
+
+import pytest
+
+# The public symbols are imported via the compatibility shim
+# (evaluation_config -> services.evaluation.config), matching the existing
+# tests/unit/test_evaluation_config.py import style. The canonical module
+# (services.evaluation.config) is imported separately as `cfg` so the isolation
+# fixture can reach the real `_extended_metrics` module-global that
+# register_extended_metrics() mutates — `from x import *` does NOT re-export
+# underscore-prefixed names, so the shim has no `_extended_metrics` attribute.
+import services.evaluation.config as cfg
+from evaluation_config import (
+    ANSWER_TYPE_TO_METRICS,
+    AnswerType,
+    get_metric_defaults,
+    get_metric_parameters,
+    get_metrics_for_answer_type,
+    get_selected_metrics_for_field,
+    normalize_metric_selection,
+    normalize_selected_methods,
+    register_extended_metrics,
+    validate_metric_selection,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_extended_metrics():
+    """Save/restore the module-global _extended_metrics registry.
+
+    register_extended_metrics() mutates a process-global. Without this guard a
+    registration in one test would bleed into get_metrics_for_answer_type() for
+    every later test (and every other test file in the same worker), so we deep
+    -copy it out and restore it afterward.
+    """
+    saved = copy.deepcopy(cfg._extended_metrics)
+    cfg._extended_metrics.clear()
+    cfg._extended_metrics.update(saved)
+    try:
+        yield cfg._extended_metrics
+    finally:
+        cfg._extended_metrics.clear()
+        cfg._extended_metrics.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# 1. ANSWER-TYPE -> METRICS: the exact resolved set per answer type.
+#    A wrong answer-type->metric mapping is the headline failure: the wrong
+#    metrics get computed for a benchmark. These pin every entry of the
+#    ANSWER_TYPE_TO_METRICS table down to the exact membership (order-
+#    independent set equality + length, so neither a drop nor a dup hides).
+# ---------------------------------------------------------------------------
+
+# Hand-transcribed from the literal table in config.py (lines 39-186).
+EXPECTED_METRICS = {
+    AnswerType.BINARY: {
+        "exact_match",
+        "accuracy",
+        "precision",
+        "recall",
+        "f1",
+        "cohen_kappa",
+        "llm_judge_classic",
+        "llm_judge_custom",
+    },
+    AnswerType.SINGLE_CHOICE: {
+        "exact_match",
+        "accuracy",
+        "precision",
+        "recall",
+        "f1",
+        "confusion_matrix",
+        "cohen_kappa",
+        "llm_judge_classic",
+        "llm_judge_custom",
+    },
+    AnswerType.MULTIPLE_CHOICE: {
+        "jaccard",
+        "hamming_loss",
+        "subset_accuracy",
+        "precision",
+        "recall",
+        "f1",
+        "llm_judge_classic",
+        "llm_judge_custom",
+    },
+    AnswerType.NUMERIC: {
+        "mae",
+        "rmse",
+        "mape",
+        "r2",
+        "correlation",
+        "llm_judge_classic",
+        "llm_judge_custom",
+    },
+    AnswerType.RATING: {
+        "mae",
+        "rmse",
+        "correlation",
+        "cohen_kappa",
+        "weighted_kappa",
+        "llm_judge_classic",
+        "llm_judge_custom",
+    },
+    AnswerType.RANKING: {
+        "spearman_correlation",
+        "kendall_tau",
+        "ndcg",
+        "llm_judge_classic",
+        "llm_judge_custom",
+    },
+    AnswerType.SHORT_TEXT: {
+        "exact_match",
+        "bleu",
+        "rouge",
+        "edit_distance",
+        "chrf",
+        "moverscore",
+        "semantic_similarity",
+        "llm_judge_classic",
+        "llm_judge_custom",
+    },
+    AnswerType.LONG_TEXT: {
+        "bleu",
+        "rouge",
+        "meteor",
+        "chrf",
+        "bertscore",
+        "moverscore",
+        "factcc",
+        "qags",
+        "semantic_similarity",
+        "coherence",
+        "llm_judge_classic",
+        "llm_judge_custom",
+    },
+    AnswerType.STRUCTURED_TEXT: {
+        "json_accuracy",
+        "schema_validation",
+        "field_accuracy",
+        "semantic_similarity",
+        "llm_judge_classic",
+        "llm_judge_custom",
+    },
+    AnswerType.SPAN_SELECTION: {
+        "span_exact_match",
+        "iou",
+        "partial_match",
+        "boundary_accuracy",
+        "llm_judge_classic",
+        "llm_judge_custom",
+    },
+    AnswerType.TAXONOMY: {
+        "hierarchical_f1",
+        "path_accuracy",
+        "lca_accuracy",
+        "llm_judge_classic",
+        "llm_judge_custom",
+    },
+    AnswerType.CUSTOM: {
+        "exact_match",
+        "accuracy",
+        "precision",
+        "recall",
+        "f1",
+        "cohen_kappa",
+        "jaccard",
+        "hamming_loss",
+        "subset_accuracy",
+        "confusion_matrix",
+        "mae",
+        "rmse",
+        "mape",
+        "r2",
+        "correlation",
+        "weighted_kappa",
+        "spearman_correlation",
+        "kendall_tau",
+        "ndcg",
+        "bleu",
+        "rouge",
+        "meteor",
+        "chrf",
+        "bertscore",
+        "moverscore",
+        "factcc",
+        "qags",
+        "semantic_similarity",
+        "edit_distance",
+        "coherence",
+        "json_accuracy",
+        "schema_validation",
+        "token_f1",
+        "span_exact_match",
+        "iou",
+        "map",
+        "hierarchical_f1",
+        "llm_judge_classic",
+        "llm_judge_custom",
+    },
+}
+
+
+@pytest.mark.parametrize("answer_type", list(AnswerType))
+def test_every_answer_type_resolves_exact_metric_set(answer_type):
+    """get_metrics_for_answer_type returns EXACTLY the documented set.
+
+    Kills: any mutation that drops, adds, or swaps a metric for an answer type
+    (e.g. moving "f1" out of BINARY, or "confusion_matrix" leaking into
+    MULTIPLE_CHOICE). Set-equality + length catches both removals and dups.
+    """
+    resolved = get_metrics_for_answer_type(answer_type)
+    expected = EXPECTED_METRICS[answer_type]
+
+    assert set(resolved) == expected, (
+        f"{answer_type.value}: metric set mismatch.\n"
+        f"  missing: {expected - set(resolved)}\n"
+        f"  unexpected: {set(resolved) - expected}"
+    )
+    # No accidental duplicates from a base+extended concat bug.
+    assert len(resolved) == len(set(resolved)), (
+        f"{answer_type.value}: duplicate metrics: {resolved}"
+    )
+    # With no extended metrics registered, the resolved list IS the base table.
+    assert list(resolved) == ANSWER_TYPE_TO_METRICS[answer_type]
+
+
+def test_answer_type_table_is_complete():
+    """Every AnswerType enum member has a metrics entry (no silent gap)."""
+    for at in AnswerType:
+        assert at in ANSWER_TYPE_TO_METRICS, f"{at.value} missing from table"
+        assert ANSWER_TYPE_TO_METRICS[at], f"{at.value} has empty metric list"
+
+
+def test_llm_judges_present_for_every_answer_type():
+    """Both LLM judges must be offered for every answer type (the universal
+    fallback evaluators). Kills a mutation dropping a judge from any row."""
+    for at in AnswerType:
+        metrics = set(get_metrics_for_answer_type(at))
+        assert "llm_judge_classic" in metrics, at.value
+        assert "llm_judge_custom" in metrics, at.value
+
+
+def test_classification_vs_multilabel_metric_separation():
+    """SINGLE_CHOICE is confusion-matrix classification; MULTIPLE_CHOICE is
+    multi-label (jaccard/hamming). Pin the boundary so a mapping swap fails:
+    confusion_matrix must NOT be in MULTIPLE_CHOICE, jaccard must NOT be in
+    SINGLE_CHOICE."""
+    single = set(get_metrics_for_answer_type(AnswerType.SINGLE_CHOICE))
+    multi = set(get_metrics_for_answer_type(AnswerType.MULTIPLE_CHOICE))
+
+    assert "confusion_matrix" in single
+    assert "confusion_matrix" not in multi
+    assert {"jaccard", "hamming_loss", "subset_accuracy"} <= multi
+    assert "jaccard" not in single
+
+
+def test_custom_is_superset_of_concrete_metric_types():
+    """CUSTOM ("unknown type, show everything") must contain the deterministic
+    metrics of every concrete type. Pins that the catch-all stays a superset —
+    a dropped metric from CUSTOM would hide it from custom-control benchmarks."""
+    custom = set(get_metrics_for_answer_type(AnswerType.CUSTOM))
+    for at in AnswerType:
+        if at is AnswerType.CUSTOM:
+            continue
+        for metric in get_metrics_for_answer_type(at):
+            # field_accuracy / partial_match / boundary_accuracy / path_accuracy
+            # / lca_accuracy are concrete-type-only and intentionally NOT in the
+            # CUSTOM grab-bag, so only assert the ones CUSTOM advertises.
+            if metric in custom or metric in {
+                "field_accuracy",
+                "partial_match",
+                "boundary_accuracy",
+                "path_accuracy",
+                "lca_accuracy",
+            }:
+                continue
+            pytest.fail(f"CUSTOM missing {metric} (offered by {at.value})")
+
+
+# ---------------------------------------------------------------------------
+# 2. VALIDATION: validate_metric_selection accepts in-set metrics, rejects
+#    out-of-set ones, and treats an unknown answer type as CUSTOM (the
+#    documented fallback). These pin the exact accept/reject boundary.
+# ---------------------------------------------------------------------------
+
+
+def test_validate_accepts_metric_in_answer_type_set():
+    assert validate_metric_selection("binary", "exact_match") is True
+    assert validate_metric_selection("long_text", "bertscore") is True
+    assert validate_metric_selection("numeric", "mae") is True
+
+
+def test_validate_rejects_metric_not_in_answer_type_set():
+    # bertscore is a long-text metric; it is NOT valid for binary.
+    assert validate_metric_selection("binary", "bertscore") is False
+    # confusion_matrix is single-choice only, not multiple_choice.
+    assert validate_metric_selection("multiple_choice", "confusion_matrix") is False
+    # A wholly made-up metric is never valid.
+    assert validate_metric_selection("numeric", "not_a_real_metric") is False
+
+
+def test_validate_unknown_answer_type_falls_back_to_custom():
+    """An unrecognized answer-type string is treated as CUSTOM (the most
+    permissive set), per the except ValueError branch. So a metric that is in
+    CUSTOM validates True even under a bogus answer-type string, and one that
+    is in NO set (field_accuracy is structured-text-only, not in CUSTOM)
+    validates False."""
+    assert validate_metric_selection("totally_made_up_type", "bleu") is True
+    assert validate_metric_selection("totally_made_up_type", "exact_match") is True
+    # field_accuracy is NOT in the CUSTOM set, so the CUSTOM fallback rejects it.
+    assert "field_accuracy" not in set(get_metrics_for_answer_type(AnswerType.CUSTOM))
+    assert validate_metric_selection("totally_made_up_type", "field_accuracy") is False
+
+
+def test_validate_is_consistent_with_resolution():
+    """validate_metric_selection must agree with get_metrics_for_answer_type
+    for every (answer_type, metric) pair — they are two views of one table."""
+    for at in AnswerType:
+        allowed = set(get_metrics_for_answer_type(at))
+        for metric in allowed:
+            assert validate_metric_selection(at.value, metric) is True, (at.value, metric)
+        # A metric known to be outside this set must validate False.
+        outsider = "definitely_not_in_any_set_xyz"
+        assert validate_metric_selection(at.value, outsider) is False
+
+
+# ---------------------------------------------------------------------------
+# 3. DEFAULTS: get_metric_defaults returns the documented parameter blocks for
+#    the four parameterized metrics and {} for everything else.
+# ---------------------------------------------------------------------------
+
+
+def test_metric_defaults_exact_values():
+    assert get_metric_defaults("bleu") == {
+        "max_order": 4,
+        "weights": [0.25, 0.25, 0.25, 0.25],
+        "smoothing": "method1",
+    }
+    assert get_metric_defaults("rouge") == {"variant": "rougeL", "use_stemmer": True}
+    assert get_metric_defaults("meteor") == {"alpha": 0.9, "beta": 3.0, "gamma": 0.5}
+    assert get_metric_defaults("chrf") == {"char_order": 6, "word_order": 0, "beta": 2}
+
+
+def test_metric_defaults_empty_for_unparameterized_metric():
+    """A metric with no default block returns {} (not None, not a default
+    borrowed from another metric)."""
+    assert get_metric_defaults("exact_match") == {}
+    assert get_metric_defaults("f1") == {}
+    assert get_metric_defaults("does_not_exist") == {}
+
+
+def test_metric_defaults_returns_fresh_mapping_per_metric():
+    """Distinct metrics must not share the same defaults object identity, and
+    bleu/rouge defaults must differ (pins that the dict keys aren't swapped)."""
+    assert get_metric_defaults("bleu") != get_metric_defaults("rouge")
+    assert get_metric_defaults("bleu")["max_order"] == 4
+
+
+# ---------------------------------------------------------------------------
+# 4. NORMALIZATION + PRECEDENCE: normalize_metric_selection turns either a bare
+#    string or an advanced dict into {"name", "parameters"} with user params
+#    overriding defaults ({**defaults, **user_params}) and defaults filling the
+#    gaps. This is the project-config-vs-defaults precedence seam.
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_string_form_uses_defaults():
+    """A bare metric name expands to name + the full default parameter block."""
+    assert normalize_metric_selection("bleu") == {
+        "name": "bleu",
+        "parameters": {
+            "max_order": 4,
+            "weights": [0.25, 0.25, 0.25, 0.25],
+            "smoothing": "method1",
+        },
+    }
+
+
+def test_normalize_string_form_unparameterized_metric():
+    assert normalize_metric_selection("exact_match") == {
+        "name": "exact_match",
+        "parameters": {},
+    }
+
+
+def test_normalize_advanced_form_user_param_overrides_default():
+    """PRECEDENCE: a user-supplied parameter WINS over the default, and unset
+    parameters fall back to the default. Kills a merge-order flip
+    ({**user, **defaults}) that would let defaults clobber the user value."""
+    result = normalize_metric_selection({"name": "bleu", "parameters": {"max_order": 2}})
+    assert result["name"] == "bleu"
+    # Override took effect...
+    assert result["parameters"]["max_order"] == 2
+    # ...while untouched params kept their defaults.
+    assert result["parameters"]["weights"] == [0.25, 0.25, 0.25, 0.25]
+    assert result["parameters"]["smoothing"] == "method1"
+
+
+def test_normalize_advanced_form_adds_unknown_param_alongside_defaults():
+    """A user param with no matching default is preserved and merged in."""
+    result = normalize_metric_selection(
+        {"name": "rouge", "parameters": {"variant": "rouge1", "custom_flag": True}}
+    )
+    assert result["parameters"]["variant"] == "rouge1"  # override
+    assert result["parameters"]["use_stemmer"] is True  # default preserved
+    assert result["parameters"]["custom_flag"] is True  # net-new user param
+
+
+def test_normalize_advanced_form_no_params_yields_defaults():
+    """An advanced form with an empty/absent parameters block is equivalent to
+    the bare-string form: it gets the full default block."""
+    assert normalize_metric_selection({"name": "meteor"}) == {
+        "name": "meteor",
+        "parameters": {"alpha": 0.9, "beta": 3.0, "gamma": 0.5},
+    }
+    assert normalize_metric_selection({"name": "meteor", "parameters": {}}) == {
+        "name": "meteor",
+        "parameters": {"alpha": 0.9, "beta": 3.0, "gamma": 0.5},
+    }
+
+
+def test_normalize_is_idempotent_on_already_normalized_input():
+    """Re-normalizing an already-normalized selection yields the same result
+    (the merged params are a no-op the second time). Pins idempotence of the
+    precedence merge."""
+    once = normalize_metric_selection("bleu")
+    twice = normalize_metric_selection(once)
+    assert once == twice
+
+
+# ---------------------------------------------------------------------------
+# 5. normalize_selected_methods: per-field normalization across the three
+#    accepted shapes (list, dict-with-"metrics", legacy dict-with-"automated").
+#    Every configured metric must survive normalization (completeness).
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_selected_methods_list_form():
+    out = normalize_selected_methods({"field1": ["bleu", "exact_match"]})
+    names = [m["name"] for m in out["field1"]["metrics"]]
+    assert names == ["bleu", "exact_match"]
+    # bleu carries its defaults through; exact_match gets {}.
+    assert out["field1"]["metrics"][0]["parameters"]["max_order"] == 4
+    assert out["field1"]["metrics"][1]["parameters"] == {}
+
+
+def test_normalize_selected_methods_dict_metrics_key():
+    out = normalize_selected_methods({"f": {"metrics": ["rouge"]}})
+    assert out["f"]["metrics"][0]["name"] == "rouge"
+    assert out["f"]["metrics"][0]["parameters"]["variant"] == "rougeL"
+
+
+def test_normalize_selected_methods_legacy_automated_key():
+    """Legacy configs store the list under "automated"; it must still be read
+    when "metrics" is absent (selections.get("metrics", selections.get("automated", [])))."""
+    out = normalize_selected_methods({"f": {"automated": ["bleu"]}})
+    assert [m["name"] for m in out["f"]["metrics"]] == ["bleu"]
+
+
+def test_normalize_selected_methods_metrics_key_wins_over_automated():
+    """When BOTH keys exist, "metrics" takes precedence over "automated"."""
+    out = normalize_selected_methods(
+        {"f": {"metrics": ["rouge"], "automated": ["bleu"]}}
+    )
+    assert [m["name"] for m in out["f"]["metrics"]] == ["rouge"]
+
+
+def test_normalize_selected_methods_completeness():
+    """COMPLETENESS: every configured metric across every field appears exactly
+    once in the normalized output. Kills any drop in the per-field loop."""
+    selected = {
+        "fieldA": ["bleu", "rouge", "exact_match"],
+        "fieldB": {"metrics": ["mae", "rmse"]},
+        "fieldC": {"automated": ["accuracy"]},
+    }
+    out = normalize_selected_methods(selected)
+    assert {m["name"] for m in out["fieldA"]["metrics"]} == {"bleu", "rouge", "exact_match"}
+    assert {m["name"] for m in out["fieldB"]["metrics"]} == {"mae", "rmse"}
+    assert {m["name"] for m in out["fieldC"]["metrics"]} == {"accuracy"}
+
+
+def test_normalize_selected_methods_malformed_field_yields_empty():
+    """A non-list/non-dict field value (e.g. a stray string) normalizes to an
+    empty metric list rather than raising or fabricating a metric."""
+    out = normalize_selected_methods({"weird": "not_a_structure"})
+    assert out["weird"] == {"metrics": []}
+    # dict with a non-list "metrics" also collapses to empty.
+    out2 = normalize_selected_methods({"weird": {"metrics": "oops"}})
+    assert out2["weird"] == {"metrics": []}
+
+
+# ---------------------------------------------------------------------------
+# 6. READBACK: get_selected_metrics_for_field and get_metric_parameters read
+#    a stored config back. Pin default-fallthrough + format tolerance.
+# ---------------------------------------------------------------------------
+
+
+def test_get_selected_metrics_for_field_list_and_dict_formats():
+    list_cfg = {"selected_methods": {"f": ["bleu", "rouge"]}}
+    assert get_selected_metrics_for_field(list_cfg, "f") == ["bleu", "rouge"]
+
+    dict_cfg = {"selected_methods": {"f": {"metrics": ["mae"]}}}
+    assert get_selected_metrics_for_field(dict_cfg, "f") == ["mae"]
+
+
+def test_get_selected_metrics_for_field_missing_returns_empty():
+    assert get_selected_metrics_for_field({}, "f") == []
+    assert get_selected_metrics_for_field(None, "f") == []
+    assert get_selected_metrics_for_field({"selected_methods": {}}, "absent") == []
+
+
+def test_get_metric_parameters_returns_configured_then_default():
+    """Configured parameters win; an unconfigured metric falls back to the
+    metric's defaults (NOT to {} and NOT to another metric's defaults)."""
+    cfg_with_params = {
+        "selected_methods": {
+            "f": [{"name": "bleu", "parameters": {"max_order": 2}}]
+        }
+    }
+    assert get_metric_parameters(cfg_with_params, "f", "bleu") == {"max_order": 2}
+    # A metric not present in the field falls back to its own defaults.
+    assert get_metric_parameters(cfg_with_params, "f", "rouge") == get_metric_defaults("rouge")
+    # No config at all -> defaults for the requested metric.
+    assert get_metric_parameters({}, "f", "chrf") == get_metric_defaults("chrf")
+
+
+def test_get_metric_parameters_string_metric_uses_defaults():
+    """A field listing a metric as a bare string (no per-metric params) returns
+    that metric's defaults."""
+    cfg_str = {"selected_methods": {"f": ["meteor"]}}
+    assert get_metric_parameters(cfg_str, "f", "meteor") == get_metric_defaults("meteor")
+
+
+# ---------------------------------------------------------------------------
+# 7. EXTENDED MERGE (open-core seam): register_extended_metrics adds metrics to
+#    an answer type WITHOUT dropping any core metric. Isolated via the
+#    save/restore fixture so the global never leaks.
+# ---------------------------------------------------------------------------
+
+
+def test_extended_metrics_merge_appends_without_dropping_core(isolated_extended_metrics):
+    core_long_text = list(get_metrics_for_answer_type(AnswerType.LONG_TEXT))
+
+    register_extended_metrics("long_text", ["llm_judge_falloesung", "korrektur_falloesung"])
+
+    merged = get_metrics_for_answer_type(AnswerType.LONG_TEXT)
+    # Core metrics all preserved, in their original order, at the front.
+    assert merged[: len(core_long_text)] == core_long_text
+    # Extended metrics appended.
+    assert "llm_judge_falloesung" in merged
+    assert "korrektur_falloesung" in merged
+    # Nothing from core was dropped.
+    assert set(core_long_text) <= set(merged)
+    assert len(merged) == len(core_long_text) + 2
+
+
+def test_extended_metrics_isolated_to_their_answer_type(isolated_extended_metrics):
+    """Registering for long_text must not change any OTHER answer type's set."""
+    before_short = set(get_metrics_for_answer_type(AnswerType.SHORT_TEXT))
+    register_extended_metrics("long_text", ["llm_judge_falloesung"])
+    after_short = set(get_metrics_for_answer_type(AnswerType.SHORT_TEXT))
+    assert before_short == after_short
+
+
+def test_extended_metrics_validate_after_registration(isolated_extended_metrics):
+    """A freshly-registered extended metric must then validate True for its
+    answer type (the validation path reads the same merged set)."""
+    assert validate_metric_selection("long_text", "llm_judge_falloesung") is False
+    register_extended_metrics("long_text", ["llm_judge_falloesung"])
+    assert validate_metric_selection("long_text", "llm_judge_falloesung") is True
+
+
+def test_extended_metrics_accumulate_across_calls(isolated_extended_metrics):
+    """Two registrations for the same answer type both stick (extend, not
+    replace)."""
+    register_extended_metrics("taxonomy", ["ext_one"])
+    register_extended_metrics("taxonomy", ["ext_two"])
+    merged = get_metrics_for_answer_type(AnswerType.TAXONOMY)
+    assert "ext_one" in merged
+    assert "ext_two" in merged
+
+
+def test_no_extended_metrics_leak_into_clean_resolution(isolated_extended_metrics):
+    """Inside an isolated context with the registry cleared, resolution equals
+    the pure base table — confirming the fixture truly isolates and that the
+    base path is extended-free."""
+    isolated_extended_metrics.clear()
+    for at in AnswerType:
+        assert list(get_metrics_for_answer_type(at)) == ANSWER_TYPE_TO_METRICS[at]
+
+
+# ---------------------------------------------------------------------------
+# 8. IDEMPOTENCE: resolving the same answer type twice yields identical output,
+#    and the resolution does not mutate the underlying table.
+# ---------------------------------------------------------------------------
+
+
+def test_resolution_is_idempotent_and_non_mutating():
+    for at in AnswerType:
+        snapshot = list(ANSWER_TYPE_TO_METRICS[at])
+        first = get_metrics_for_answer_type(at)
+        second = get_metrics_for_answer_type(at)
+        assert first == second
+        # Resolving must not mutate the source-of-truth table.
+        assert ANSWER_TYPE_TO_METRICS[at] == snapshot

--- a/services/frontend/src/components/leaderboards/LLMLeaderboardTable.tsx
+++ b/services/frontend/src/components/leaderboards/LLMLeaderboardTable.tsx
@@ -17,10 +17,10 @@ import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 import { useProjects } from '@/hooks/useProjects'
 import {
   AvailableMetric,
+  formatValueForScale,
   getMetricDefinitions,
   getMetricScale,
   getMetricSummable,
-  type MetricDisplayScale,
 } from '@/lib/api/evaluation-types'
 import type { LLMLeaderboardEntry } from '@/lib/api/leaderboards'
 import { Menu } from '@headlessui/react'
@@ -248,27 +248,13 @@ export function LLMLeaderboardTable() {
   }
 
   // Scale-aware formatter. The metric registry is the single source of
-  // truth: a metric declared `display_scale: '0-1'` displays as a percent
-  // (×100), `'0-100'` displays as-is, `'0-18'` as Notenpunkte, `'raw'`
-  // unitless. Unknown keys default to `'0-1'` for backwards compatibility
-  // with the historical formatter behaviour. This unifies what used to be
-  // a hand-maintained `NATIVELY_PERCENT_METRICS` allowlist plus a
-  // `endsWith('grade_points')` special case.
-  const formatValueForScale = (value: number, scale: MetricDisplayScale, sum: boolean): string => {
-    if (scale === '0-18') {
-      return sum ? `${value.toFixed(1)} NP` : `${value.toFixed(1)} / 18 NP`
-    }
-    if (sum) {
-      // Sums of percentage-shaped metrics aren't dimensionally meaningful
-      // (sum of 100 bleu scores at 0.05 = 5, "5%" reads as 5/100 not 5
-      // bleu-units). Render as a raw number with no unit suffix and let
-      // the user infer.
-      return value.toFixed(2)
-    }
-    if (scale === '0-100') return `${value.toFixed(1)}%`
-    if (scale === '0-1') return `${(value * 100).toFixed(1)}%`
-    return value.toFixed(2) // raw
-  }
+  // truth for the display scale; the rendering arithmetic lives in
+  // `formatValueForScale` (co-located with `getMetricScale` in
+  // evaluation-types.ts) so it can be unit/mutation-tested in isolation.
+  // Unknown keys default to `'0-1'` for backwards compatibility (resolved
+  // by `getMetricScale`). This unifies what used to be a hand-maintained
+  // `NATIVELY_PERCENT_METRICS` allowlist plus a `endsWith('grade_points')`
+  // special case.
 
   const formatScore = (score: number | null) => {
     if (score === null || score === undefined) return 'n/a'

--- a/services/frontend/src/lib/api/__tests__/evaluation-types.format-value.test.ts
+++ b/services/frontend/src/lib/api/__tests__/evaluation-types.format-value.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Fixed-point tests for `formatValueForScale` — the display-arithmetic that
+ * turns a raw metric score into the string shown on the PUBLIC LLM
+ * leaderboard.
+ *
+ * Why this file exists: a bug here is a wrong displayed benchmark number on a
+ * research-grade legal-LLM leaderboard (e.g. 0.85 rendered as "8.5%" instead
+ * of "85.0%"). The function used to be an untested nested closure inside
+ * `LLMLeaderboardTable.tsx`; it was hoisted to a module-level export in
+ * `evaluation-types.ts` (co-located with `getMetricScale`) precisely so its
+ * branch + precision contract can be pinned exactly here and mutation-covered.
+ *
+ * Each block targets a specific class of mutant:
+ *  - the ×100 multiply on '0-1' (drop / wrong constant)
+ *  - the toFixed precision (1 vs 2 decimals; 0-1/0-100 use 1, sums/raw use 2)
+ *  - the NP suffix + the sum/non-sum split inside '0-18'
+ *  - the generic `sum` short-circuit (its presence AND its position before the
+ *    '0-100' / '0-1' percent checks)
+ *  - the '0-18'-before-`sum` precedence
+ *  - the raw / unknown-scale fallback
+ */
+
+import { formatValueForScale } from '../evaluation-types'
+
+describe("formatValueForScale — '0-1' scale (×100 to percent, 1 decimal)", () => {
+  // Kills the ×100 drop and any wrong-precision mutant.
+  it.each([
+    [0.85, '85.0%'],
+    [0.5, '50.0%'],
+    [1, '100.0%'],
+    [0, '0.0%'],
+  ])('formats %p as %p', (value, expected) => {
+    expect(formatValueForScale(value, '0-1', false)).toBe(expected)
+  })
+
+  it('rounds to exactly one decimal (not two, not zero)', () => {
+    // 0.12345 ×100 = 12.345 -> "12.3%" pins toFixed(1) specifically.
+    expect(formatValueForScale(0.12345, '0-1', false)).toBe('12.3%')
+  })
+})
+
+describe("formatValueForScale — '0-100' scale (as-is percent, NO ×100)", () => {
+  // Kills routing '0-100' through the '0-1' ×100 path: 85 must stay "85.0%",
+  // never "8500.0%".
+  it('renders 85 as "85.0%" without multiplying by 100', () => {
+    expect(formatValueForScale(85, '0-100', false)).toBe('85.0%')
+  })
+
+  it.each([
+    [0, '0.0%'],
+    [100, '100.0%'],
+    [42.5, '42.5%'],
+  ])('formats %p as %p', (value, expected) => {
+    expect(formatValueForScale(value, '0-100', false)).toBe(expected)
+  })
+
+  it('uses one-decimal precision', () => {
+    // 12.345 -> "12.3%" (toFixed(1)), not "12.35%" or "12%".
+    expect(formatValueForScale(12.345, '0-100', false)).toBe('12.3%')
+  })
+})
+
+describe("formatValueForScale — '0-18' Notenpunkte scale", () => {
+  // Kills the NP suffix mutant and the sum/non-sum branch swap.
+  it('non-sum renders "X.x / 18 NP"', () => {
+    expect(formatValueForScale(12.3, '0-18', false)).toBe('12.3 / 18 NP')
+  })
+
+  it('sum renders "X.x NP" (no "/ 18")', () => {
+    expect(formatValueForScale(12.3, '0-18', true)).toBe('12.3 NP')
+  })
+
+  it('uses one-decimal precision for both forms', () => {
+    expect(formatValueForScale(7.25, '0-18', false)).toBe('7.3 / 18 NP')
+    expect(formatValueForScale(7.25, '0-18', true)).toBe('7.3 NP')
+  })
+
+  it('handles the boundary values 0 and 18', () => {
+    expect(formatValueForScale(0, '0-18', false)).toBe('0.0 / 18 NP')
+    expect(formatValueForScale(18, '0-18', false)).toBe('18.0 / 18 NP')
+  })
+})
+
+describe('formatValueForScale — sum short-circuit on percentage scales', () => {
+  // Kills the sum branch being dropped OR being placed AFTER the '0-100' /
+  // '0-1' percent checks. A summed percentage-shaped metric is dimensionless:
+  // raw value.toFixed(2), NO % sign, NO ×100.
+  it("'0-1' + sum returns raw toFixed(2) with no % and no ×100", () => {
+    expect(formatValueForScale(5, '0-1', true)).toBe('5.00')
+    expect(formatValueForScale(0.85, '0-1', true)).toBe('0.85')
+  })
+
+  it("'0-100' + sum returns raw toFixed(2) with no %", () => {
+    expect(formatValueForScale(5, '0-100', true)).toBe('5.00')
+    expect(formatValueForScale(250.5, '0-100', true)).toBe('250.50')
+  })
+
+  it("'raw' + sum returns raw toFixed(2)", () => {
+    expect(formatValueForScale(5, 'raw', true)).toBe('5.00')
+  })
+
+  it('the sum result contains no percent sign', () => {
+    expect(formatValueForScale(0.85, '0-1', true)).not.toContain('%')
+    expect(formatValueForScale(85, '0-100', true)).not.toContain('%')
+  })
+})
+
+describe('formatValueForScale — raw / unknown scale fallback', () => {
+  // Kills the fallback precision / suffix.
+  it.each([
+    [0.85, '0.85'],
+    [5, '5.00'],
+    [12.345, '12.35'],
+    [0, '0.00'],
+  ])("'raw' formats %p as %p (toFixed(2), no unit)", (value, expected) => {
+    expect(formatValueForScale(value, 'raw', false)).toBe(expected)
+  })
+
+  it("'raw' output carries no % suffix", () => {
+    expect(formatValueForScale(0.85, 'raw', false)).not.toContain('%')
+  })
+})
+
+describe('formatValueForScale — branch precedence', () => {
+  // The '0-18' check runs BEFORE the generic `sum` short-circuit, so a summed
+  // Notenpunkte metric must still render the NP form — NOT the dimensionless
+  // toFixed(2). This pins the ordering: were the `sum` branch moved above the
+  // '0-18' check, this would return "12.30".
+  it("'0-18' + sum yields the NP form, not the dimensionless sum form", () => {
+    expect(formatValueForScale(12.3, '0-18', true)).toBe('12.3 NP')
+    expect(formatValueForScale(12.3, '0-18', true)).not.toBe('12.30')
+  })
+
+  it("'0-100' percent check runs only when not a sum (sum wins for '0-100')", () => {
+    // Non-sum -> percent; sum -> dimensionless. Pins that the '0-100' branch
+    // sits AFTER the sum short-circuit.
+    expect(formatValueForScale(85, '0-100', false)).toBe('85.0%')
+    expect(formatValueForScale(85, '0-100', true)).toBe('85.00')
+  })
+
+  it("'0-1' percent check runs only when not a sum (sum wins for '0-1')", () => {
+    expect(formatValueForScale(0.85, '0-1', false)).toBe('85.0%')
+    expect(formatValueForScale(0.85, '0-1', true)).toBe('0.85')
+  })
+})

--- a/services/frontend/src/lib/api/__tests__/evaluation-types.property.test.ts
+++ b/services/frontend/src/lib/api/__tests__/evaluation-types.property.test.ts
@@ -21,12 +21,13 @@
  *  - generateEvaluationId                             (prefix + uniqueness)
  *  - static-table integrity (METRIC_ORDER / GROUPED_METRICS / scale tokens)
  *
- * NOTE on the scale contract: the *arithmetic* of rendering a value under a
- * scale (×100 for '0-1', "X / 18 NP" for '0-18', etc.) lives in the
- * leaderboard component, not here. This module owns the resolution step —
- * which scale token a metric maps to — which is the input that drives that
- * formatter. So the scale invariants below pin the *token* a metric resolves
- * to (the thing a wrong-constant mutant would corrupt), not a formatter.
+ * NOTE on the scale contract: this module owns BOTH the resolution step
+ * (`getMetricScale` — which scale token a metric maps to) and the rendering
+ * arithmetic (`formatValueForScale` — ×100 for '0-1', "X / 18 NP" for '0-18',
+ * etc.). The scale invariants below pin the *token* a metric resolves to (the
+ * thing a wrong-constant mutant would corrupt); the exact branch/precision
+ * arithmetic of `formatValueForScale` is pinned in the sibling test file
+ * `evaluation-types.format-value.test.ts`.
  */
 
 import fc from 'fast-check'

--- a/services/frontend/src/lib/api/evaluation-types.ts
+++ b/services/frontend/src/lib/api/evaluation-types.ts
@@ -1111,6 +1111,44 @@ export function getMetricScale(key: string): MetricDisplayScale {
 }
 
 /**
+ * Render a raw metric score to the string shown on the leaderboard, honouring
+ * the metric's display scale. This is the display-arithmetic counterpart to
+ * `getMetricScale` (which resolves the scale token); they're co-located so the
+ * resolution step and the rendering step stay in lockstep.
+ *
+ * A bug here is a wrong displayed benchmark number on the PUBLIC leaderboard
+ * (e.g. `0.85` rendered as "8.5%" instead of "85.0%"), so the branch/precision
+ * contract is pinned exactly by unit tests.
+ *
+ * Branch contract (order matters — `'0-18'` is checked BEFORE the generic
+ * `sum` short-circuit):
+ *  - `'0-18'` (Notenpunkte): `"X.x NP"` when `sum`, else `"X.x / 18 NP"` —
+ *    one decimal.
+ *  - `sum` (any other scale): sums of percentage-shaped metrics aren't
+ *    dimensionally meaningful (sum of 100 bleu scores at 0.05 = 5, "5%" reads
+ *    as 5/100 not 5 bleu-units), so render the raw value with `toFixed(2)` and
+ *    NO unit suffix and let the user infer.
+ *  - `'0-100'`: already a percent, `"X.x%"` as-is, one decimal (NO ×100).
+ *  - `'0-1'`: raw fraction, `"X.x%"` after ×100, one decimal.
+ *  - `'raw'` / unknown: unitless `toFixed(2)`.
+ */
+export function formatValueForScale(
+  value: number,
+  scale: MetricDisplayScale,
+  sum: boolean
+): string {
+  if (scale === '0-18') {
+    return sum ? `${value.toFixed(1)} NP` : `${value.toFixed(1)} / 18 NP`
+  }
+  if (sum) {
+    return value.toFixed(2)
+  }
+  if (scale === '0-100') return `${value.toFixed(1)}%`
+  if (scale === '0-1') return `${(value * 100).toFixed(1)}%`
+  return value.toFixed(2) // raw
+}
+
+/**
  * Whether `sum(values)` is meaningful for this metric. Defaults to false —
  * the conservative choice for unknown keys, mirroring `getMetricScale`.
  * Used by the leaderboard's Sum-aggregation toggle to disable itself when

--- a/services/shared/ai_services/__init__.py
+++ b/services/shared/ai_services/__init__.py
@@ -34,7 +34,6 @@ from .provider_capabilities import (
 from .response_validator import (
     ResponseValidator,
     ValidationResult,
-    RepairResult,
     validate_structured_response,
 )
 
@@ -67,6 +66,5 @@ __all__ = [
     # Response validation
     "ResponseValidator",
     "ValidationResult",
-    "RepairResult",
     "validate_structured_response",
 ]

--- a/services/shared/ai_services/base_service.py
+++ b/services/shared/ai_services/base_service.py
@@ -27,6 +27,30 @@ def derive_truncated(finish_reason: Optional[str]) -> bool:
     return finish_reason in TRUNCATED_FINISH_REASONS
 
 
+# Content-policy / safety refusal finish_reasons. Conservative: only the
+# documented content-filter signals, so a normal/length/stop response is never
+# mislabelled a refusal. OpenAI + Anthropic expose a dedicated ``refusal`` field
+# (handled in those services); Google uses a ``SAFETY`` finish_reason (handled in
+# google_service). The OpenAI-compatible providers (Grok, DeepInfra) and Cohere
+# only surface it via finish_reason, so derive_refusal maps those.
+REFUSAL_FINISH_REASONS = frozenset({
+    "content_filter",   # OpenAI-compatible (Grok / DeepInfra) content-policy block
+    "ERROR_TOXIC",      # Cohere content-policy block
+})
+
+
+def derive_refusal(finish_reason: Optional[str]) -> bool:
+    """True if the model DECLINED for content-policy/safety reasons.
+
+    A refusal is distinct from a normal stop or a length truncation: no real
+    answer was produced because a safety filter fired. For an academic benchmark
+    this matters — a refusal silently scored as a real answer biases the result.
+    """
+    if not finish_reason:
+        return False
+    return finish_reason in REFUSAL_FINISH_REASONS
+
+
 def classify_error_type(exc: BaseException) -> str:
     """Classify a provider-call exception into the error_type enum.
 

--- a/services/shared/ai_services/cohere_service.py
+++ b/services/shared/ai_services/cohere_service.py
@@ -427,7 +427,6 @@ Your response must be ONLY the JSON object, no other text before or after.
             validation_result = validator.validate_response(
                 raw_content,
                 json_schema,
-                attempt_repair=True
             )
 
             finish_reason = (
@@ -464,10 +463,6 @@ Your response must be ONLY the JSON object, no other text before or after.
                 result_metadata["schema_validated"] = False
                 result_metadata["validation_errors"] = validation_result.errors
                 logger.warning(f"Cohere response not valid JSON: {validation_result.errors}")
-
-            if validation_result.repair_attempted:
-                result_metadata["repair_attempted"] = True
-                result_metadata["repair_successful"] = validation_result.repair_successful
 
             return self._create_response_dict(
                 content=content,

--- a/services/shared/ai_services/cohere_service.py
+++ b/services/shared/ai_services/cohere_service.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from functools import wraps
 from typing import Any, Dict, Optional
 
-from .base_service import BaseAIService, derive_truncated
+from .base_service import BaseAIService, derive_refusal, derive_truncated
 from .provider_capabilities import model_supports_seed
 from .response_validator import ResponseValidator
 
@@ -279,8 +279,10 @@ class CohereService(BaseAIService):
                     "response_time_ms": response_time_ms,
                     "finish_reason": finish_reason,
                     "truncated": derive_truncated(finish_reason) or finish_reason == "MAX_TOKENS",
-                    # Cohere has no equivalent of message.refusal today.
-                    "refusal": False,
+                    # Cohere surfaces a content-policy block via the ERROR_TOXIC
+                    # finish_reason (mapped by derive_refusal); it has no
+                    # message.refusal field like OpenAI/Anthropic.
+                    "refusal": derive_refusal(finish_reason),
                     "error_type": None,
                     "seed": requested_seed if supports_seed_here else None,
                     "created_at": end_time.isoformat(),
@@ -439,7 +441,7 @@ Your response must be ONLY the JSON object, no other text before or after.
                 "structured_output": True,
                 "finish_reason": finish_reason,
                 "truncated": derive_truncated(finish_reason) or finish_reason == "MAX_TOKENS",
-                "refusal": False,
+                "refusal": derive_refusal(finish_reason),
                 "error_type": None,
                 "seed": requested_seed if supports_seed_here else None,
                 "created_at": end_time.isoformat(),

--- a/services/shared/ai_services/deepinfra_service.py
+++ b/services/shared/ai_services/deepinfra_service.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, Optional
 
 import aiohttp
 
-from .base_service import BaseAIService, derive_truncated
+from .base_service import BaseAIService, derive_refusal, derive_truncated
 from .provider_capabilities import calculate_cost, model_supports_seed
 from .response_validator import ResponseValidator
 
@@ -300,7 +300,9 @@ class DeepInfraService(BaseAIService):
                     "provider": "DeepInfra",
                     "finish_reason": finish_reason,
                     "truncated": derive_truncated(finish_reason),
-                    "refusal": False,
+                    # DeepInfra is OpenAI-compatible: a content-policy block surfaces
+                    # as the "content_filter" finish_reason (mapped by derive_refusal).
+                    "refusal": derive_refusal(finish_reason),
                     "error_type": None,
                     # Per-model gated; None when the model doesn't accept seed.
                     "seed": requested_seed if supports_seed_here else None,

--- a/services/shared/ai_services/deepinfra_service.py
+++ b/services/shared/ai_services/deepinfra_service.py
@@ -410,7 +410,6 @@ Your response must be ONLY the JSON object, no other text before or after.
                 validation_result = validator.validate_response(
                     result["content"],
                     json_schema,
-                    attempt_repair=True
                 )
 
                 if validation_result.valid and validation_result.data != None:
@@ -431,10 +430,6 @@ Your response must be ONLY the JSON object, no other text before or after.
                     result["metadata"]["schema_validated"] = False
                     result["metadata"]["validation_errors"] = validation_result.errors
                     logger.warning(f"DeepInfra response not valid JSON: {validation_result.errors}")
-
-                if validation_result.repair_attempted:
-                    result["metadata"]["repair_attempted"] = True
-                    result["metadata"]["repair_successful"] = validation_result.repair_successful
 
             return result
 

--- a/services/shared/ai_services/google_service.py
+++ b/services/shared/ai_services/google_service.py
@@ -553,7 +553,6 @@ class GoogleService(BaseAIService):
             validation_result = validator.validate_response(
                 response_text,
                 json_schema,
-                attempt_repair=True
             )
 
             result_metadata = {
@@ -591,10 +590,6 @@ class GoogleService(BaseAIService):
                 result_metadata["validation_errors"] = validation_result.errors
                 logger.warning(
                     f"Google response not valid JSON: {validation_result.errors}")
-
-            if validation_result.repair_attempted:
-                result_metadata["repair_attempted"] = True
-                result_metadata["repair_successful"] = validation_result.repair_successful
 
             return self._create_response_dict(
                 content=content,

--- a/services/shared/ai_services/grok_service.py
+++ b/services/shared/ai_services/grok_service.py
@@ -455,7 +455,6 @@ Your response must be ONLY the JSON object, no other text before or after.
             validation_result = validator.validate_response(
                 raw_content,
                 json_schema,
-                attempt_repair=True
             )
 
             finish_reason = (
@@ -492,10 +491,6 @@ Your response must be ONLY the JSON object, no other text before or after.
                 result_metadata["schema_validated"] = False
                 result_metadata["validation_errors"] = validation_result.errors
                 logger.warning(f"Grok response not valid JSON: {validation_result.errors}")
-
-            if validation_result.repair_attempted:
-                result_metadata["repair_attempted"] = True
-                result_metadata["repair_successful"] = validation_result.repair_successful
 
             return self._create_response_dict(
                 content=content,

--- a/services/shared/ai_services/grok_service.py
+++ b/services/shared/ai_services/grok_service.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, Optional
 
 import aiohttp
 
-from .base_service import BaseAIService, derive_truncated
+from .base_service import BaseAIService, derive_refusal, derive_truncated
 from .provider_capabilities import model_supports_seed
 from .response_validator import ResponseValidator
 
@@ -280,7 +280,9 @@ class GrokService(BaseAIService):
                     "response_time_ms": response_time_ms,
                     "finish_reason": finish_reason,
                     "truncated": derive_truncated(finish_reason),
-                    "refusal": False,
+                    # Grok is OpenAI-compatible: a content-policy block surfaces
+                    # as the "content_filter" finish_reason (mapped by derive_refusal).
+                    "refusal": derive_refusal(finish_reason),
                     "error_type": None,
                     "seed": requested_seed if supports_seed_here else None,
                     "created_at": end_time.isoformat(),
@@ -467,7 +469,7 @@ Your response must be ONLY the JSON object, no other text before or after.
                 "structured_output": True,
                 "finish_reason": finish_reason,
                 "truncated": derive_truncated(finish_reason),
-                "refusal": False,
+                "refusal": derive_refusal(finish_reason),
                 "error_type": None,
                 "seed": requested_seed if supports_seed_here else None,
                 "created_at": end_time.isoformat(),

--- a/services/shared/ai_services/mistral_service.py
+++ b/services/shared/ai_services/mistral_service.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from functools import wraps
 from typing import Any, Dict, Optional
 
-from .base_service import BaseAIService, derive_truncated
+from .base_service import BaseAIService, derive_refusal, derive_truncated
 from .provider_capabilities import model_supports_seed
 from .response_validator import ResponseValidator
 
@@ -278,7 +278,10 @@ class MistralService(BaseAIService):
                     "response_time_ms": response_time_ms,
                     "finish_reason": finish_reason,
                     "truncated": derive_truncated(finish_reason),
-                    "refusal": False,
+                    # Centralized content-policy mapping; Mistral has no dedicated
+                    # refusal field, so this catches a "content_filter"-style reason
+                    # if one is surfaced (else stays False, as before).
+                    "refusal": derive_refusal(finish_reason),
                     "error_type": None,
                     "seed": requested_seed if supports_seed_here else None,
                     "created_at": end_time.isoformat(),
@@ -427,7 +430,7 @@ Your response must be ONLY the JSON object, no other text before or after.
                 "structured_output": True,
                 "finish_reason": finish_reason,
                 "truncated": derive_truncated(finish_reason),
-                "refusal": False,
+                "refusal": derive_refusal(finish_reason),
                 "error_type": None,
                 "seed": requested_seed if supports_seed_here else None,
                 "created_at": end_time.isoformat(),

--- a/services/shared/ai_services/mistral_service.py
+++ b/services/shared/ai_services/mistral_service.py
@@ -416,7 +416,6 @@ Your response must be ONLY the JSON object, no other text before or after.
             validation_result = validator.validate_response(
                 raw_content,
                 json_schema,
-                attempt_repair=True
             )
 
             finish_reason = (
@@ -453,10 +452,6 @@ Your response must be ONLY the JSON object, no other text before or after.
                 result_metadata["schema_validated"] = False
                 result_metadata["validation_errors"] = validation_result.errors
                 logger.warning(f"Mistral response not valid JSON: {validation_result.errors}")
-
-            if validation_result.repair_attempted:
-                result_metadata["repair_attempted"] = True
-                result_metadata["repair_successful"] = validation_result.repair_successful
 
             return self._create_response_dict(
                 content=content,

--- a/services/shared/ai_services/response_validator.py
+++ b/services/shared/ai_services/response_validator.py
@@ -1,9 +1,15 @@
 """
 Response Validation Layer for AI Service Outputs.
 
-Provides post-generation validation for providers without strict schema enforcement.
-Handles JSON extraction from markdown blocks, validation against schemas, and
-repair of common JSON formatting issues.
+Provides post-generation validation for providers without strict schema
+enforcement: extracts JSON from markdown/code blocks and validates it against a
+schema.
+
+There is intentionally NO repair pass. The earlier repair machinery was dead
+code (``extract_json_from_text`` only ever returns already-parseable JSON, so the
+repair branch was unreachable), and for an academic benchmark fail-closed is the
+correct posture anyway: a malformed provider response is reported as a failure
+rather than silently rewritten into data of uncertain provenance.
 """
 
 import json
@@ -25,22 +31,11 @@ class ValidationResult:
     errors: List[str]
     raw_content: str
     extracted_json: Optional[str]
-    repair_attempted: bool
-    repair_successful: bool
-
-
-@dataclass
-class RepairResult:
-    """Result of JSON repair attempt."""
-    success: bool
-    repaired_json: Optional[str]
-    original_error: str
-    repair_method: Optional[str]
 
 
 class ResponseValidator:
     """
-    Validates and repairs JSON responses from AI providers.
+    Validates JSON responses from AI providers.
 
     Used primarily for providers that don't guarantee valid JSON output
     (Google, DeepInfra, Grok, Mistral, Cohere when using prompt-based).
@@ -72,26 +67,26 @@ class ResponseValidator:
         self,
         response_content: str,
         json_schema: Dict[str, Any],
-        attempt_repair: bool = True
     ) -> ValidationResult:
         """
         Validate a response against a JSON schema.
 
+        Extracts JSON from the (possibly markdown-wrapped) response and validates
+        it against the schema. A response from which no valid JSON can be
+        extracted, or that violates the schema, is reported as ``valid=False`` —
+        there is no repair pass (fail-closed).
+
         Args:
             response_content: Raw response content from AI provider
             json_schema: JSON Schema to validate against
-            attempt_repair: Whether to attempt repair on invalid JSON
 
         Returns:
             ValidationResult with validation status and parsed data
         """
         errors: List[str] = []
-        extracted_json: Optional[str] = None
-        repair_attempted = False
-        repair_successful = False
-        parsed_data: Optional[Dict[str, Any]] = None
 
-        # Step 1: Try to extract JSON from the response
+        # Step 1: extract JSON. extract_json_from_text only returns a candidate
+        # that already json.loads-es, or None.
         extracted_json = self.extract_json_from_text(response_content)
 
         if not extracted_json:
@@ -102,41 +97,13 @@ class ResponseValidator:
                 errors=errors,
                 raw_content=response_content,
                 extracted_json=None,
-                repair_attempted=False,
-                repair_successful=False,
             )
 
-        # Step 2: Try to parse the extracted JSON
-        try:
-            parsed_data = json.loads(extracted_json)
-        except json.JSONDecodeError as e:
-            errors.append(f"JSON parse error: {str(e)}")
+        # Step 2: parse. Guaranteed to succeed (extract_json_from_text already
+        # parsed this candidate), so this cannot raise.
+        parsed_data = json.loads(extracted_json)
 
-            if attempt_repair:
-                repair_attempted = True
-                repair_result = self.attempt_repair(extracted_json, str(e))
-
-                if repair_result.success and repair_result.repaired_json:
-                    try:
-                        parsed_data = json.loads(repair_result.repaired_json)
-                        extracted_json = repair_result.repaired_json
-                        repair_successful = True
-                        errors.append(f"Repair successful via {repair_result.repair_method}")
-                    except json.JSONDecodeError as e2:
-                        errors.append(f"Repair failed: {str(e2)}")
-
-        if parsed_data is None:
-            return ValidationResult(
-                valid=False,
-                data=None,
-                errors=errors,
-                raw_content=response_content,
-                extracted_json=extracted_json,
-                repair_attempted=repair_attempted,
-                repair_successful=repair_successful,
-            )
-
-        # Step 3: Validate against schema
+        # Step 3: validate against schema
         schema_errors = self._validate_against_schema(parsed_data, json_schema)
 
         if schema_errors:
@@ -147,25 +114,22 @@ class ResponseValidator:
                 errors=errors,
                 raw_content=response_content,
                 extracted_json=extracted_json,
-                repair_attempted=repair_attempted,
-                repair_successful=repair_successful,
             )
 
         return ValidationResult(
             valid=True,
             data=parsed_data,
-            errors=errors,  # May contain repair notes
+            errors=errors,
             raw_content=response_content,
             extracted_json=extracted_json,
-            repair_attempted=repair_attempted,
-            repair_successful=repair_successful,
         )
 
     def extract_json_from_text(self, text: str) -> Optional[str]:
         """
         Extract JSON from text that may contain markdown or other content.
 
-        Tries multiple extraction patterns in order of specificity.
+        Tries multiple extraction patterns in order of specificity. Only returns
+        a candidate that already parses as JSON.
 
         Args:
             text: Raw text potentially containing JSON
@@ -197,46 +161,6 @@ class ResponseValidator:
 
         return None
 
-    def attempt_repair(self, json_string: str, error: str) -> RepairResult:
-        """
-        Attempt to repair common JSON formatting issues.
-
-        Args:
-            json_string: Malformed JSON string
-            error: Error message from initial parse attempt
-
-        Returns:
-            RepairResult with repair status and repaired JSON if successful
-        """
-        repair_methods = [
-            ("trailing_comma", self._fix_trailing_commas),
-            ("unquoted_keys", self._fix_unquoted_keys),
-            ("single_quotes", self._fix_single_quotes),
-            ("newline_in_string", self._fix_newlines_in_strings),
-            ("missing_closing", self._fix_missing_closing),
-            ("escape_sequences", self._fix_escape_sequences),
-        ]
-
-        for method_name, repair_func in repair_methods:
-            try:
-                repaired = repair_func(json_string)
-                json.loads(repaired)
-                return RepairResult(
-                    success=True,
-                    repaired_json=repaired,
-                    original_error=error,
-                    repair_method=method_name,
-                )
-            except (json.JSONDecodeError, Exception):
-                continue
-
-        return RepairResult(
-            success=False,
-            repaired_json=None,
-            original_error=error,
-            repair_method=None,
-        )
-
     def _validate_against_schema(
         self,
         data: Dict[str, Any],
@@ -264,81 +188,6 @@ class ResponseValidator:
 
         return errors
 
-    def _fix_trailing_commas(self, json_string: str) -> str:
-        """Remove trailing commas before closing brackets."""
-        # Remove trailing comma before }
-        result = re.sub(r',\s*}', '}', json_string)
-        # Remove trailing comma before ]
-        result = re.sub(r',\s*]', ']', result)
-        return result
-
-    def _fix_unquoted_keys(self, json_string: str) -> str:
-        """Add quotes around unquoted object keys."""
-        # Match unquoted keys: word characters followed by :
-        pattern = r'(?<=[{,\s])(\w+)(?=\s*:)'
-        return re.sub(pattern, r'"\1"', json_string)
-
-    def _fix_single_quotes(self, json_string: str) -> str:
-        """Replace single quotes with double quotes."""
-        # Simple replacement - may not work for all cases
-        result = json_string.replace("'", '"')
-        return result
-
-    def _fix_newlines_in_strings(self, json_string: str) -> str:
-        """Escape newlines inside string values."""
-        # This is a simplified approach - proper handling would require parsing
-        in_string = False
-        result = []
-        escape_next = False
-
-        for char in json_string:
-            if escape_next:
-                result.append(char)
-                escape_next = False
-                continue
-
-            if char == '\\':
-                escape_next = True
-                result.append(char)
-                continue
-
-            if char == '"':
-                in_string = not in_string
-                result.append(char)
-                continue
-
-            if in_string and char == '\n':
-                result.append('\\n')
-            elif in_string and char == '\r':
-                result.append('\\r')
-            elif in_string and char == '\t':
-                result.append('\\t')
-            else:
-                result.append(char)
-
-        return ''.join(result)
-
-    def _fix_missing_closing(self, json_string: str) -> str:
-        """Add missing closing brackets."""
-        open_braces = json_string.count('{')
-        close_braces = json_string.count('}')
-        open_brackets = json_string.count('[')
-        close_brackets = json_string.count(']')
-
-        result = json_string
-        result += '}' * (open_braces - close_braces)
-        result += ']' * (open_brackets - close_brackets)
-
-        return result
-
-    def _fix_escape_sequences(self, json_string: str) -> str:
-        """Fix improperly escaped sequences."""
-        # Fix common escape sequence issues
-        result = json_string
-        # Fix single backslash before quote
-        result = re.sub(r'(?<!\\)\\(?!")', r'\\\\', result)
-        return result
-
 
 def validate_structured_response(
     response_content: str,
@@ -364,11 +213,6 @@ def validate_structured_response(
     if not result.valid:
         logger.warning(
             f"Response validation failed for {provider}: {result.errors}"
-        )
-    elif result.repair_attempted:
-        logger.info(
-            f"Response from {provider} required repair "
-            f"(success: {result.repair_successful})"
         )
 
     return result.valid, result.data, result.errors

--- a/services/workers/tasks.py
+++ b/services/workers/tasks.py
@@ -301,6 +301,67 @@ def _normalize_field_key(field_name: str | None, *, is_annotation: bool) -> str 
     return f"{cfg}|{pred}|{ref}"
 
 
+def _pred_field_matches(row_field_name: str | None, config_pred_field: str) -> bool:
+    """Does a stored *bare* ``TaskEvaluation.field_name`` correspond to a
+    config's ``prediction_fields`` entry, for missing-only key reconstruction?
+
+    Immediate eval persists the BARE prediction field as ``field_name`` (e.g.
+    ``"human:loesung"`` or ``"loesung"`` — see the immediate-eval block in
+    ``run_single_sample_evaluation``), whereas the missing-only matcher keys on
+    the 3-part ``{config_id}|{pred}|{ref}`` form. 3-part rows are already handled
+    by :func:`_normalize_field_key`; this helper only bridges the bare form so a
+    row whose ``evaluation_config_id`` is known can be mapped back to the exact
+    expected key. The ``human:``/``model:`` role prefix is tolerated on either
+    side so a bare ``"loesung"`` row matches a ``"human:loesung"`` config field.
+    """
+    if not row_field_name:
+        return False
+    # 3-part rows are the _normalize_field_key path, not this one.
+    if "|" in row_field_name:
+        return False
+
+    def _strip_role(s: str) -> str:
+        if s in ("__all_human__", "__all_model__"):
+            return s
+        if s.startswith("human:") or s.startswith("model:"):
+            return s.split(":", 1)[1]
+        return s
+
+    if row_field_name == config_pred_field:
+        return True
+    return _strip_role(row_field_name) == _strip_role(config_pred_field)
+
+
+def _reconstruct_expected_keys(row, configs_by_id: dict) -> set:
+    """Expected-key strings an existing ``TaskEvaluation`` row satisfies, derived
+    from its discrete ``evaluation_config_id`` (Issue #111 / migration 057).
+
+    Immediate eval stores a bare ``field_name`` that the 3-part missing-only
+    matcher misses, but it also stores ``evaluation_config_id``; from that we
+    rebuild the exact ``{config_id}|{pred}|{ref}`` strings that
+    ``all_expected_field_keys`` is built from, so an immediate-graded unit counts
+    as "done" without changing what immediate writes. Returns an empty set when
+    the row carries no config id, or a config id not among the current run's
+    configs (a re-saved config gets a new id — those rows aren't recognized).
+
+    Wildcard prediction fields (``__all_human__``/``__all_model__``) are skipped:
+    the expected set holds the literal wildcard string while rows hold the
+    expanded field, so wildcard configs are a pre-existing missing-only
+    limitation this must not silently change.
+    """
+    keys: set = set()
+    cfg = configs_by_id.get(getattr(row, "evaluation_config_id", None))
+    if not cfg:
+        return keys
+    for pf in cfg.get("prediction_fields", []):
+        if pf in ("__all_human__", "__all_model__"):
+            continue
+        if _pred_field_matches(row.field_name, pf):
+            for rf in cfg.get("reference_fields", []):
+                keys.add(f"{cfg.get('id', 'unknown')}|{pf}|{rf}")
+    return keys
+
+
 # Add current directory to Python path for imports
 current_dir = os.path.dirname(os.path.abspath(__file__))
 if current_dir not in sys.path:
@@ -3065,6 +3126,13 @@ def run_evaluation(
                 for rf in c.get("reference_fields", [])
             }
 
+            # Index configs by id so missing-only can reconstruct expected keys
+            # for rows that carry the discrete `evaluation_config_id` (Issue #111)
+            # but a bare `field_name` — i.e. immediate-eval rows, which the 3-part
+            # `_normalize_field_key` matcher alone never recognizes. See
+            # `_reconstruct_expected_keys`.
+            configs_by_id = {c.get("id", "unknown"): c for c in enabled_configs}
+
             # Pre-load the gen-side missing-only skip set (same query as
             # legacy 2755-2794 — terminal-error rows count as "tried" to
             # avoid hopeless retries).
@@ -3076,6 +3144,7 @@ def run_evaluation(
                         TaskEvaluation.generation_id,
                         TaskEvaluation.field_name,
                         TaskEvaluation.metrics,
+                        TaskEvaluation.evaluation_config_id,
                     )
                     .join(EvaluationRun, TaskEvaluation.evaluation_id == EvaluationRun.id)
                     .filter(
@@ -3087,9 +3156,11 @@ def run_evaluation(
                 )
                 for r in existing:
                     if _row_has_score(r.metrics) or _row_is_terminal_error(r.metrics):
-                        evaluated_by_gen.setdefault(r.generation_id, set()).add(
-                            _normalize_field_key(r.field_name, is_annotation=False)
-                        )
+                        done = evaluated_by_gen.setdefault(r.generation_id, set())
+                        done.add(_normalize_field_key(r.field_name, is_annotation=False))
+                        # Also recognize bare-field_name rows (immediate eval) via
+                        # their discrete evaluation_config_id.
+                        done |= _reconstruct_expected_keys(r, configs_by_id)
                 logger.info(
                     f"Loaded existing gen evaluations: {sum(len(v) for v in evaluated_by_gen.values())} "
                     f"results across {len(evaluated_by_gen)} generations"
@@ -3174,6 +3245,7 @@ def run_evaluation(
                             TaskEvaluation.annotation_id,
                             TaskEvaluation.field_name,
                             TaskEvaluation.metrics,
+                            TaskEvaluation.evaluation_config_id,
                         )
                         .join(EvaluationRun, TaskEvaluation.evaluation_id == EvaluationRun.id)
                         .filter(
@@ -3185,9 +3257,11 @@ def run_evaluation(
                     )
                     for r in existing_ann:
                         if _row_has_score(r.metrics) or _row_is_terminal_error(r.metrics):
-                            evaluated_by_ann.setdefault(r.annotation_id, set()).add(
-                                _normalize_field_key(r.field_name, is_annotation=True)
-                            )
+                            done = evaluated_by_ann.setdefault(r.annotation_id, set())
+                            done.add(_normalize_field_key(r.field_name, is_annotation=True))
+                            # Also recognize bare-field_name rows (immediate eval)
+                            # via their discrete evaluation_config_id.
+                            done |= _reconstruct_expected_keys(r, configs_by_id)
 
                 for ann in all_annotations:
                     ann_done = evaluated_by_ann.get(ann.id, set())

--- a/services/workers/tests/integration/test_orchestration_branches_e2e.py
+++ b/services/workers/tests/integration/test_orchestration_branches_e2e.py
@@ -630,6 +630,111 @@ def test_run_evaluation_missing_only_nothing_to_dispatch_completes(
     )
 
 
+def _add_immediate_row(db_conn, *, run, task, ann, field_name, config_id):
+    """Persist an immediate-eval-style TaskEvaluation: a BARE ``field_name``
+    (what ``run_single_sample_evaluation`` writes), a discrete
+    ``evaluation_config_id`` (Issue #111), and a unified nested-dict metric
+    blob that ``_row_has_score`` counts as scored."""
+    import uuid as _uuid
+
+    jr_id = _make_default_judge_run(db_conn, run)
+    db_conn.add(TaskEvaluation(
+        id=str(_uuid.uuid4()),
+        evaluation_id=run.id,
+        judge_run_id=jr_id,
+        task_id=task.id,
+        annotation_id=ann.id,
+        generation_id=None,
+        field_name=field_name,
+        evaluation_config_id=config_id,
+        answer_type="text",
+        ground_truth="ja",
+        prediction="ja",
+        metrics={"exact_match": {"value": 1.0, "method": "exact_match",
+                                 "details": {}, "error": None}},
+        passed=True,
+    ))
+    db_conn.commit()
+
+
+def test_missing_only_recognizes_immediate_row_via_config_id(
+    db_conn, make_user, make_project, make_task, make_annotation,
+    make_evaluation_run,
+):
+    """A bare-field_name immediate-eval row must count as DONE in a subsequent
+    batch missing-only run — recognized via its discrete ``evaluation_config_id``
+    — so the orchestrator short-circuits (``cells_dispatched == 0``) and writes
+    no new rows. Reproduces the prod bug where immediate-graded annotations were
+    re-graded by a missing-only batch run."""
+    user = make_user()
+    project = make_project(created_by=user.id)
+    task = make_task(project.id, {"expected": "ja"}, created_by=user.id)
+    ann = make_annotation(
+        project.id, task.id, completed_by=user.id,
+        result=[_ann_result("answer", "ja")],
+    )
+    imm = make_evaluation_run(project.id, user.id, model_id="immediate",
+                              status="completed")
+    _add_immediate_row(db_conn, run=imm, task=task, ann=ann,
+                       field_name="human:answer", config_id="cfg1")
+
+    batch = make_evaluation_run(project.id, user.id, status="pending")
+    db_conn.commit()
+
+    config = _human_exact_match_config()  # id=cfg1, pred human:answer, ref task.expected
+    result = tasks.run_evaluation(
+        evaluation_id=batch.id, project_id=project.id,
+        evaluation_configs=[config], evaluate_missing_only=True,
+    )
+    db_conn.expire_all()
+
+    assert result["status"] == "success"
+    assert result["cells_dispatched"] == 0
+    fresh = _refresh(db_conn, batch)
+    assert fresh.status == "completed"
+    assert (fresh.eval_metadata or {}).get("note") == \
+        "no cells to dispatch (missing-only short-circuit)"
+    # No new rows written under the batch run — the immediate grade stood in.
+    assert (
+        db_conn.query(TaskEvaluation)
+        .filter(TaskEvaluation.evaluation_id == batch.id)
+        .count()
+        == 0
+    )
+
+
+def test_missing_only_does_not_overskip_other_field_immediate_row(
+    db_conn, make_user, make_project, make_task, make_annotation,
+    make_evaluation_run,
+):
+    """Over-skip guard: an immediate row graded on a DIFFERENT field
+    (``human:other``) must NOT satisfy a config expecting ``human:answer``. The
+    annotation is still dispatched (``cells_dispatched == 1``)."""
+    user = make_user()
+    project = make_project(created_by=user.id)
+    task = make_task(project.id, {"expected": "ja"}, created_by=user.id)
+    ann = make_annotation(
+        project.id, task.id, completed_by=user.id,
+        result=[_ann_result("answer", "ja")],
+    )
+    imm = make_evaluation_run(project.id, user.id, model_id="immediate",
+                              status="completed")
+    _add_immediate_row(db_conn, run=imm, task=task, ann=ann,
+                       field_name="human:other", config_id="cfg1")
+
+    batch = make_evaluation_run(project.id, user.id, status="pending")
+    db_conn.commit()
+
+    config = _human_exact_match_config()  # expects human:answer, not human:other
+    result = tasks.run_evaluation(
+        evaluation_id=batch.id, project_id=project.id,
+        evaluation_configs=[config], evaluate_missing_only=True,
+    )
+    db_conn.expire_all()
+    assert result["status"] == "dispatched"
+    assert result["cells_dispatched"] == 1
+
+
 def test_run_evaluation_evaluation_not_found(db_conn):
     """A nonexistent evaluation id returns the not-found error arm without
     raising (the very first guard in run_evaluation)."""

--- a/services/workers/tests/test_base_service_orchestration_kills.py
+++ b/services/workers/tests/test_base_service_orchestration_kills.py
@@ -1,0 +1,518 @@
+"""Mutation-killing tests for the generation-orchestration scaffolding in
+``services/shared/ai_services/base_service.py``.
+
+The pure helpers ``derive_truncated`` / ``classify_error_type`` are already
+covered by ``test_ai_service_metadata.py`` and are NOT re-tested here. This
+file targets the under-tested *orchestration* surface, where a wrong decision
+silently loses or mislabels a generation:
+
+* ``_create_response_dict``  — the standardized success envelope.
+* ``_create_error_response`` — the standardized failure envelope (must stay
+  distinguishable from an empty-but-successful generation, or a failed call
+  gets scored as a real empty answer).
+* ``get_invocation_provenance`` — the audit fields stamped onto metadata.
+* ``get_retry_history_snapshot`` — the contextvar-backed retry audit trail
+  that the per-provider ``retry_with_exponential_backoff`` decorator feeds.
+
+Import strategy mirrors ``test_ai_service_metadata.py``: ``base_service`` is
+file-imported by path so we don't trigger the ``ai_services`` package SDK
+cascade (openai / anthropic / google.genai / …). The orchestration helpers
+under test have no SDK dependency.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Defensive env so a relative/sibling import inside base_service (none today,
+# but cheap insurance against the package __init__ side effects) never blocks
+# the file-import.
+os.environ.setdefault("ENCRYPTION_KEY", "test-encryption-key-0000000000000000")
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
+os.environ.setdefault("JWT_SECRET", "test-jwt-secret")
+os.environ.setdefault("TESTING", "1")
+
+import importlib.util  # noqa: E402
+
+_workers_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_services_root = os.path.dirname(_workers_root)
+_base_service_path = os.path.join(
+    _services_root, "shared", "ai_services", "base_service.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "_orchestration_kills_base_service", _base_service_path
+)
+_base_service = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_base_service)
+
+BaseAIService = _base_service.BaseAIService
+get_retry_history_snapshot = _base_service.get_retry_history_snapshot
+_retry_history_ctx = _base_service._retry_history_ctx
+
+
+# ---------------------------------------------------------------------------
+# Minimal concrete subclass. BaseAIService is abstract (generate +
+# _initialize_client). We give it a no-op client init and an unused
+# generate(); the orchestration helpers under test live on the base class.
+# The class name is deliberately ``...Service`` so that the
+# ``.replace("Service", "")`` service-name derivation has something to strip.
+# ---------------------------------------------------------------------------
+class FakeProviderService(BaseAIService):
+    def _initialize_client(self):
+        self.client = object()
+
+    def generate(self, prompt, system_prompt="", model_name=None,
+                 max_tokens=1500, temperature=0.0, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+
+def _fresh_service():
+    return FakeProviderService(api_key="unused")
+
+
+# ===========================================================================
+# _create_response_dict — the success envelope
+# ===========================================================================
+class TestCreateResponseDict:
+    def test_exact_success_shape(self):
+        svc = _fresh_service()
+        usage = {"prompt_tokens": 11, "completion_tokens": 22, "total_tokens": 33}
+        resp = svc._create_response_dict(
+            content="hello world",
+            model="gpt-test",
+            usage=usage,
+        )
+
+        # Success flag defaults True.
+        assert resp["success"] is True
+        # Content / model / usage pass through verbatim.
+        assert resp["content"] == "hello world"
+        assert resp["model"] == "gpt-test"
+        assert resp["usage"] == {
+            "prompt_tokens": 11,
+            "completion_tokens": 22,
+            "total_tokens": 33,
+        }
+        # usage is the same object handed in (no copy/rewrite of the token map).
+        assert resp["usage"] is usage
+
+        # Metadata block: service name is the class name with "Service"
+        # stripped. "FakeProviderService" -> "FakeProvider".
+        assert resp["metadata"]["service"] == "FakeProvider"
+        assert "timestamp" in resp["metadata"]
+        assert "created_at" in resp["metadata"]
+        # Both timestamps are ISO-8601 strings (datetime.now().isoformat()).
+        assert isinstance(resp["metadata"]["timestamp"], str)
+        assert "T" in resp["metadata"]["timestamp"]
+
+        # No error key on a clean success (error defaults to None -> falsy).
+        assert "error" not in resp
+
+        # Exactly the documented top-level key set, nothing extra leaked.
+        assert set(resp.keys()) == {"content", "model", "usage", "metadata", "success"}
+
+    def test_success_false_passthrough(self):
+        # success is a real parameter, not hardcoded True.
+        svc = _fresh_service()
+        resp = svc._create_response_dict(
+            content="x", model="m", usage={}, success=False
+        )
+        assert resp["success"] is False
+
+    def test_error_key_only_present_when_truthy(self):
+        svc = _fresh_service()
+        # Empty-string error stays falsy -> no error key.
+        resp_empty = svc._create_response_dict(
+            content="x", model="m", usage={}, error=""
+        )
+        assert "error" not in resp_empty
+
+        # Non-empty error string IS surfaced verbatim.
+        resp_err = svc._create_response_dict(
+            content="x", model="m", usage={}, error="boom"
+        )
+        assert resp_err["error"] == "boom"
+
+    def test_additional_data_merged_at_top_level(self):
+        # **additional_data lands at the TOP level (not nested in metadata),
+        # via dict.update() after the base dict is built.
+        svc = _fresh_service()
+        resp = svc._create_response_dict(
+            content="c",
+            model="m",
+            usage={},
+            truncated=True,
+            refusal=False,
+            finish_reason="length",
+            seed=42,
+        )
+        assert resp["truncated"] is True
+        assert resp["refusal"] is False
+        assert resp["finish_reason"] == "length"
+        assert resp["seed"] == 42
+        # These are top-level passthroughs, not buried in metadata.
+        assert "truncated" not in resp["metadata"]
+
+    def test_additional_data_can_override_base_keys(self):
+        # update() runs LAST, so additional_data wins on key collision. Only
+        # keys that are NOT named params of _create_response_dict can be
+        # passed this way (content/model/usage/success/error are named, so
+        # passing them via **additional_data is a TypeError — see
+        # test_named_param_collision_is_a_typeerror). "metadata" is not a named
+        # param, so it routes into additional_data and overrides the whole
+        # base metadata block — pinning that .update() runs after base build.
+        svc = _fresh_service()
+        extra = {"metadata": {"replaced": True}}
+        resp = svc._create_response_dict(
+            content="original", model="m", usage={}, **extra
+        )
+        assert resp["metadata"] == {"replaced": True}
+        assert resp["content"] == "original"
+        assert resp["success"] is True
+
+    def test_named_param_collision_is_a_typeerror(self):
+        # Documenting the boundary the test above relies on: because content
+        # is an explicit named parameter, you cannot also smuggle it through
+        # **additional_data — Python raises before the body runs. This is the
+        # real contract, not a bug: named fields are set positionally, only
+        # truly-extra keys flow through additional_data.
+        import pytest
+
+        svc = _fresh_service()
+        with pytest.raises(TypeError):
+            svc._create_response_dict(
+                content="original", model="m", usage={}, **{"content": "x"}
+            )
+
+    def test_service_name_strips_only_service_suffix(self):
+        # The replace strips the literal substring "Service". For our class
+        # "FakeProviderService" that yields "FakeProvider" (one occurrence).
+        svc = _fresh_service()
+        resp = svc._create_response_dict(content="c", model="m", usage={})
+        assert resp["metadata"]["service"] == "FakeProvider"
+        assert "Service" not in resp["metadata"]["service"]
+
+
+# ===========================================================================
+# _create_error_response — the failure envelope
+# ===========================================================================
+class TestCreateErrorResponse:
+    def test_exact_error_shape(self):
+        svc = _fresh_service()
+        exc = Exception("HTTP 429: rate limit exceeded")
+        resp = svc._create_error_response(error=exc, model="gpt-test")
+
+        # Failure is flagged, not silently a success.
+        assert resp["success"] is False
+        # Content is the empty STRING, never None — downstream persistence
+        # treats a real generation's content as a string.
+        assert resp["content"] == ""
+        assert resp["content"] is not None
+        # Model echoes the attempted model.
+        assert resp["model"] == "gpt-test"
+        # The error message is surfaced verbatim at top level.
+        assert resp["error"] == "HTTP 429: rate limit exceeded"
+        # Usage is fully zeroed (no phantom tokens billed for a failed call).
+        assert resp["usage"] == {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        }
+
+    def test_error_type_classified_into_metadata(self):
+        # _create_error_response routes through classify_error_type. A 429
+        # message classifies as rate_limit; pin that it lands in metadata.
+        svc = _fresh_service()
+        resp = svc._create_error_response(
+            error=Exception("HTTP 429: rate limit"), model="m"
+        )
+        assert resp["metadata"]["error_type"] == "rate_limit"
+
+        resp_auth = svc._create_error_response(
+            error=Exception("401 Unauthorized"), model="m"
+        )
+        assert resp_auth["metadata"]["error_type"] == "auth"
+
+        resp_generic = svc._create_error_response(
+            error=Exception("internal server error"), model="m"
+        )
+        assert resp_generic["metadata"]["error_type"] == "api_error"
+
+    def test_standard_academic_metadata_fields_on_failure(self):
+        # Phase 6.6: the four standard fields are stamped on the error path
+        # with their failure-side constants. A flipped constant here would
+        # mislabel a failed generation as truncated / refused.
+        svc = _fresh_service()
+        resp = svc._create_error_response(error=ValueError("nope"), model="m")
+        md = resp["metadata"]
+        assert md["finish_reason"] is None
+        assert md["truncated"] is False
+        assert md["refusal"] is False
+        assert md["seed"] is None
+
+    def test_provenance_merged_onto_error_metadata(self):
+        # The error path also surfaces invocation provenance so a researcher
+        # can see which retry exhausted. Default (no stamping) -> Nones + 0.
+        svc = _fresh_service()
+        resp = svc._create_error_response(error=Exception("x"), model="m")
+        md = resp["metadata"]
+        assert md["retry_attempts"] == []
+        assert md["retry_count"] == 0
+        assert md["provider_route"] is None
+        assert md["provider_name"] is None
+        assert md["billed_user_id"] is None
+        assert md["billed_organization_id"] is None
+
+    def test_service_name_override_does_not_change_metadata_service(self):
+        # service_name only affects the log line / classification context, not
+        # the metadata["service"] field, which is always class-derived.
+        svc = _fresh_service()
+        resp = svc._create_error_response(
+            error=Exception("x"), model="m", service_name="CustomName"
+        )
+        assert resp["metadata"]["service"] == "FakeProvider"
+
+    def test_error_distinguishable_from_empty_success(self):
+        # The crown-jewel invariant: a FAILED generation must never look like a
+        # genuine empty-string success. Both have content == "", so the
+        # discriminator is success=False AND an error key present.
+        svc = _fresh_service()
+
+        empty_success = svc._create_response_dict(
+            content="",
+            model="m",
+            usage={"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        )
+        failure = svc._create_error_response(error=Exception("boom"), model="m")
+
+        # Same empty content...
+        assert empty_success["content"] == failure["content"] == ""
+
+        # ...but mutually exclusive success flags.
+        assert empty_success["success"] is True
+        assert failure["success"] is False
+
+        # The empty success carries no error key; the failure does.
+        assert "error" not in empty_success
+        assert "error" in failure
+
+        # And only the failure carries an error_type in metadata.
+        assert "error_type" not in empty_success["metadata"]
+        assert failure["metadata"]["error_type"] == "api_error"
+
+
+# ===========================================================================
+# get_invocation_provenance — the audit fields
+# ===========================================================================
+class TestGetInvocationProvenance:
+    def test_default_provenance_all_none(self):
+        # A direct caller (no factory stamping) gets the documented keys with
+        # None values and an empty retry trail.
+        svc = _fresh_service()
+        prov = svc.get_invocation_provenance()
+        assert prov == {
+            "retry_attempts": [],
+            "retry_count": 0,
+            "provider_route": None,
+            "provider_name": None,
+            "billed_user_id": None,
+            "billed_organization_id": None,
+        }
+
+    def test_provenance_reads_stamped_attributes(self):
+        # The factory stamps these private attrs; provenance must read them
+        # back under the documented public key names (route/name/user/org).
+        svc = _fresh_service()
+        svc._key_resolution_route = "org_key"
+        svc._provider_name = "openai"
+        svc._invocation_user_id = "user-123"
+        svc._invocation_organization_id = "org-456"
+
+        prov = svc.get_invocation_provenance()
+        assert prov["provider_route"] == "org_key"
+        assert prov["provider_name"] == "openai"
+        assert prov["billed_user_id"] == "user-123"
+        assert prov["billed_organization_id"] == "org-456"
+
+    def test_provenance_retry_count_matches_recorded_attempts(self):
+        # retry_count must equal len(retry_attempts) — pin they stay coupled.
+        svc = _fresh_service()
+        history = [
+            {"attempt": 1, "is_rate_limit": True, "retried": True},
+            {"attempt": 2, "is_rate_limit": True, "retried": True},
+            {"attempt": 3, "is_rate_limit": False, "retried": False},
+        ]
+        token = _retry_history_ctx.set(history)
+        try:
+            prov = svc.get_invocation_provenance()
+        finally:
+            _retry_history_ctx.reset(token)
+
+        assert prov["retry_count"] == 3
+        assert len(prov["retry_attempts"]) == 3
+        assert prov["retry_count"] == len(prov["retry_attempts"])
+        assert prov["retry_attempts"] == history
+
+
+# ===========================================================================
+# get_retry_history_snapshot — the contextvar-backed audit trail
+#
+# The real per-provider retry decorator (retry_with_exponential_backoff in
+# openai_service.py and its siblings) does exactly three things with the
+# contextvar this snapshot reads:
+#   token = _retry_history_ctx.set([])  # fresh list per call
+#   history.append({...})               # one record per failed attempt
+#   _retry_history_ctx.reset(token)     # restore after the call
+# We drive the SAME contextvar the same way to pin the snapshot's copy
+# semantics + boundaries, without importing the provider SDK module.
+# ===========================================================================
+class TestGetRetryHistorySnapshot:
+    def teardown_method(self):
+        # Make sure no test leaks a populated contextvar into the next one.
+        _retry_history_ctx.set(None)
+
+    def test_empty_when_no_decorator_active(self):
+        # Default contextvar value is None -> snapshot is an empty list.
+        _retry_history_ctx.set(None)
+        assert get_retry_history_snapshot() == []
+
+    def test_empty_list_value_also_yields_empty(self):
+        # A first-attempt success leaves the decorator's list empty; snapshot
+        # of an empty list is still [].
+        token = _retry_history_ctx.set([])
+        try:
+            assert get_retry_history_snapshot() == []
+        finally:
+            _retry_history_ctx.reset(token)
+
+    def test_reflects_recorded_attempts(self):
+        history = [
+            {"attempt": 1, "error": "429 rate limit", "is_rate_limit": True,
+             "latency_ms": 5, "retried": True},
+            {"attempt": 2, "error": "boom", "is_rate_limit": False,
+             "latency_ms": 7, "retried": False},
+        ]
+        token = _retry_history_ctx.set(history)
+        try:
+            snap = get_retry_history_snapshot()
+        finally:
+            _retry_history_ctx.reset(token)
+
+        assert snap == history
+        assert len(snap) == 2
+
+    def test_returns_a_copy_not_the_live_list(self):
+        # The docstring guarantees a *copy* so a persisted snapshot survives
+        # the decorator's reset(). Mutating the snapshot must NOT touch the
+        # contextvar's list, and vice versa.
+        live = [{"attempt": 1, "is_rate_limit": True}]
+        token = _retry_history_ctx.set(live)
+        try:
+            snap = get_retry_history_snapshot()
+            assert snap == live
+            # Different object identity.
+            assert snap is not live
+            # Mutating the snapshot doesn't grow the live list.
+            snap.append({"attempt": 99})
+            assert len(_retry_history_ctx.get()) == 1
+            # Mutating the live list after the snapshot doesn't grow the snap.
+            live.append({"attempt": 2})
+            assert len(snap) == 2  # 1 original + 1 we appended above
+        finally:
+            _retry_history_ctx.reset(token)
+
+
+# ===========================================================================
+# Retry decorator semantics — driven through the SAME contextvar the real
+# decorator uses, asserting the audit-trail contract end to end.
+#
+# We intentionally do NOT import retry_with_exponential_backoff from
+# openai_service (that pulls the OpenAI SDK + the whole provider cascade the
+# file-import is designed to avoid). Instead we model a call that fails N
+# times then succeeds, recording attempts exactly as the source decorator
+# does, and pin what base_service guarantees about that trail: the snapshot
+# and provenance read it back faithfully, retry_count is the number of failed
+# attempts (NOT off-by-one), and the give-up record is distinguishable from a
+# retried one. The off-by-one boundary (retries >= max_retries) is reasoned
+# below.
+# ===========================================================================
+class TestRetryTrailContract:
+    def teardown_method(self):
+        _retry_history_ctx.set(None)
+
+    def _simulate_attempts(self, errors, max_retries):
+        """Replay the source decorator's history-recording loop faithfully.
+
+        Mirrors openai_service.retry_with_exponential_backoff's inner loop:
+        a transient (rate-limit) error is retried while ``retries <
+        max_retries``; the give-up record has ``retried=False``. Returns the
+        recorded history list (the same shape the live decorator pushes into
+        the contextvar).
+        """
+        history = []
+        retries = 0
+        for err in errors:
+            error_str = str(err).lower()
+            is_rate_limit = "429" in error_str or "rate limit" in error_str
+            history.append({
+                "attempt": retries + 1,
+                "error": str(err)[:200],
+                "is_rate_limit": is_rate_limit,
+                "retried": is_rate_limit and retries < max_retries,
+            })
+            if not is_rate_limit or retries >= max_retries:
+                break
+            retries += 1
+        return history
+
+    def test_transient_then_success_records_only_failures(self):
+        # 2 rate-limit failures then a success: the success itself records
+        # nothing, so the trail has exactly 2 entries, both retried.
+        svc = _fresh_service()
+        history = self._simulate_attempts(
+            ["429 rate limit", "429 rate limit"], max_retries=5
+        )
+        token = _retry_history_ctx.set(history)
+        try:
+            prov = svc.get_invocation_provenance()
+            snap = get_retry_history_snapshot()
+        finally:
+            _retry_history_ctx.reset(token)
+
+        assert prov["retry_count"] == 2
+        assert len(snap) == 2
+        assert all(rec["retried"] is True for rec in snap)
+        assert [rec["attempt"] for rec in snap] == [1, 2]
+
+    def test_non_transient_error_is_not_retried(self):
+        # A non-rate-limit error gives up on the first attempt: exactly one
+        # record, retried=False. (A mutation flipping the is_rate_limit gate
+        # would wrongly mark it retried.)
+        history = self._simulate_attempts(["boom: internal error"], max_retries=5)
+        assert len(history) == 1
+        assert history[0]["is_rate_limit"] is False
+        assert history[0]["retried"] is False
+
+    def test_exhaustion_boundary_is_max_retries_plus_one_attempts(self):
+        # With max_retries=2 and unbroken rate-limits, the loop makes attempts
+        # at retries=0,1,2 and gives up at retries==max_retries. That's
+        # max_retries+1 == 3 recorded attempts; the LAST one is the give-up
+        # (retried=False) because retries >= max_retries. This pins the
+        # off-by-one boundary of the ``retries >= max_retries`` condition.
+        errors = ["429 rate limit"] * 10  # more than enough to exhaust
+        history = self._simulate_attempts(errors, max_retries=2)
+
+        assert len(history) == 3  # attempts at retries 0, 1, 2
+        # First two were retried; the third exhausted.
+        assert [rec["retried"] for rec in history] == [True, True, False]
+        # The give-up record is still a rate-limit, just not retried.
+        assert history[-1]["is_rate_limit"] is True
+        assert history[-1]["attempt"] == 3
+
+    def test_max_retries_zero_gives_up_immediately(self):
+        # max_retries=0: even a rate-limit gives up on the very first attempt
+        # (retries(0) >= max_retries(0)). One record, retried=False.
+        history = self._simulate_attempts(["429 rate limit"] * 5, max_retries=0)
+        assert len(history) == 1
+        assert history[0]["is_rate_limit"] is True
+        assert history[0]["retried"] is False

--- a/services/workers/tests/test_missing_only_dict_shape.py
+++ b/services/workers/tests/test_missing_only_dict_shape.py
@@ -377,3 +377,86 @@ def test_task_evaluation_constructors_pass_evaluation_config_id():
         f"{constructor_count} TaskEvaluation(...) constructors but only "
         f"{kwarg_count} occurrences of 'evaluation_config_id=' in tasks.py."
     )
+
+
+# Inline mirror of `tasks.py:_pred_field_matches`. Same drift pattern.
+
+def _pred_field_matches(row_field_name, config_pred_field):
+    """Mirror of `tasks.py:_pred_field_matches`. Keep in sync."""
+    _wildcards = ("__all_human__", "__all_model__")
+    if not row_field_name:
+        return False
+    if "|" in row_field_name:
+        return False
+
+    def _strip_role(s):
+        if s in _wildcards:
+            return s
+        if s.startswith("human:") or s.startswith("model:"):
+            return s.split(":", 1)[1]
+        return s
+
+    if row_field_name == config_pred_field:
+        return True
+    return _strip_role(row_field_name) == _strip_role(config_pred_field)
+
+
+def test_inline_pred_field_matches_present_in_tasks_py():
+    """Drift guard for the immediate-eval recognition path (config-id based).
+
+    The bug this covers: immediate eval persists a BARE field_name
+    (e.g. ``human:loesung``) plus a discrete ``evaluation_config_id``, but the
+    missing-only matcher keyed only on the 3-part ``{cfg}|{pred}|{ref}`` form,
+    so it never recognized immediate grades → it re-graded every
+    immediate-graded annotation on the next missing-only run. The fix
+    reconstructs the expected key from ``evaluation_config_id`` via
+    ``_pred_field_matches`` + ``_reconstruct_expected_keys``.
+    """
+    tasks_path = Path(__file__).parent.parent / "tasks.py"
+    src = tasks_path.read_text()
+    assert "def _pred_field_matches(" in src, (
+        "tasks.py is missing the `_pred_field_matches` helper that maps a bare "
+        "immediate-eval field_name to a config prediction field."
+    )
+    assert "def _reconstruct_expected_keys(" in src, (
+        "tasks.py is missing `_reconstruct_expected_keys` — the config-id-based "
+        "recognition of bare immediate-eval rows in missing-only mode."
+    )
+    # Definition + BOTH skip-set loops (generation + annotation) must use it.
+    assert src.count("_reconstruct_expected_keys(") >= 3, (
+        "Expected `_reconstruct_expected_keys` definition + calls at BOTH the "
+        "generation and annotation missing-only skip-set inserts in tasks.py."
+    )
+
+
+class TestPredFieldMatches:
+    """A bare immediate-eval ``field_name`` (the config's prediction field) vs.
+    a config ``prediction_fields`` entry — tolerating the human:/model: role
+    prefix so a backfilled/legacy row maps to the right config."""
+
+    def test_exact_bare_match(self):
+        assert _pred_field_matches("human:loesung", "human:loesung") is True
+
+    def test_bare_without_prefix_matches_human_field(self):
+        # Korrektur-style bare 'loesung' row vs a 'human:loesung' config field.
+        assert _pred_field_matches("loesung", "human:loesung") is True
+
+    def test_model_prefix_tolerated(self):
+        assert _pred_field_matches("loesung", "model:loesung") is True
+
+    def test_different_field_does_not_match(self):
+        assert _pred_field_matches("human:other", "human:loesung") is False
+
+    def test_three_part_row_excluded(self):
+        # 3-part rows are the _normalize_field_key path, not this helper.
+        assert (
+            _pred_field_matches("cfg|human:loesung|musterlösung", "human:loesung")
+            is False
+        )
+
+    def test_wildcard_never_matches(self):
+        assert _pred_field_matches("human:loesung", "__all_human__") is False
+
+    def test_empty(self):
+        assert _pred_field_matches(None, "human:loesung") is False
+        assert _pred_field_matches("", "human:loesung") is False

--- a/services/workers/tests/test_provider_refusal_detection_kills.py
+++ b/services/workers/tests/test_provider_refusal_detection_kills.py
@@ -1,0 +1,435 @@
+"""Mutation-grade pins for the REFUSAL-detection fix in the provider clients.
+
+WHY THIS FILE EXISTS
+--------------------
+A content-policy refusal that gets silently scored as a real model answer
+biases an academic LLM benchmark: the leaderboard credits the model with an
+answer it actually declined to give. Until this fix the OpenAI-compatible
+providers (Grok, DeepInfra) and Cohere hardcoded ``"refusal": False`` on the
+success path, so a content-filter block was indistinguishable from a normal
+answer.
+
+THE FIX (in ``services/shared/ai_services/base_service.py``):
+
+  * ``REFUSAL_FINISH_REASONS = frozenset({"content_filter", "ERROR_TOXIC"})``
+  * ``derive_refusal(finish_reason) -> bool`` — True iff the finish_reason is
+    in that set; False for None / "" / any other reason.
+
+  ``grok_service.generate()``, ``deepinfra_service._generate_async()`` and
+  ``cohere_service.generate()`` now call ``derive_refusal(finish_reason)`` in
+  their main parse path (was a hardcoded ``False``). ``mistral_service`` does
+  too — its normal finish reasons ("stop"/"length") aren't in the set, so it
+  stays False unless a content_filter-style reason appears, which proves the
+  centralized mapping is wired in rather than re-hardcoded.
+
+WHAT THIS FILE PINS
+-------------------
+1. ``derive_refusal`` truth table + the EXACT frozenset membership (so a
+   reverted set, an extra member, or an inverted return is caught).
+2. End-to-end, per-provider: a refusal finish_reason makes the returned
+   ``metadata.refusal`` True, and a normal finish_reason keeps it False
+   (regression guard). These kill a reverted/inverted ``derive_refusal``
+   call and a wrong/typo'd ``finish_reason`` field name in any provider.
+
+The E2E-construction + client-mock approach mirrors the sibling parsing files
+``test_provider_parsing_cohere_mistral_grok_kills.py`` and
+``test_provider_parsing_google_deepinfra_kills.py``: env vars set before
+import, service built with a dummy key, client replaced with a duck-typed
+fake, ``E2E_TEST_MODE`` popped so the REAL parse path runs (not the canned
+E2E mock dict).
+"""
+
+from __future__ import annotations
+
+import os
+
+# Encryption / auth env must be set BEFORE importing the service modules:
+# importing the ai_services package transitively pulls /shared modules whose
+# module-level singletons read these. conftest already sets BENGER_TEST_MODE;
+# we add the rest defensively so this file is import-safe in isolation too.
+os.environ.setdefault("TESTING", "true")
+os.environ.setdefault("BENGER_TEST_MODE", "1")
+os.environ.setdefault("ENCRYPTION_KEY", "test-encryption-key-0000000000000000")
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
+os.environ.setdefault("JWT_SECRET", "test-jwt-secret")
+os.environ.setdefault("JWT_SECRET_KEY", "test-jwt-secret")
+# Make absolutely sure the E2E short-circuit branch is NOT taken — we want the
+# REAL parsing path (which calls derive_refusal), not the canned E2E mock dict.
+os.environ.pop("E2E_TEST_MODE", None)
+
+import importlib.util  # noqa: E402
+import types  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# 1) derive_refusal unit tests
+#
+# Direct file-import of the helper under test (mirrors
+# test_ai_service_metadata.py). Going through the ``ai_services`` package would
+# eagerly import every provider's SDK; the base-service helpers have no SDK
+# dependencies.
+# --------------------------------------------------------------------------
+_workers_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_services_root = os.path.dirname(_workers_root)
+_base_service_path = os.path.join(
+    _services_root, "shared", "ai_services", "base_service.py"
+)
+_spec = importlib.util.spec_from_file_location("base_service", _base_service_path)
+_base_service = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_base_service)
+
+derive_refusal = _base_service.derive_refusal
+REFUSAL_FINISH_REASONS = _base_service.REFUSAL_FINISH_REASONS
+
+
+class TestDeriveRefusal:
+    """Truth table for derive_refusal. A refusal is a content-policy/safety
+    decline — distinct from a normal stop or a length truncation."""
+
+    def test_content_filter_is_refusal(self):
+        """OpenAI-compatible (Grok/DeepInfra) content-policy block."""
+        assert derive_refusal("content_filter") is True
+
+    def test_error_toxic_is_refusal(self):
+        """Cohere content-policy block."""
+        assert derive_refusal("ERROR_TOXIC") is True
+
+    def test_normal_stop_reasons_are_not_refusals(self):
+        """The everyday terminators across providers must never be a refusal:
+        a single inverted/over-broad rule would mislabel every normal answer."""
+        assert derive_refusal("stop") is False        # OpenAI / Grok / DeepInfra / Mistral
+        assert derive_refusal("length") is False       # OpenAI / Cohere / Mistral truncation
+        assert derive_refusal("MAX_TOKENS") is False    # Google truncation
+        assert derive_refusal("COMPLETE") is False      # Cohere normal terminator
+
+    def test_none_and_empty_are_not_refusals(self):
+        """Missing / empty finish_reason → not a refusal (the ``if not
+        finish_reason`` guard). Catches a mutation that drops the guard."""
+        assert derive_refusal(None) is False
+        assert derive_refusal("") is False
+
+    def test_frozenset_membership_is_exactly_the_two_documented_reasons(self):
+        """Pin the EXACT set. A widened set (mislabels normal answers) or a
+        narrowed set (misses real refusals) both fail here. Equality, not
+        subset, so a reverted/extra member is caught either way."""
+        assert REFUSAL_FINISH_REASONS == frozenset({"content_filter", "ERROR_TOXIC"})
+        assert isinstance(REFUSAL_FINISH_REASONS, frozenset)
+
+
+# --------------------------------------------------------------------------
+# 2) Per-provider end-to-end refusal detection.
+#
+# Construction + client-mock pattern reused verbatim from the sibling parsing
+# files. Each service is built with a dummy api-key, its client replaced with
+# a duck-typed fake that returns exactly the attributes the parser reads, and
+# generate() is driven so the REAL parse path computes metadata.refusal.
+# --------------------------------------------------------------------------
+from ai_services.cohere_service import CohereService  # noqa: E402
+from ai_services.grok_service import GrokService  # noqa: E402
+from ai_services.mistral_service import MistralService  # noqa: E402
+from ai_services import deepinfra_service as di_mod  # noqa: E402
+
+DeepInfraService = di_mod.DeepInfraService
+
+
+# ===== GROK fakes (OpenAI-compatible HTTP JSON over aiohttp) ===============
+def _grok_json(content, *, finish_reason, prompt_tokens=1,
+               completion_tokens=1, total_tokens=2):
+    """Build the OpenAI-compatible JSON dict the Grok async path decodes."""
+    choice = {"message": {"content": content}}
+    if finish_reason is not None:
+        choice["finish_reason"] = finish_reason
+    return {
+        "choices": [choice],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+        },
+    }
+
+
+class _FakeAiohttpResponse:
+    """Minimal async-context-manager response standing in for aiohttp's."""
+
+    def __init__(self, json_payload):
+        self._json = json_payload
+
+    def raise_for_status(self):
+        return None
+
+    async def json(self):
+        return self._json
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeAiohttpSession:
+    """Stand-in for aiohttp.ClientSession; .post returns our fake response."""
+
+    def __init__(self, json_payload):
+        self._json = json_payload
+
+    def post(self, *args, **kwargs):
+        return _FakeAiohttpResponse(self._json)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _make_grok():
+    svc = GrokService(api_key="dummy-key")
+    assert svc.is_available()
+    return svc
+
+
+def _run_grok_generate(svc, grok_json, **gen_kwargs):
+    with patch(
+        "ai_services.grok_service.aiohttp.ClientSession",
+        return_value=_FakeAiohttpSession(grok_json),
+    ):
+        return svc.generate(prompt="p", system_prompt="s", **gen_kwargs)
+
+
+# ===== DEEPINFRA fakes (OpenAI-compatible HTTP JSON over aiohttp) ==========
+class _FakeAioResponse:
+    """Duck-types the bits of aiohttp's response _generate_async reads:
+    ``.status``, ``await .text()``, ``await .json()``."""
+
+    def __init__(self, *, status=200, json_body=None, text_body=""):
+        self.status = status
+        self._json = json_body or {}
+        self._text = text_body
+
+    async def text(self):
+        return self._text
+
+    async def json(self):
+        return self._json
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeAioSession:
+    """Replaces ``aiohttp.ClientSession`` in the deepinfra module."""
+
+    response_factory = None  # set per-test: () -> _FakeAioResponse
+
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def post(self, url, headers=None, json=None, timeout=None):
+        return type(self).response_factory()
+
+
+def _make_deepinfra_service():
+    """api_key makes ``self.client is True`` so is_available() is True and
+    the real parser runs."""
+    return DeepInfraService(api_key="test-deepinfra-key")
+
+
+def _deepinfra_json(content, *, finish_reason, prompt_tokens=5,
+                    completion_tokens=5, total_tokens=10):
+    choice = {"message": {"content": content}, "finish_reason": finish_reason}
+    return {
+        "choices": [choice],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+        },
+    }
+
+
+@pytest.fixture
+def patch_aiohttp(monkeypatch):
+    """Patch aiohttp.ClientSession inside deepinfra_service with the fake;
+    yields a setter that installs the per-test response factory."""
+
+    def _install(response_factory):
+        _FakeAioSession.response_factory = staticmethod(response_factory)
+        monkeypatch.setattr(di_mod.aiohttp, "ClientSession", _FakeAioSession)
+        return _FakeAioSession
+
+    return _install
+
+
+# ===== COHERE fakes (v2 chat objects) =====================================
+def _cohere_response(blocks, *, finish_reason, input_tokens=1, output_tokens=1):
+    content_blocks = [types.SimpleNamespace(text=t) for t in blocks]
+    resp = types.SimpleNamespace()
+    resp.message = types.SimpleNamespace(content=content_blocks)
+    resp.finish_reason = finish_reason
+    tokens = types.SimpleNamespace(
+        input_tokens=input_tokens, output_tokens=output_tokens
+    )
+    resp.usage = types.SimpleNamespace(tokens=tokens)
+    return resp
+
+
+def _make_cohere(client_chat_return):
+    svc = CohereService(api_key="dummy-key")
+    svc.client = MagicMock()
+    svc.client.chat = MagicMock(return_value=client_chat_return)
+    return svc
+
+
+# ===== MISTRAL fakes (chat.complete objects) ==============================
+def _mistral_response(content, *, finish_reason, prompt_tokens=1,
+                      completion_tokens=1, total_tokens=2):
+    message = types.SimpleNamespace(content=content)
+    choice = types.SimpleNamespace(message=message, finish_reason=finish_reason)
+    resp = types.SimpleNamespace()
+    resp.choices = [choice]
+    resp.usage = types.SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+    )
+    return resp
+
+
+def _make_mistral(complete_return):
+    svc = MistralService(api_key="dummy-key")
+    svc.client = MagicMock()
+    svc.client.chat = MagicMock()
+    svc.client.chat.complete = MagicMock(return_value=complete_return)
+    return svc
+
+
+# ==========================================================================
+# GROK — refusal threaded from finish_reason
+# ==========================================================================
+class TestGrokRefusalDetection:
+    """Grok (OpenAI-compatible): a 'content_filter' finish_reason must set
+    metadata.refusal True; a normal 'stop' must keep it False."""
+
+    def test_content_filter_finish_reason_flags_refusal(self):
+        """LOAD-BEARING: the fix. content_filter → refusal True via
+        derive_refusal. Kills the old hardcoded False and an inverted call."""
+        payload = _grok_json("", finish_reason="content_filter")
+        svc = _make_grok()
+        out = _run_grok_generate(svc, payload, model_name="grok-3")
+        assert out["metadata"]["finish_reason"] == "content_filter"
+        assert out["metadata"]["refusal"] is True
+
+    def test_normal_stop_keeps_refusal_false(self):
+        """REGRESSION guard: a normal answer must NOT be mislabelled a
+        refusal (the complement of the content_filter case)."""
+        payload = _grok_json("Die Berufung hat Erfolg.", finish_reason="stop")
+        svc = _make_grok()
+        out = _run_grok_generate(svc, payload, model_name="grok-3")
+        assert out["metadata"]["finish_reason"] == "stop"
+        assert out["metadata"]["refusal"] is False
+
+
+# ==========================================================================
+# DEEPINFRA — refusal threaded from finish_reason
+# ==========================================================================
+class TestDeepInfraRefusalDetection:
+    def test_content_filter_finish_reason_flags_refusal(self, patch_aiohttp):
+        """LOAD-BEARING: content_filter → refusal True on the DeepInfra
+        success path (was hardcoded False)."""
+        patch_aiohttp(
+            lambda: _FakeAioResponse(
+                json_body=_deepinfra_json("", finish_reason="content_filter")
+            )
+        )
+        svc = _make_deepinfra_service()
+        out = svc.generate(prompt="p", model_name="DeepSeek-V3.1")
+        assert out["metadata"]["finish_reason"] == "content_filter"
+        assert out["metadata"]["refusal"] is True
+
+    def test_normal_stop_keeps_refusal_false(self, patch_aiohttp):
+        """REGRESSION guard: stop → refusal False."""
+        patch_aiohttp(
+            lambda: _FakeAioResponse(
+                json_body=_deepinfra_json("Die Antwort lautet 42.", finish_reason="stop")
+            )
+        )
+        svc = _make_deepinfra_service()
+        out = svc.generate(prompt="p", model_name="DeepSeek-V3.1")
+        assert out["metadata"]["finish_reason"] == "stop"
+        assert out["metadata"]["refusal"] is False
+
+
+# ==========================================================================
+# COHERE — refusal threaded from finish_reason
+# ==========================================================================
+class TestCohereRefusalDetection:
+    """Cohere signals a content-policy block via finish_reason 'ERROR_TOXIC'
+    (its own vocabulary). The fix maps it through derive_refusal."""
+
+    def test_error_toxic_flags_refusal_but_not_truncated(self):
+        """LOAD-BEARING: ERROR_TOXIC → refusal True. AND it must NOT be
+        flagged truncated: Cohere's truncated line ORs ``finish_reason ==
+        'MAX_TOKENS'``, and ERROR_TOXIC is neither in the truncated set nor
+        == 'MAX_TOKENS', so truncated stays False. This pins that the two
+        flags don't bleed into each other."""
+        resp = _cohere_response(
+            [""], finish_reason="ERROR_TOXIC", input_tokens=10, output_tokens=0
+        )
+        svc = _make_cohere(resp)
+        out = svc.generate(prompt="p", model_name="command-r-plus-08-2024")
+        assert out["metadata"]["finish_reason"] == "ERROR_TOXIC"
+        assert out["metadata"]["refusal"] is True
+        assert out["metadata"]["truncated"] is False
+
+    def test_normal_complete_keeps_refusal_false(self):
+        """REGRESSION guard: COMPLETE (Cohere's normal terminator) →
+        refusal False."""
+        resp = _cohere_response(
+            ["Die Klage ist begründet."], finish_reason="COMPLETE",
+            input_tokens=10, output_tokens=20,
+        )
+        svc = _make_cohere(resp)
+        out = svc.generate(prompt="p", model_name="command-r-plus-08-2024")
+        assert out["metadata"]["finish_reason"] == "COMPLETE"
+        assert out["metadata"]["refusal"] is False
+
+
+# ==========================================================================
+# MISTRAL — centralized mapping applies (defensive)
+# ==========================================================================
+class TestMistralRefusalDetection:
+    """Mistral's normal reasons ('stop'/'length') are not refusals, so it
+    stays False — BUT if a content_filter-style reason appears, the same
+    centralized derive_refusal mapping must flag it. This proves the wiring,
+    not a re-hardcoded False."""
+
+    def test_content_filter_finish_reason_flags_refusal(self):
+        """A content_filter reason → refusal True, proving derive_refusal is
+        actually called on Mistral's path (not hardcoded)."""
+        resp = _mistral_response("", finish_reason="content_filter")
+        svc = _make_mistral(resp)
+        out = svc.generate(prompt="p", model_name="mistral-large-latest")
+        assert out["metadata"]["finish_reason"] == "content_filter"
+        assert out["metadata"]["refusal"] is True
+
+    def test_normal_stop_keeps_refusal_false(self):
+        """REGRESSION guard: stop → refusal False."""
+        resp = _mistral_response("Der Anspruch besteht.", finish_reason="stop")
+        svc = _make_mistral(resp)
+        out = svc.generate(prompt="p", model_name="mistral-large-latest")
+        assert out["metadata"]["finish_reason"] == "stop"
+        assert out["metadata"]["refusal"] is False

--- a/services/workers/tests/test_response_validator_kills.py
+++ b/services/workers/tests/test_response_validator_kills.py
@@ -1,25 +1,27 @@
-"""Mutation-grade kills for the JSON-repair + validation layer in
+"""Mutation-grade kills for the validation layer in
 ``services/shared/ai_services/response_validator.py``.
 
-This module repairs malformed LLM JSON *before* a benchmark score is parsed
-out of it. A repair that corrupts VALID JSON, or mis-fixes malformed JSON,
-silently produces wrong parsed data -> a wrong benchmark score. The whole
-file had no dedicated test; this file pins every repair helper, the
-extractor, the orchestrator, and the two public entry points.
+This module extracts JSON out of a (possibly markdown-wrapped) LLM response
+and validates it against a schema *before* a benchmark score is parsed out of
+it. ``validate_response`` is **fail-closed**: it extracts JSON, parses it, and
+schema-validates it; a malformed, missing, or schema-violating response is
+reported as ``valid=False`` rather than rewritten. There is **no repair pass**.
 
-The most load-bearing assertions are the ANTI-CORRUPTION ones: each naive
-``_fix_*`` helper, applied to already-valid JSON, must (where it is honest
-about its own limitations) leave the parsed meaning unchanged. Several of
-the helpers are deliberately naive regex/string rewrites; where they DO
-over-match valid JSON we pin the *actual* observed behaviour and document
-in the docstring that (a) it is a known limitation of the isolated helper
-and (b) why it is end-to-end-safe (see ``TestEndToEndNeverCorruptsValidJson``):
-the helpers are private and only ever invoked via ``attempt_repair``, which
-is only ever invoked on a string that already FAILED ``json.loads``. Valid
-JSON is therefore never fed to a ``_fix_*`` helper in production.
+Historical note (kept for context): an earlier version carried JSON-"repair"
+machinery -- an orchestrator plus a set of naive regex/string fix helpers.
+That code was **dead** -- ``extract_json_from_text`` only ever returns a
+candidate that already ``json.loads``-es, so the repair branch was
+unreachable -- and was removed. For an academic benchmark fail-closed is also
+the correct posture: a malformed provider response is surfaced as a failure,
+not silently corrected into data of uncertain provenance. The fail-closed
+behaviour for a string that *would* have been "repairable" (e.g.
+``{"score":5,}``) is pinned in ``TestValidateResponse`` and
+``TestFailClosedOnceRepairableInput``: extraction returns None, so
+``validate_response`` exits at the extraction step with ``valid=False`` /
+``data=None``.
 
-Import note: the helpers under test live in the ``ai_services`` package
-whose ``__init__`` eagerly imports every provider SDK (openai, anthropic,
+Import note: the module under test lives in the ``ai_services`` package whose
+``__init__`` eagerly imports every provider SDK (openai, anthropic,
 google.genai, ...). We file-import ``response_validator.py`` directly via
 ``importlib.util.spec_from_file_location`` to avoid that cascade -- mirrors
 ``tests/test_ai_service_metadata.py``. The module itself only depends on
@@ -46,7 +48,6 @@ _spec.loader.exec_module(_rv)
 
 ResponseValidator = _rv.ResponseValidator
 ValidationResult = _rv.ValidationResult
-RepairResult = _rv.RepairResult
 validate_structured_response = _rv.validate_structured_response
 
 
@@ -55,339 +56,7 @@ def _v(strict: bool = True) -> "ResponseValidator":
 
 
 # ===========================================================================
-# _fix_trailing_commas  (line 267)
-#   re.sub(r',\s*}', '}', s) then re.sub(r',\s*]', ']', s)
-# ===========================================================================
-class TestFixTrailingCommas:
-    def test_removes_trailing_comma_before_brace(self):
-        """MUST-fix: object trailing comma. ``{"a":1,}`` is invalid JSON;
-        the helper strips the ``,`` before ``}`` so the result parses."""
-        out = _v()._fix_trailing_commas('{"a":1,}')
-        assert out == '{"a":1}'
-        assert json.loads(out) == {"a": 1}
-
-    def test_removes_trailing_comma_before_bracket(self):
-        """MUST-fix: array trailing comma ``[1,2,]`` -> ``[1,2]``."""
-        out = _v()._fix_trailing_commas("[1,2,]")
-        assert out == "[1,2]"
-        assert json.loads(out) == [1, 2]
-
-    def test_removes_trailing_comma_with_whitespace(self):
-        r"""``\s*`` in the pattern means whitespace/newlines between the
-        comma and the closer are also consumed (pretty-printed trailing
-        comma)."""
-        out = _v()._fix_trailing_commas('{"a":1 ,\n  }')
-        assert json.loads(out) == {"a": 1}
-
-    def test_does_not_remove_legitimate_separator_comma(self):
-        """ANTI-CORRUPTION: a comma that separates two members is NOT
-        followed by a closer, so the pattern ``,\\s*}`` cannot match it.
-        Valid two-key object must be byte-identical out."""
-        src = '{"a":1, "b":2}'
-        out = _v()._fix_trailing_commas(src)
-        assert out == src
-        assert json.loads(out) == {"a": 1, "b": 2}
-
-    def test_does_not_touch_plain_comma_inside_string_value(self):
-        """ANTI-CORRUPTION: a comma inside a string value (``"hello,
-        world"``) is not followed by a closer, so it is untouched -- the
-        common, safe case."""
-        src = '{"a":"hello, world"}'
-        out = _v()._fix_trailing_commas(src)
-        assert out == src
-        assert json.loads(out) == {"a": "hello, world"}
-
-    def test_comma_then_brace_inside_string_is_a_known_helper_limitation(self):
-        r"""TRICKY / known naive-regex limitation. The VALID input
-        ``{"a":"x,}"}`` has the literal substring ``,}`` *inside* the
-        string value ``"x,}"``. The regex ``,\s*}`` is string-blind, so it
-        rewrites that to ``}``, producing ``{"a":"x}"}`` whose value is now
-        ``"x}"`` -- a corruption of valid JSON IN ISOLATION.
-
-        We pin the actual behaviour (not the ideal one) so a mutation that
-        flips the regex is still caught, and document that this is harmless
-        end-to-end: ``_fix_trailing_commas`` is only reached from
-        ``attempt_repair``, which is only called after ``json.loads`` has
-        already failed -- valid JSON never enters here. See
-        ``TestEndToEndNeverCorruptsValidJson``.
-        """
-        src = '{"a":"x,}"}'
-        assert json.loads(src) == {"a": "x,}"}  # source is valid
-        out = _v()._fix_trailing_commas(src)
-        assert out == '{"a":"x}"}'  # naive over-match
-        assert json.loads(out) == {"a": "x}"}  # meaning changed in isolation
-
-
-# ===========================================================================
-# _fix_unquoted_keys  (line 275)
-#   re.sub(r'(?<=[{,\s])(\w+)(?=\s*:)', r'"\1"', s)
-# ===========================================================================
-class TestFixUnquotedKeys:
-    def test_quotes_a_bare_key(self):
-        """MUST-fix: ``{a:1}`` -> ``{"a":1}``. The key ``a`` is preceded by
-        ``{`` (lookbehind) and followed by ``:`` (lookahead)."""
-        out = _v()._fix_unquoted_keys("{a:1}")
-        assert out == '{"a":1}'
-        assert json.loads(out) == {"a": 1}
-
-    def test_quotes_multiple_bare_keys(self):
-        """Second key ``b`` is preceded by the space after the comma, which
-        the ``\\s`` arm of the lookbehind matches."""
-        out = _v()._fix_unquoted_keys("{a:1, b:2}")
-        assert out == '{"a":1, "b":2}'
-        assert json.loads(out) == {"a": 1, "b": 2}
-
-    def test_does_not_double_quote_an_already_quoted_key(self):
-        """ANTI-CORRUPTION: an already-quoted key ``"a"`` -- the inner word
-        ``a`` is preceded by ``"`` (not in ``[{,\\s]``), so the lookbehind
-        fails and nothing is added. Valid input stays byte-identical."""
-        src = '{"a":1}'
-        out = _v()._fix_unquoted_keys(src)
-        assert out == src
-        assert json.loads(out) == {"a": 1}
-
-    def test_does_not_quote_colon_inside_url_string_value(self):
-        """ANTI-CORRUPTION (the named danger): a ``://`` inside a string
-        value. ``url`` is preceded by ``"`` so it is not a key; the ``http``
-        before ``://`` is preceded by ``"`` too -> no match. Untouched."""
-        src = '{"url":"http://example.com"}'
-        out = _v()._fix_unquoted_keys(src)
-        assert out == src
-        assert json.loads(out) == {"url": "http://example.com"}
-
-    def test_does_not_quote_word_colon_inside_string_value(self):
-        """ANTI-CORRUPTION: ``{"a":"key:val"}`` -- ``key`` is preceded by
-        ``"``, so the lookbehind fails and the string value is untouched."""
-        src = '{"a":"key:val"}'
-        out = _v()._fix_unquoted_keys(src)
-        assert out == src
-        assert json.loads(out) == {"a": "key:val"}
-
-    def test_space_word_colon_inside_string_is_a_known_helper_limitation(self):
-        r"""TRICKY / known naive-regex limitation. In the VALID input
-        ``{"a":"x y:z"}`` the substring ``y:`` sits inside the string value,
-        preceded by a space. The ``\s`` arm of the lookbehind matches that
-        space and the lookahead matches ``:``, so ``y`` gets wrapped:
-        ``{"a":"x "y":z"}`` -- now INVALID JSON.
-
-        Pinned as actual behaviour + documented as a helper-in-isolation
-        limitation that is end-to-end-safe (valid JSON never reaches here)."""
-        src = '{"a":"x y:z"}'
-        assert json.loads(src) == {"a": "x y:z"}  # source valid
-        out = _v()._fix_unquoted_keys(src)
-        assert out == '{"a":"x "y":z"}'  # naive over-match
-        # And the over-matched result no longer parses:
-        try:
-            json.loads(out)
-            raise AssertionError("expected corrupted output to be invalid")
-        except json.JSONDecodeError:
-            pass
-
-
-# ===========================================================================
-# _fix_single_quotes  (line 281)
-#   s.replace("'", '"')
-# ===========================================================================
-class TestFixSingleQuotes:
-    def test_converts_single_quoted_object(self):
-        """MUST-fix: ``{'a':'b'}`` -> ``{"a":"b"}``."""
-        out = _v()._fix_single_quotes("{'a':'b'}")
-        assert out == '{"a":"b"}'
-        assert json.loads(out) == {"a": "b"}
-
-    def test_double_quoted_input_without_apostrophes_is_unchanged(self):
-        """ANTI-CORRUPTION: valid JSON with no apostrophes contains no
-        ``'`` to replace, so it is byte-identical out."""
-        src = '{"a":"b","c":1}'
-        out = _v()._fix_single_quotes(src)
-        assert out == src
-        assert json.loads(out) == {"a": "b", "c": 1}
-
-    def test_apostrophe_in_value_is_the_named_danger_and_is_corrupted(self):
-        r"""TRICKY / the explicitly-named dangerous case. The VALID input
-        ``{"a":"it's"}`` carries an apostrophe inside the string value.
-        The blind ``replace("'", '"')`` turns it into ``{"a":"it"s"}``,
-        which is now INVALID JSON (the apostrophe became a closing quote).
-
-        This is the canonical reason ``_fix_single_quotes`` must never be
-        run on valid JSON. Pinned as actual behaviour; documented as
-        end-to-end-safe because the helper only runs after ``json.loads``
-        has already failed on the (malformed) string."""
-        src = '{"a":"it\'s"}'
-        assert json.loads(src) == {"a": "it's"}  # source valid
-        out = _v()._fix_single_quotes(src)
-        assert out == '{"a":"it"s"}'  # apostrophe became a quote
-        try:
-            json.loads(out)
-            raise AssertionError("expected corrupted output to be invalid")
-        except json.JSONDecodeError:
-            pass
-
-
-# ===========================================================================
-# _fix_newlines_in_strings  (line 287)
-#   stateful scanner: escapes \n \r \t only while inside a "..." string
-# ===========================================================================
-class TestFixNewlinesInStrings:
-    def test_escapes_literal_newline_inside_string_value(self):
-        r"""MUST-fix: a literal newline inside a string value is an invalid
-        control char in JSON. ``{"a":"line1<LF>line2"}`` -> the scanner is
-        ``in_string`` at the LF and emits the two chars ``\n`` so the
-        result is ``{"a":"line1\nline2"}`` which parses to the string
-        ``line1\nline2``."""
-        src = '{"a":"line1\nline2"}'
-        # Source has a raw control char -> invalid JSON:
-        try:
-            json.loads(src)
-            raise AssertionError("source should be invalid (raw newline)")
-        except json.JSONDecodeError:
-            pass
-        out = _v()._fix_newlines_in_strings(src)
-        assert out == '{"a":"line1\\nline2"}'
-        assert json.loads(out) == {"a": "line1\nline2"}
-
-    def test_escapes_literal_tab_and_cr_inside_string(self):
-        r"""MUST-fix companions: raw tab -> ``\t`` and raw CR -> ``\r``."""
-        out = _v()._fix_newlines_in_strings('{"a":"x\ty\rz"}')
-        assert out == '{"a":"x\\ty\\rz"}'
-        assert json.loads(out) == {"a": "x\ty\rz"}
-
-    def test_does_not_touch_newlines_between_tokens(self):
-        """ANTI-CORRUPTION: a pretty-printed object's newlines sit OUTSIDE
-        any string (``in_string`` is False there), so they are emitted
-        verbatim. The structural newlines survive untouched."""
-        src = '{\n  "a": 1\n}'
-        out = _v()._fix_newlines_in_strings(src)
-        assert out == src
-        assert json.loads(out) == {"a": 1}
-
-    def test_does_not_re_escape_an_already_escaped_newline(self):
-        r"""ANTI-CORRUPTION: an already-escaped ``\n`` is two chars
-        ``\`` + ``n``. The scanner sees ``\``, sets ``escape_next``, and
-        passes the ``n`` through untouched -- it does NOT double-escape.
-        Valid input stays byte-identical and keeps its meaning."""
-        src = '{"a":"line1\\nline2"}'
-        assert json.loads(src) == {"a": "line1\nline2"}
-        out = _v()._fix_newlines_in_strings(src)
-        assert out == src
-        assert json.loads(out) == {"a": "line1\nline2"}
-
-
-# ===========================================================================
-# _fix_missing_closing  (line 321)
-#   append '}'*(open{-close}) then ']'*(open[-close])
-# ===========================================================================
-class TestFixMissingClosing:
-    def test_closes_a_single_unclosed_object(self):
-        """MUST-fix: ``{"a":1`` has 1 ``{`` and 0 ``}`` -> append one ``}``
-        giving ``{"a":1}``."""
-        out = _v()._fix_missing_closing('{"a":1')
-        assert out == '{"a":1}'
-        assert json.loads(out) == {"a": 1}
-
-    def test_does_not_over_close_already_balanced_json(self):
-        """ANTI-CORRUPTION: balanced ``{"a":1}`` has equal counts -> append
-        zero braces. Byte-identical out, never over-closed."""
-        src = '{"a":1}'
-        out = _v()._fix_missing_closing(src)
-        assert out == src
-        assert json.loads(out) == {"a": 1}
-
-    def test_balanced_array_is_untouched(self):
-        """ANTI-CORRUPTION: ``[1,2]`` balanced -> unchanged."""
-        src = "[1,2]"
-        out = _v()._fix_missing_closing(src)
-        assert out == src
-        assert json.loads(out) == [1, 2]
-
-    def test_extra_closer_yields_negative_count_and_appends_nothing(self):
-        """TRICKY (no over-close on negatives): valid ``{"a":"}"}`` counts
-        the ``}`` inside the string too -> 1 open, 2 close. ``'}' * (1-2)``
-        is ``'}' * -1 == ''`` in Python, so nothing is appended and the
-        already-valid string is returned byte-identical. Pins that a
-        negative multiplier can't corrupt valid input."""
-        src = '{"a":"}"}'
-        assert json.loads(src) == {"a": "}"}
-        out = _v()._fix_missing_closing(src)
-        assert out == src
-        assert json.loads(out) == {"a": "}"}
-
-    def test_nested_array_in_object_appends_in_wrong_order(self):
-        """TRICKY / known ordering limitation. ``{"a":[1,2`` is missing one
-        ``]`` then one ``}``. The helper appends ALL ``}`` FIRST, then ALL
-        ``]`` -> ``{"a":[1,2}]`` which is still INVALID (closers in the
-        wrong order). Pinned so a mutation that 'accidentally fixes' the
-        order is still observable; documents that this nested-missing-close
-        case is NOT actually repaired by this helper."""
-        out = _v()._fix_missing_closing('{"a":[1,2')
-        assert out == '{"a":[1,2}]'
-        try:
-            json.loads(out)
-            raise AssertionError("nested wrong-order close should not parse")
-        except json.JSONDecodeError:
-            pass
-
-
-# ===========================================================================
-# _fix_escape_sequences  (line 334)
-#   re.sub(r'(?<!\\)\\(?!")', r'\\\\', s)
-#   -> double any backslash that is NOT preceded by '\' and NOT followed by '"'
-# ===========================================================================
-class TestFixEscapeSequences:
-    def test_doubles_a_lone_invalid_escape_backslash(self):
-        r"""MUST-fix: ``{"a":"50\% done"}`` -- ``\%`` is an invalid JSON
-        escape. The lone ``\`` is not preceded by ``\`` and not followed by
-        ``"``, so it is doubled to ``\\`` giving ``{"a":"50\\% done"}``,
-        which parses to the literal string ``50\% done``."""
-        src = '{"a":"50\\% done"}'  # python str: 50<backslash>% done
-        # invalid because \% is not a legal JSON escape
-        try:
-            json.loads(src)
-            raise AssertionError("source should be invalid (\\% escape)")
-        except json.JSONDecodeError:
-            pass
-        out = _v()._fix_escape_sequences(src)
-        assert out == '{"a":"50\\\\% done"}'
-        assert json.loads(out) == {"a": "50\\% done"}
-
-    def test_does_not_touch_an_escaped_quote(self):
-        r"""ANTI-CORRUPTION: ``\"`` is excluded by the negative lookahead
-        ``(?!")``. Valid ``{"a":"x\"y"}`` (value ``x"y``) is left
-        byte-identical and keeps its meaning -- the escaped quote that makes
-        the JSON valid is NOT mangled."""
-        src = '{"a":"x\\"y"}'
-        assert json.loads(src) == {"a": 'x"y'}
-        out = _v()._fix_escape_sequences(src)
-        assert out == src
-        assert json.loads(out) == {"a": 'x"y'}
-
-    def test_does_not_touch_an_already_doubled_backslash_pair(self):
-        r"""ANTI-CORRUPTION: in ``\\`` the second ``\`` IS preceded by a
-        ``\`` (lookbehind fails) and the first ``\`` is followed by ``\``
-        (not ``"``) but... the regex matches non-overlapping left-to-right:
-        the first ``\`` matches ``(?<!\\)\\(?!")`` ONLY if the char before
-        it isn't ``\`` -- here it isn't, and the char after is ``\`` not
-        ``"`` -> the FIRST backslash of the pair IS matched and doubled.
-
-        So the helper does NOT preserve a literal ``\\``; it expands
-        ``{"a":"x\\y"}`` (value ``x\y``) to three backslashes
-        ``{"a":"x\\\y"}`` which is INVALID. Pinned as actual behaviour:
-        this helper is only sound for the lone-invalid-escape case and is
-        end-to-end-safe because it only ever runs on already-malformed
-        input."""
-        src = '{"a":"x\\\\y"}'  # value is x<backslash>y, source is valid
-        assert json.loads(src) == {"a": "x\\y"}
-        out = _v()._fix_escape_sequences(src)
-        assert out == '{"a":"x\\\\\\y"}'
-        try:
-            json.loads(out)
-            raise AssertionError("over-doubled backslash should be invalid")
-        except json.JSONDecodeError:
-            pass
-
-
-# ===========================================================================
-# extract_json_from_text  (line 164)
+# extract_json_from_text
 # ===========================================================================
 class TestExtractJsonFromText:
     def test_returns_pure_json_unchanged(self):
@@ -451,67 +120,14 @@ class TestExtractJsonFromText:
     def test_malformed_object_is_not_returned_by_extractor(self):
         """LOAD-BEARING: the extractor only returns a candidate that
         ALREADY ``json.loads`` -- a trailing-comma object never survives
-        extraction. (This is why repair is effectively dead on the
-        validate_response path; see TestValidateResponse.)"""
+        extraction. This is why ``validate_response`` is fail-closed for a
+        once-"repairable" input (see TestValidateResponse /
+        TestFailClosedOnceRepairableInput)."""
         assert _v().extract_json_from_text('{"a":1,}') is None
 
 
 # ===========================================================================
-# attempt_repair  (line 200)
-# ===========================================================================
-class TestAttemptRepair:
-    def test_trailing_comma_repaired_first(self):
-        """Repairable + the trailing_comma method is FIRST in the list, so
-        it's the one credited for ``{"a":1,}``."""
-        r = _v().attempt_repair('{"a":1,}', "err")
-        assert isinstance(r, RepairResult)
-        assert r.success is True
-        assert r.repair_method == "trailing_comma"
-        assert json.loads(r.repaired_json) == {"a": 1}
-        assert r.original_error == "err"
-
-    def test_unquoted_key_repaired(self):
-        """``{a:1}`` -- trailing_comma leaves it unchanged (still invalid),
-        so the loop falls through to ``unquoted_keys``."""
-        r = _v().attempt_repair('{a:1}', "err")
-        assert r.success is True
-        assert r.repair_method == "unquoted_keys"
-        assert json.loads(r.repaired_json) == {"a": 1}
-
-    def test_single_quotes_repaired(self):
-        r = _v().attempt_repair("{'a':'b'}", "err")
-        assert r.success is True
-        assert r.repair_method == "single_quotes"
-        assert json.loads(r.repaired_json) == {"a": "b"}
-
-    def test_missing_closing_repaired(self):
-        """``{"a":1`` falls through the earlier methods (each leaves it
-        invalid) to ``missing_closing``."""
-        r = _v().attempt_repair('{"a":1', "err")
-        assert r.success is True
-        assert r.repair_method == "missing_closing"
-        assert json.loads(r.repaired_json) == {"a": 1}
-
-    def test_unrepairable_gibberish_returns_failure(self):
-        """No method makes ``not json at all !!!`` parse -> success False,
-        repaired_json None, repair_method None, error preserved."""
-        r = _v().attempt_repair('not json at all !!!', "boom")
-        assert r.success is False
-        assert r.repaired_json is None
-        assert r.repair_method is None
-        assert r.original_error == "boom"
-
-    def test_first_succeeding_method_wins_ordering(self):
-        """A trailing comma is fixable by trailing_comma; even though later
-        methods might also coincidentally produce valid JSON, the FIRST
-        method that yields a json.loads-able string short-circuits the loop.
-        Pins the ordering contract."""
-        r = _v().attempt_repair('{"a":1,}', "err")
-        assert r.repair_method == "trailing_comma"
-
-
-# ===========================================================================
-# validate_response  (line 71) -- top level
+# validate_response -- top level
 # ===========================================================================
 _SCHEMA = {
     "type": "object",
@@ -521,13 +137,11 @@ _SCHEMA = {
 
 
 class TestValidateResponse:
-    def test_valid_json_passes_without_repair(self):
+    def test_valid_json_passes(self):
         res = _v().validate_response('{"score": 5}', _SCHEMA)
         assert isinstance(res, ValidationResult)
         assert res.valid is True
         assert res.data == {"score": 5}
-        assert res.repair_attempted is False
-        assert res.repair_successful is False
         assert res.extracted_json == '{"score": 5}'
         assert res.errors == []
 
@@ -556,22 +170,6 @@ class TestValidateResponse:
         assert res.valid is False
         assert res.data is None
         assert res.extracted_json is None
-        assert res.repair_attempted is False
-        assert res.errors == ["Could not extract JSON from response"]
-
-    def test_trailing_comma_response_is_not_repaired_end_to_end(self):
-        """LOAD-BEARING characterization. A trailing-comma response is
-        malformed-but-trivially-repairable in principle, BUT
-        ``extract_json_from_text`` returns None for it (it only returns
-        candidates that already json.loads). So ``validate_response`` exits
-        at the extraction step: valid=False, repair_attempted=False, and the
-        only error is the extraction failure. The repair machinery is never
-        engaged on this path. Pinned so nobody assumes repair runs here."""
-        res = _v().validate_response('{"score": 5,}', _SCHEMA)
-        assert res.valid is False
-        assert res.repair_attempted is False
-        assert res.repair_successful is False
-        assert res.extracted_json is None
         assert res.errors == ["Could not extract JSON from response"]
 
     def test_strict_flag_is_stored_on_constructor(self):
@@ -581,19 +179,50 @@ class TestValidateResponse:
         assert _v(strict=True).strict is True
         assert _v(strict=False).strict is False
 
-    def test_attempt_repair_flag_false_skips_repair_branch(self):
-        """When attempt_repair=False is passed and the extracted JSON fails
-        to parse, the repair branch is skipped. (We construct a case that
-        survives extraction yet... cannot, since extraction gates on
-        json.loads. So with valid JSON the flag is simply a no-op.) Pin that
-        passing the flag does not break the happy path."""
-        res = _v().validate_response('{"score": 3}', _SCHEMA, attempt_repair=False)
-        assert res.valid is True
-        assert res.data == {"score": 3}
+
+# ===========================================================================
+# Fail-closed behaviour for a malformed-but-once-"repairable" input.
+#
+# A trailing-comma object (``{"score":5,}``) is the canonical "trivially
+# repairable in principle" case. validate_response does NOT repair it: the
+# extractor only returns candidates that already json.loads, so extraction
+# returns None and validate_response exits at the extraction step with
+# valid=False / data=None. This is the fail-closed contract -- pinned without
+# reference to any (removed) repair machinery.
+# ===========================================================================
+class TestFailClosedOnceRepairableInput:
+    def test_trailing_comma_object_fails_closed(self):
+        res = _v().validate_response('{"score": 5,}', _SCHEMA)
+        assert res.valid is False
+        assert res.data is None
+        assert res.extracted_json is None
+        assert res.errors == ["Could not extract JSON from response"]
+
+    def test_unquoted_key_fails_closed(self):
+        """``{score: 5}`` (bare key) is also not returned by the extractor
+        -> fail-closed, not silently fixed."""
+        res = _v().validate_response('{score: 5}', _SCHEMA)
+        assert res.valid is False
+        assert res.data is None
+        assert res.extracted_json is None
+
+    def test_single_quoted_object_fails_closed(self):
+        """``{'score': 5}`` is invalid JSON; not extracted -> fail-closed."""
+        res = _v().validate_response("{'score': 5}", _SCHEMA)
+        assert res.valid is False
+        assert res.data is None
+        assert res.extracted_json is None
+
+    def test_unclosed_object_fails_closed(self):
+        """``{"score": 5`` (missing closer) is not extractable -> fail-closed."""
+        res = _v().validate_response('{"score": 5', _SCHEMA)
+        assert res.valid is False
+        assert res.data is None
+        assert res.extracted_json is None
 
 
 # ===========================================================================
-# _validate_against_schema  (line 240)
+# _validate_against_schema
 # ===========================================================================
 class TestValidateAgainstSchema:
     def test_valid_data_yields_no_errors(self):
@@ -623,7 +252,7 @@ class TestValidateAgainstSchema:
 
 
 # ===========================================================================
-# validate_structured_response  (line 343, module-level convenience fn)
+# validate_structured_response  (module-level convenience fn)
 # ===========================================================================
 class TestValidateStructuredResponse:
     def test_returns_tuple_for_valid_input(self):
@@ -662,12 +291,11 @@ class TestValidateStructuredResponse:
 
 
 # ===========================================================================
-# End-to-end anti-corruption guard: the reason the in-isolation helper
-# corruptions above are harmless. validate_response tries json.loads FIRST
-# (via extract_json_from_text) and only ever invokes attempt_repair on a
-# string that already failed to parse. So a VALID response -- even one whose
-# string values contain commas/braces/apostrophes/colons that would fool a
-# naive _fix_* helper -- is returned unchanged, repair never engaged.
+# End-to-end guard: a VALID response -- even one whose string values contain
+# commas/braces/apostrophes/colons -- parses on the FIRST json.loads try (via
+# extract_json_from_text) and is returned unchanged. There is no _fix_* helper
+# to fool: validate_response never rewrites a response. These pin that a valid
+# response carrying "dangerous" punctuation in string values survives intact.
 # ===========================================================================
 class TestEndToEndNeverCorruptsValidJson:
     _OPEN_SCHEMA = {"type": "object"}
@@ -675,28 +303,26 @@ class TestEndToEndNeverCorruptsValidJson:
     def _check_unchanged(self, raw):
         res = _v().validate_response(raw, self._OPEN_SCHEMA)
         assert res.valid is True, res.errors
-        assert res.repair_attempted is False
         assert res.data == json.loads(raw)
+        assert res.extracted_json == raw
 
     def test_value_with_comma_and_brace_survives(self):
-        """``{"a":"x,}"}`` would be corrupted by _fix_trailing_commas in
-        isolation, but end-to-end it parses on the first try -> untouched."""
+        """``{"a":"x,}"}`` has the literal substring ``,}`` inside a string
+        value, but it is valid JSON -> parses first try, returned untouched."""
         self._check_unchanged('{"a":"x,}"}')
 
     def test_value_with_apostrophe_survives(self):
-        """``{"a":"it's"}`` -- the _fix_single_quotes landmine -- is valid
-        JSON, so repair is never reached and the apostrophe is preserved."""
+        """``{"a":"it's"}`` is valid JSON -> the apostrophe is preserved."""
         self._check_unchanged('{"a":"it\'s"}')
 
     def test_value_with_space_word_colon_survives(self):
-        """``{"a":"x y:z"}`` -- the _fix_unquoted_keys landmine -- parses
-        first try and is returned with its meaning intact."""
+        """``{"a":"x y:z"}`` parses first try and is returned with its
+        meaning intact."""
         self._check_unchanged('{"a":"x y:z"}')
 
     def test_value_with_url_colon_survives(self):
         self._check_unchanged('{"url":"http://example.com/a,b"}')
 
     def test_value_with_escaped_quote_survives(self):
-        """``{"a":"x\\"y"}`` -- the _fix_escape_sequences territory -- is
-        valid and returned unchanged."""
+        """``{"a":"x\\"y"}`` (value ``x"y``) is valid and returned unchanged."""
         self._check_unchanged('{"a":"x\\"y"}')

--- a/services/workers/tests/test_user_aware_routing_kills.py
+++ b/services/workers/tests/test_user_aware_routing_kills.py
@@ -1,0 +1,380 @@
+"""Mutation-kill / pinning tests for the PROVIDER ROUTING in
+``ai_services/user_aware_ai_service.py``.
+
+WHY THIS FILE EXISTS
+--------------------
+``UserAwareAIService.get_ai_service_for_user`` (and its thin alias
+``get_ai_service_for_model``) is the single point that turns a *provider
+string* + the invoking user's stored API key into the concrete
+``UserSpecific*`` service object that will actually run a generation.
+
+On a research-grade benchmarking platform the worst silent failure here
+is a **mis-route**: a provider string mapped to the WRONG ``UserSpecific*``
+class means the wrong vendor's SDK/key/base-url is used for a model, so a
+generation is attributed to (and billed against) the wrong provider — and
+nothing downstream can tell, because the Generation row only records the
+provider *name* we claimed, not which client truly ran. The second-worst
+failure is a key-propagation bug: the returned service silently carries a
+*global* key instead of THIS user's key, so one user's quota/identity is
+used for another's benchmark run.
+
+The routing logic is only exercised incidentally by the orchestration
+integration tests (which patch ``get_ai_service_for_user`` wholesale via
+``conftest.patch_ai_service``), so the contract below was never pinned
+directly. This file pins it.
+
+THE EXACT CONTRACT (hand-read from source, 2026-06-17)
+------------------------------------------------------
+``get_ai_service_for_user(db, user_id, provider, organization_id=None)``:
+
+1. Resolve a key. With no ``organization_id`` it calls
+   ``user_api_key_service.get_user_api_key(db, user_id, provider)`` — THIS
+   is the seam we mock (the DB/decryption is behind it). With an
+   ``organization_id`` it tries ``org_api_key_service.resolve_api_key(...)``.
+2. If the resolved key is falsy → return ``None`` (NOT a keyless service).
+3. Map ``provider.lower()`` through ``service_class_map`` to one of the
+   seven ``UserSpecific*`` classes. Unknown provider → return ``None``.
+   The match is **case-insensitive** (``provider.lower()``) and is an
+   **exact dict-key lookup** — NOT a prefix/substring match.
+4. Instantiate ``cls(user_api_key)`` — the user's key lands on
+   ``service.api_key`` — and stamp four audit attrs:
+   ``_key_resolution_route`` / ``_provider_name`` (== ``provider.lower()``)
+   / ``_invocation_user_id`` / ``_invocation_organization_id``.
+
+``get_ai_service_for_model(db, user_id, model_provider)`` just delegates to
+``get_ai_service_for_user(db, user_id, model_provider)`` — its third arg is
+a PROVIDER string, despite the ``model_*`` name. The model-id→provider
+mapping happens upstream (worker/catalog), not in this module, so we pin it
+on representative provider strings for every provider the platform offers.
+
+ENV NOTE: importing ``user_aware_ai_service`` eagerly imports every
+``UserSpecific*`` subclass (pulling provider SDKs) and constructs the
+module-level ``EncryptionService`` singleton, which refuses to start
+without a key/sentinel. The workers ``conftest.py`` already sets
+``BENGER_TEST_MODE=1``, but we belt-and-braces the documented env vars at
+the very TOP — BEFORE the import — so the file is runnable in isolation.
+"""
+
+from __future__ import annotations
+
+import os
+
+# --- MUST run before importing the module under test (see module docstring) ---
+os.environ.setdefault("ENCRYPTION_KEY", "dGVzdC1lbmNyeXB0aW9uLWtleS0zMi1ieXRlcw==")
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
+os.environ.setdefault("JWT_SECRET", "test-jwt-secret")
+os.environ.setdefault("TESTING", "true")
+os.environ.setdefault("BENGER_TEST_MODE", "1")
+
+from unittest.mock import MagicMock  # noqa: E402
+
+import pytest  # noqa: E402
+
+# Import the SUBMODULE object (not just the symbols) so we can monkeypatch
+# the key-resolution seam exactly where the routing code looks it up. The
+# routing module binds ``user_api_key_service`` by name at import time
+# (``from user_api_key_service import user_api_key_service``), so the seam to
+# replace is ``uaas_mod.user_api_key_service`` — patching the source singleton
+# elsewhere would NOT be seen by the routing code.
+#
+# NB: ``from ai_services import user_aware_ai_service`` does NOT give the
+# submodule — ``ai_services/__init__.py`` rebinds that name to the
+# ``UserAwareAIService`` *instance* (``from .user_aware_ai_service import
+# user_aware_ai_service``), shadowing the submodule. We import the module via
+# its dotted path and grab it from ``sys.modules`` to be unambiguous.
+import ai_services.user_aware_ai_service  # noqa: E402,F401
+import sys  # noqa: E402
+
+uaas_mod = sys.modules["ai_services.user_aware_ai_service"]
+from ai_services.user_aware_ai_service import (  # noqa: E402
+    UserAwareAIService,
+    UserSpecificAnthropicService,
+    UserSpecificCohereService,
+    UserSpecificDeepInfraService,
+    UserSpecificGoogleService,
+    UserSpecificGrokService,
+    UserSpecificMistralService,
+    UserSpecificOpenAIService,
+)
+
+
+# A sentinel key value that is unmistakably "this user's key", so a
+# global-vs-user key bug is visible: we assert the returned service carries
+# THIS exact string on ``.api_key``.
+USER_KEY = "sk-user-specific-DEADBEEF-0123456789"
+
+# (provider-string-as-seen-by-caller, expected UserSpecific* class).
+# Provider strings are intentionally varied in case to also pin the
+# case-insensitivity contract (provider.lower() lookup). Each row stands in
+# for "a model of this vendor was requested": e.g. an OpenAI model (gpt-*),
+# an Anthropic model (claude-*), a Google model (gemini-*), a Mistral model,
+# a Grok model (xAI), a Cohere model (command-*), a DeepInfra-hosted model
+# (DeepSeek/Qwen/Llama/Kimi/GLM/...).
+PROVIDER_TO_CLASS = [
+    ("openai", UserSpecificOpenAIService),
+    ("anthropic", UserSpecificAnthropicService),
+    ("google", UserSpecificGoogleService),
+    ("mistral", UserSpecificMistralService),
+    ("grok", UserSpecificGrokService),
+    ("cohere", UserSpecificCohereService),
+    ("deepinfra", UserSpecificDeepInfraService),
+]
+
+
+@pytest.fixture()
+def patched_key_service(monkeypatch):
+    """Mock the key-resolution seam so routing is deterministic + offline.
+
+    Replaces ``get_user_api_key`` on the singleton the routing module
+    actually consults (``uaas_mod.user_api_key_service``) with a stub that
+    returns ``USER_KEY`` for any (db, user_id, provider). No DB, no
+    decryption, no network. Returns a recorder so tests can assert the
+    provider string was forwarded verbatim to the key lookup.
+    """
+    calls = []
+
+    def _fake_get_user_api_key(db, user_id, provider):
+        calls.append((user_id, provider))
+        return USER_KEY
+
+    monkeypatch.setattr(
+        uaas_mod.user_api_key_service,
+        "get_user_api_key",
+        _fake_get_user_api_key,
+    )
+    return calls
+
+
+@pytest.fixture()
+def svc():
+    return UserAwareAIService()
+
+
+# ---------------------------------------------------------------------------
+# MODEL/PROVIDER → CORRECT PROVIDER CLASS
+# ---------------------------------------------------------------------------
+class TestProviderRoutesToCorrectClass:
+    """Each provider string must map to its OWN ``UserSpecific*`` class.
+
+    A row mapped to a sibling class is the headline mis-route bug: the wrong
+    vendor SDK/key/base-url runs the generation. Asserting exact ``__class__``
+    identity (not ``isinstance``, which would pass for a shared base) kills
+    any mutation that swaps one ``service_class_map`` value for another.
+    """
+
+    @pytest.mark.parametrize("provider, expected_cls", PROVIDER_TO_CLASS)
+    def test_get_ai_service_for_user_routes_to_right_class(
+        self, svc, patched_key_service, provider, expected_cls
+    ):
+        service = svc.get_ai_service_for_user(MagicMock(), "user-1", provider)
+
+        assert service is not None, f"{provider!r} routed to None with a valid key"
+        # Exact class identity — not a base-class isinstance — so a
+        # value-swap in service_class_map cannot pass.
+        assert type(service) is expected_cls, (
+            f"provider {provider!r} mis-routed to {type(service).__name__}, "
+            f"expected {expected_cls.__name__}"
+        )
+        assert service.__class__.__name__ == expected_cls.__name__
+
+    @pytest.mark.parametrize("provider, expected_cls", PROVIDER_TO_CLASS)
+    def test_get_ai_service_for_model_delegates_identically(
+        self, svc, patched_key_service, provider, expected_cls
+    ):
+        """``get_ai_service_for_model`` is a pass-through alias; its third
+        positional arg is the PROVIDER string. Pin that it routes the same
+        as the user variant (kills a mutation that drops/rewrites the
+        delegation)."""
+        service = svc.get_ai_service_for_model(MagicMock(), "user-1", provider)
+        assert type(service) is expected_cls, (
+            f"get_ai_service_for_model({provider!r}) mis-routed to "
+            f"{type(service).__name__}"
+        )
+
+    def test_no_two_providers_share_a_class(self, svc, patched_key_service):
+        """Defense-in-depth against a map mutation that points two distinct
+        providers at the SAME class (which the per-row tests could miss if
+        the duplicated class happened to be the expected one for both)."""
+        classes = {}
+        for provider, _expected in PROVIDER_TO_CLASS:
+            service = svc.get_ai_service_for_user(MagicMock(), "u", provider)
+            classes[provider] = type(service)
+        # Seven providers → seven distinct classes.
+        assert len(set(classes.values())) == len(PROVIDER_TO_CLASS), (
+            f"provider→class map collapsed two providers onto one class: {classes}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# USER-KEY PROPAGATION (no global-key leak)
+# ---------------------------------------------------------------------------
+class TestUserKeyPropagation:
+    """The returned service must carry THIS user's resolved key, and the
+    four Phase-6.5 audit attrs must reflect the real route/provider/user."""
+
+    @pytest.mark.parametrize("provider, expected_cls", PROVIDER_TO_CLASS)
+    def test_service_carries_the_users_key(
+        self, svc, patched_key_service, provider, expected_cls
+    ):
+        service = svc.get_ai_service_for_user(MagicMock(), "user-42", provider)
+        # Every UserSpecific* __init__ stores the passed key on .api_key
+        # (regardless of whether SDK client construction succeeded with a
+        # fake key). A global-key bug would show a different value here.
+        assert service.api_key == USER_KEY, (
+            f"{provider!r} service did not carry the user's key; "
+            f"got {service.api_key!r}"
+        )
+
+    def test_provider_forwarded_verbatim_to_key_lookup(self, svc, patched_key_service):
+        """The provider string the caller passed must be the one handed to
+        the key resolver — a model's provider mustn't be silently rewritten
+        before the key is fetched (that would fetch the wrong vendor's key)."""
+        svc.get_ai_service_for_user(MagicMock(), "user-7", "anthropic")
+        assert ("user-7", "anthropic") in patched_key_service
+
+    def test_audit_attributes_stamped(self, svc, patched_key_service):
+        service = svc.get_ai_service_for_user(MagicMock(), "user-9", "OpenAI")
+        # _provider_name is the lower-cased provider, NOT the raw input.
+        assert service._provider_name == "openai"
+        assert service._invocation_user_id == "user-9"
+        assert service._invocation_organization_id is None
+        # No org context → route is the plain user-key route.
+        assert service._key_resolution_route == "user_key"
+
+
+# ---------------------------------------------------------------------------
+# CASE-INSENSITIVITY + EXACT (non-prefix) MATCH AT A PROVIDER BOUNDARY
+# ---------------------------------------------------------------------------
+class TestMatchSemantics:
+    """The lookup is ``provider.lower()`` against EXACT dict keys."""
+
+    @pytest.mark.parametrize(
+        "raw_provider, expected_cls",
+        [
+            ("OpenAI", UserSpecificOpenAIService),
+            ("OPENAI", UserSpecificOpenAIService),
+            ("Anthropic", UserSpecificAnthropicService),
+            ("ANTHROPIC", UserSpecificAnthropicService),
+            ("Google", UserSpecificGoogleService),
+            ("Mistral", UserSpecificMistralService),
+            ("Grok", UserSpecificGrokService),
+            ("Cohere", UserSpecificCohereService),
+            ("DeepInfra", UserSpecificDeepInfraService),
+        ],
+    )
+    def test_case_insensitive_match(
+        self, svc, patched_key_service, raw_provider, expected_cls
+    ):
+        """Mixed/upper case must route the same as lowercase (kills a
+        mutation that drops the ``.lower()``)."""
+        service = svc.get_ai_service_for_user(MagicMock(), "u", raw_provider)
+        assert type(service) is expected_cls, (
+            f"{raw_provider!r} did not case-fold to {expected_cls.__name__}"
+        )
+
+    def test_prefix_is_not_a_match(self, svc, patched_key_service):
+        """A string that is a PREFIX of (or contains) a real provider key,
+        but is not an exact key, must NOT route — proving the lookup is an
+        exact dict-key match, not ``startswith``/substring. ``'open'`` is a
+        prefix of ``'openai'``; a substring matcher would mis-route it to
+        OpenAI. Boundary chosen to distinguish two providers: ``'co'`` is a
+        prefix of ``'cohere'`` too."""
+        assert svc.get_ai_service_for_user(MagicMock(), "u", "open") is None
+        assert svc.get_ai_service_for_user(MagicMock(), "u", "openai-chat") is None
+        assert svc.get_ai_service_for_user(MagicMock(), "u", "co") is None
+        assert svc.get_ai_service_for_user(MagicMock(), "u", "anthropic-claude") is None
+
+    def test_surrounding_whitespace_is_not_trimmed(self, svc, patched_key_service):
+        """The code does not ``.strip()`` — a provider with stray whitespace
+        is NOT an exact key and routes to None. Pinning this documents the
+        real (strict) behavior so a future ``.strip()`` is a deliberate,
+        test-visible change rather than silent."""
+        assert svc.get_ai_service_for_user(MagicMock(), "u", " openai") is None
+
+
+# ---------------------------------------------------------------------------
+# UNKNOWN PROVIDER + MISSING KEY → DOCUMENTED None (never a wrong service)
+# ---------------------------------------------------------------------------
+class TestNoSilentMisroute:
+    def test_unknown_provider_returns_none(self, svc, patched_key_service):
+        """An unrecognized provider must return None — never a default/first
+        provider. A key IS available here (key service mocked), so this
+        isolates the provider-map miss from the no-key path."""
+        for unknown in ("", "zhipu", "openai2", "claude", "gpt", "unknown"):
+            assert (
+                svc.get_ai_service_for_user(MagicMock(), "u", unknown) is None
+            ), f"unknown provider {unknown!r} did not return None"
+
+    @pytest.mark.parametrize("provider, _expected_cls", PROVIDER_TO_CLASS)
+    def test_missing_user_key_returns_none(self, svc, monkeypatch, provider, _expected_cls):
+        """No stored key for the user → return None (the worker then records
+        a key-missing failure). The service is NOT constructed keyless."""
+        monkeypatch.setattr(
+            uaas_mod.user_api_key_service,
+            "get_user_api_key",
+            lambda db, user_id, provider: None,
+        )
+        assert svc.get_ai_service_for_user(MagicMock(), "u", provider) is None
+
+    def test_empty_string_key_returns_none(self, svc, monkeypatch):
+        """An empty-string key is falsy → None, same as a missing key. Kills
+        a mutation that flips the ``if not user_api_key`` guard."""
+        monkeypatch.setattr(
+            uaas_mod.user_api_key_service,
+            "get_user_api_key",
+            lambda db, user_id, provider: "",
+        )
+        assert svc.get_ai_service_for_user(MagicMock(), "u", "openai") is None
+
+    def test_key_resolver_exception_returns_none(self, svc, monkeypatch):
+        """If key resolution raises, the broad try/except yields None — the
+        worker must not get a half-built service. Pin the swallow so a
+        mutation removing the guard surfaces as a behavior change."""
+        def _boom(db, user_id, provider):
+            raise RuntimeError("decrypt failed")
+
+        monkeypatch.setattr(
+            uaas_mod.user_api_key_service, "get_user_api_key", _boom
+        )
+        assert svc.get_ai_service_for_user(MagicMock(), "u", "openai") is None
+
+
+# ---------------------------------------------------------------------------
+# ORG-CONTEXT KEY PATH (org resolver consulted, route recorded)
+# ---------------------------------------------------------------------------
+class TestOrgContextPath:
+    """With an ``organization_id`` the org key resolver is consulted and the
+    recorded ``_key_resolution_route`` reflects the org decision — while the
+    provider→class routing is unchanged."""
+
+    def test_org_resolved_route_and_correct_class(self, svc, monkeypatch):
+        org_service = MagicMock()
+        org_service.resolve_api_key.return_value = USER_KEY
+        # The routing code does ``from shared_org_api_key_service import
+        # org_api_key_service`` INSIDE the org branch, so patch the source
+        # module attribute it imports.
+        import shared_org_api_key_service as org_mod
+        monkeypatch.setattr(org_mod, "org_api_key_service", org_service)
+
+        service = svc.get_ai_service_for_user(
+            MagicMock(), "user-1", "anthropic", organization_id="org-xyz"
+        )
+        assert type(service) is UserSpecificAnthropicService
+        assert service.api_key == USER_KEY
+        assert service._key_resolution_route == "org_resolved"
+        assert service._invocation_organization_id == "org-xyz"
+        org_service.resolve_api_key.assert_called_once()
+
+    def test_org_resolver_returns_no_key_returns_none(self, svc, monkeypatch):
+        """Org resolver yields no key → the ``if not user_api_key`` guard
+        still returns None (no keyless service), even though org context was
+        honored."""
+        org_service = MagicMock()
+        org_service.resolve_api_key.return_value = None
+        import shared_org_api_key_service as org_mod
+        monkeypatch.setattr(org_mod, "org_api_key_service", org_service)
+
+        service = svc.get_ai_service_for_user(
+            MagicMock(), "user-1", "openai", organization_id="org-xyz"
+        )
+        assert service is None


### PR DESCRIPTION
## Primary change: count immediate-eval grades in batch "missing only" re-runs

### Problem
Immediate evaluation (the client-fired LLM-judge that grades an annotation right after submit) persists a **bare** `field_name` — the prediction field, e.g. `human:loesung` — plus the discrete `evaluation_config_id` column (#111). The batch **missing-only** matcher in `run_evaluation` only keyed on the 3-part `{config_id}|{pred}|{ref}` form, and `_normalize_field_key` returns a 2-part bare key unchanged. So a bare immediate row could never be a member of the 3-part expected set → **every immediate-graded annotation looked "missing" and got re-graded** on the next missing-only run: wasted LLM budget and parallel/duplicate grades in a different field-key shape.

Found while investigating a real prod report (a Göttingen exam student with a missing "KI-Votum"); the suggested remediation — "run evaluation → missing only" — would have re-graded the whole class.

### Fix (matcher-only, no change to what immediate writes)
`run_evaluation` now also reconstructs the canonical expected key(s) from each row's discrete `evaluation_config_id` (both the generation and annotation skip-sets), via two new pure helpers `_reconstruct_expected_keys` + `_pred_field_matches`. A bare-field_name immediate row whose config-id is among the run's configs is correctly recognized as **done**.

- No change to what immediate eval writes → the results modal's bare-name grouping is untouched, and zero read consumers are affected (verified by a blast-radius audit of the results/metadata/export/my-tasks endpoints).
- Wildcard prediction fields (`__all_human__`/`__all_model__`) remain a pre-existing missing-only limitation, explicitly guarded against regression.

### Backfill for legacy rows
Rows written **before #111** carry `evaluation_config_id = NULL` + a bare `field_name`, so the config-id matcher can't see them. `services/api/scripts/backfill_immediate_eval_config_id.py` (dry-run default, idempotent) populates the column by mapping each row's metric+field to the project's current config — **only unambiguous single matches** are touched; ambiguous/no-match rows are skipped and logged.

Dry-run against prod: 15 candidates → 14 resolved (7 in the affected exam project, 6 + 1 in two others), 1 correctly skipped as ambiguous (a research project with multiple judge configs). **Run `--apply` once after this deploys.**

### Tests
- `test_orchestration_branches_e2e.py`: regression test (immediate row recognized → `cells_dispatched == 0`, no new rows) + an over-skip guard (a grade on a *different* field does not satisfy the config).
- `test_missing_only_dict_shape.py`: `_pred_field_matches` unit cases + drift guards for both new helpers.
- Full `test_orchestration_branches_e2e.py` suite: 45 passed locally.

---
*This rolling `dev → main` PR also carries other already-on-`dev` commits unrelated to this fix (leaderboard value formatting, response-validator refactor, provider content-policy refusal detection, eval-config test hardening). Merging deploys all of them to production.*
