### PR TITLE
fix(evaluation): surface human-eval (korrektur) metrics in the results dropdown

### DIFF
--- a/services/api/scripts/backfill_korrektur_falloesung_normalize.py
+++ b/services/api/scripts/backfill_korrektur_falloesung_normalize.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Normalize existing `korrektur_falloesung` task_evaluations to a 0–1 `value`.
+
+Human Falllösung grades used to persist `metrics.korrektur_falloesung.value` as
+the RAW 0–100 rubric total (e.g. 11.0, 15.0), unlike `llm_judge_falloesung`
+which stores `raw_score / 100` (0–1). The scoring code now normalizes at write
+time (`korrektur.py`: `value = total_score / 100.0`); this backfills the rows
+written before that change so every consumer (results matrix, annotator
+leaderboard, renderers) sees one 0–1 scale.
+
+Strictly value-only + idempotent. Targets the unified-shape rows whose
+`value` still equals `details.raw_score` (i.e. not yet divided) and rewrites
+`value = raw_score / 100`. After the rewrite `value != raw_score` (for any
+raw_score > 0), so a second run is a no-op; the only fixed point is
+raw_score == 0 (0/100 == 0, harmless). It NEVER touches `details` (raw_score,
+grade_points, dimensions stay as-is), and no other metric or row is read.
+
+FIPS-safe: pure jsonb numeric arithmetic, no md5 (prod Postgres has FIPS
+OpenSSL — md5() raises there).
+
+Usage (inside the api container):
+  python /app/scripts/backfill_korrektur_falloesung_normalize.py --dry-run
+  python /app/scripts/backfill_korrektur_falloesung_normalize.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+# Make database.py importable whether run as /app/scripts/<f>.py in the
+# container or piped via stdin (cwd may not be /app then).
+_HERE = os.path.dirname(os.path.abspath(__file__))
+for _p in ("/app", os.path.dirname(_HERE)):
+    if os.path.isdir(_p) and _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from sqlalchemy import text  # noqa: E402
+
+from database import get_db  # noqa: E402
+
+
+# Unified-shape rows whose value has NOT yet been normalized: value still
+# equals the raw 0–100 total. (Legacy non-object korrektur blobs, if any,
+# are skipped — they carry no `value`/`details.raw_score` pair.)
+PREDICATE = """
+    jsonb_typeof(metrics->'korrektur_falloesung') = 'object'
+    AND metrics->'korrektur_falloesung'->>'value' IS NOT NULL
+    AND metrics->'korrektur_falloesung'->'details'->>'raw_score' IS NOT NULL
+    AND (metrics->'korrektur_falloesung'->>'value')::numeric
+        = (metrics->'korrektur_falloesung'->'details'->>'raw_score')::numeric
+    AND (metrics->'korrektur_falloesung'->'details'->>'raw_score')::numeric > 0
+"""
+
+
+def _count(db) -> int:
+    return db.execute(
+        text(f"SELECT COUNT(*) FROM task_evaluations WHERE {PREDICATE}")
+    ).scalar() or 0
+
+
+def _print_dry_run_summary(db) -> int:
+    total = _count(db)
+    print(f"rows to normalize (value still == raw 0–100 total): {total}")
+    if total == 0:
+        return 0
+    print()
+    print("per project_id:")
+    rows = db.execute(text(f"""
+        SELECT t.project_id::text AS project_id, COUNT(*) AS n
+        FROM task_evaluations te
+        JOIN tasks t ON t.id = te.task_id
+        WHERE {PREDICATE}
+        GROUP BY t.project_id
+        ORDER BY n DESC
+    """)).fetchall()
+    for project_id, n in rows:
+        print(f"  {n:>5}  project={project_id}")
+    print()
+    print("sample (current value → normalized value), 8 rows:")
+    sample = db.execute(text(f"""
+        SELECT te.id::text,
+               (metrics->'korrektur_falloesung'->>'value') AS cur_value,
+               (metrics->'korrektur_falloesung'->'details'->>'raw_score') AS raw_score
+        FROM task_evaluations te
+        WHERE {PREDICATE}
+        LIMIT 8
+    """)).fetchall()
+    for tid, cur, raw in sample:
+        try:
+            nv = f"{float(raw) / 100.0:.4f}"
+        except (TypeError, ValueError):
+            nv = "?"
+        print(f"  te={tid}  value {cur} → {nv}  (raw_score {raw} unchanged)")
+    return total
+
+
+def _apply(db) -> int:
+    result = db.execute(text(f"""
+        UPDATE task_evaluations
+        SET metrics = jsonb_set(
+            metrics,
+            '{{korrektur_falloesung,value}}',
+            to_jsonb(
+                (metrics->'korrektur_falloesung'->'details'->>'raw_score')::numeric / 100.0
+            )
+        )
+        WHERE {PREDICATE}
+    """))
+    return result.rowcount or 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", default=True,
+                      help="print summary, do not commit (default)")
+    mode.add_argument("--apply", action="store_true", help="commit the normalization")
+    args = parser.parse_args()
+    apply_mode = bool(args.apply)
+
+    db = next(get_db())
+    try:
+        if not apply_mode:
+            print("=== DRY RUN (no changes will be committed) ===")
+            _print_dry_run_summary(db)
+            return 0
+
+        before = _count(db)
+        print(f"before: {before} rows to normalize")
+        updated = _apply(db)
+        db.commit()
+        after = _count(db)
+        print(f"updated rows: {updated}")
+        print(f"after: {after} rows remaining (expected: 0)")
+        if after != 0:
+            print("WARNING: rows still match the predicate after apply.")
+            return 1
+        print("done.")
+        return 0
+    except Exception as e:  # noqa: BLE001
+        db.rollback()
+        print(f"ERROR: {e}")
+        return 2
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/frontend/src/components/evaluation/EvaluationResults.tsx
+++ b/services/frontend/src/components/evaluation/EvaluationResults.tsx
@@ -212,15 +212,13 @@ export function EvaluationResults({
   // using `cfg.metric` for GROUPED_METRICS lookup (configs of the same
   // metric group together).
   const availableMetricRuns = useMemo(() => {
-    if (!results?.evaluations) return []
-
     // Include in-flight runs (`pending`, `running`) alongside `completed`
     // so the user can navigate to a metric the moment its run is
     // dispatched and watch rows fill in live, instead of waiting for the
     // whole run to finish before the dropdown surfaces it. Cells render
     // from `task_evaluations` rows directly — every committed row is
     // visible immediately, regardless of run status.
-    const visible = results.evaluations
+    const visible = (results?.evaluations ?? [])
       .filter((e) =>
         e.status === 'completed' ||
         e.status === 'running' ||
@@ -272,6 +270,34 @@ export function EvaluationResults({
           })
         }
       }
+    }
+
+    // Surface EVERY enabled project eval config as its own selectable table —
+    // including human-graded methods (korrektur_*) whose grades are NOT emitted
+    // as a normal EvaluationRun in `results.evaluations`, so they'd otherwise be
+    // absent from the dropdown and leak into an automated metric's view. These
+    // get empty `runIds`: the by-task-model fetch then sends only `?metric=`,
+    // and the endpoint scans all of the project's runs filtered by that metric
+    // key (results.py), so the human grades still populate the table.
+    for (const cfg of evaluationConfigs ?? []) {
+      if (cfg?.enabled === false) continue
+      const cfgId = cfg?.id || cfg?.metric
+      if (!cfgId || byConfig.has(cfgId)) continue
+      if (
+        selectedConfigIds &&
+        selectedConfigIds.length > 0 &&
+        !selectedConfigIds.includes(cfgId)
+      ) {
+        continue
+      }
+      byConfig.set(cfgId, {
+        id: cfgId,
+        metric: cfg?.metric || 'unknown',
+        configId: cfgId,
+        displayName: cfg?.display_name || cfg?.metric || 'Unknown',
+        samplesEvaluated: 0,
+        runIds: [],
+      })
     }
 
     // Sort by GROUPED_METRICS order (same as wizard) using cfg.metric

--- a/services/frontend/src/components/evaluation/__tests__/EvaluationResults.metricSelector.test.tsx
+++ b/services/frontend/src/components/evaluation/__tests__/EvaluationResults.metricSelector.test.tsx
@@ -285,12 +285,111 @@ describe('composite key parsing for *_by_model_metric blocks', () => {
   })
 })
 
+// Human-eval methods (korrektur_*) are graded by a person, not by a normal
+// EvaluationRun, so their grades never appear in `results.evaluations`. The
+// dropdown must still list them — sourced from the project's enabled
+// `evaluation_configs` — with empty `runIds` so the by-task-model fetch sends
+// only `?metric=` and the backend scans all project runs by metric key.
+type Cfg = { id?: string; metric?: string; display_name?: string; enabled?: boolean }
+
+// Mirror of the config-merge step appended to `availableMetricRuns` in
+// EvaluationResults.tsx. Kept in sync via the drift guard below.
+function mergeEnabledConfigs(
+  entries: ConfigEntry[],
+  configs: Cfg[],
+  selectedConfigIds: string[] = [],
+): ConfigEntry[] {
+  const byConfig = new Map(entries.map((e) => [e.id, e]))
+  for (const cfg of configs ?? []) {
+    if (cfg?.enabled === false) continue
+    const cfgId = cfg?.id || cfg?.metric
+    if (!cfgId || byConfig.has(cfgId)) continue
+    if (selectedConfigIds.length > 0 && !selectedConfigIds.includes(cfgId)) continue
+    byConfig.set(cfgId, {
+      id: cfgId,
+      metric: cfg?.metric || 'unknown',
+      configId: cfgId,
+      displayName: cfg?.display_name || cfg?.metric || 'Unknown',
+      samplesEvaluated: 0,
+      runIds: [],
+    })
+  }
+  return Array.from(byConfig.values())
+}
+
+describe('availableMetricRuns surfaces enabled configs without a run (human eval)', () => {
+  it('lists a human-graded korrektur config that has no EvaluationRun', () => {
+    // The Probeklausur prod scenario: llm_judge has immediate runs, the human
+    // korrektur method is configured + enabled but its grades are not an
+    // EvaluationRun, so it is absent from `results.evaluations`.
+    const runs: EvalRun[] = [
+      {
+        evaluation_id: 'imm-1',
+        status: 'completed',
+        samples_evaluated: 14,
+        evaluation_configs: [
+          { metric: 'llm_judge_falloesung', id: 'cfg-judge', display_name: 'Falllösung LLM Judge' },
+        ],
+      },
+    ]
+    const configs: Cfg[] = [
+      { id: 'cfg-judge', metric: 'llm_judge_falloesung', display_name: 'Falllösung LLM Judge', enabled: true },
+      { id: 'cfg-korrektur', metric: 'korrektur_falloesung', display_name: 'Korrektur (Standard Falllösung)', enabled: true },
+    ]
+    const result = mergeEnabledConfigs(groupRunsByConfig(runs), configs)
+    const korrektur = result.find((r) => r.id === 'cfg-korrektur')
+    expect(korrektur).toBeTruthy()
+    expect(korrektur!.metric).toBe('korrektur_falloesung')
+    // Empty runIds → the fetch sends only `?metric=`, backend scans all runs.
+    expect(korrektur!.runIds).toEqual([])
+    // The run-backed automated entry keeps its run id.
+    expect(result.find((r) => r.id === 'cfg-judge')!.runIds).toEqual(['imm-1'])
+  })
+
+  it('does not overwrite a config that already has runs', () => {
+    const runs: EvalRun[] = [
+      {
+        evaluation_id: 'r1',
+        status: 'completed',
+        samples_evaluated: 10,
+        evaluation_configs: [{ metric: 'bleu', id: 'cfg-bleu' }],
+      },
+    ]
+    const configs: Cfg[] = [{ id: 'cfg-bleu', metric: 'bleu', enabled: true }]
+    const result = mergeEnabledConfigs(groupRunsByConfig(runs), configs)
+    expect(result).toHaveLength(1)
+    expect(result[0].runIds).toEqual(['r1']) // not reset to []
+  })
+
+  it('excludes disabled configs', () => {
+    const configs: Cfg[] = [
+      { id: 'cfg-on', metric: 'korrektur_falloesung', enabled: true },
+      { id: 'cfg-off', metric: 'korrektur_custom', enabled: false },
+    ]
+    const result = mergeEnabledConfigs([], configs)
+    expect(result.map((r) => r.id)).toEqual(['cfg-on'])
+  })
+
+  it('respects the page-level selectedConfigIds filter', () => {
+    const configs: Cfg[] = [
+      { id: 'cfg-a', metric: 'korrektur_falloesung', enabled: true },
+      { id: 'cfg-b', metric: 'llm_judge_falloesung', enabled: true },
+    ]
+    const result = mergeEnabledConfigs([], configs, ['cfg-b'])
+    expect(result.map((r) => r.id)).toEqual(['cfg-b'])
+  })
+})
+
 describe('drift guard: EvaluationResults.tsx still iterates all configs and groups by id', () => {
   it('source file walks evaluation_configs in a for-of, not [0]', () => {
     const tsxPath = join(__dirname, '..', 'EvaluationResults.tsx')
     const src = readFileSync(tsxPath, 'utf8')
     // Multi-config iteration must be present in the metric grouping.
     expect(src).toMatch(/for \(const cfg of cfgs\)/)
+    // The config-merge step (surfaces human-eval configs) must be present:
+    // a for-of over evaluationConfigs that skips disabled ones.
+    expect(src).toMatch(/for \(const cfg of evaluationConfigs \?\? \[\]\)/)
+    expect(src).toMatch(/cfg\?\.enabled === false/)
     // The pre-fix shortcut MUST NOT come back. We allow `evaluation_configs?.[0]`
     // elsewhere in the file (other components legitimately read the
     // first config), but the metric-grouping `useMemo` must use the

--- a/services/frontend/src/lib/utils/__tests__/fieldMapping.property.test.ts
+++ b/services/frontend/src/lib/utils/__tests__/fieldMapping.property.test.ts
@@ -142,37 +142,29 @@ describe('suggestFieldMappings — properties', () => {
     )
   })
 
-  it('order independence: shuffling the source list yields the same set of (source→target) mappings', () => {
-    // The matcher walks sources in array order; for a *distinct* target set the
-    // chosen mapping for any given source must not depend on the source's
-    // position (exact + synonym + fuzzy all pick a target deterministically by
-    // the source identity when targets are distinct and disjoint enough).
+  it('no target is ever double-assigned, regardless of source order', () => {
+    // `suggestFieldMappings` is a GREEDY matcher: it walks sources in array
+    // order and claims targets via a `usedTargets` set (fieldMapping.ts). For a
+    // *contested* target, reversing the source list can legitimately hand it to
+    // a different source — a different but equally-valid full mapping. So the
+    // pairing itself is intentionally order-DEPENDENT under contention; the
+    // order-INVARIANT property that always holds (and is the one that matters —
+    // never bind two columns to one template field) is that no target is
+    // assigned to more than one source, in either ordering.
+    //
+    // (A prior version asserted cross-order pairing equality whenever both
+    // orderings fully mapped; that is a false invariant — "both fully mapped"
+    // does not imply "uncontested" — and flaked under fast-check's random seed.
+    // Follow-up: make suggestFieldMappings order-independent if we want the
+    // stronger property.)
     fc.assert(
       fc.property(distinctFieldsArb, distinctFieldsArb, (src, tgt) => {
-        const norm = (r: ReturnType<typeof suggestFieldMappings>) =>
-          r.mappings
-            .map((m) => `${m.source}=>${m.target}@${m.confidence}`)
-            .sort()
-        const a = norm(suggestFieldMappings(src, tgt))
-        const reversed = [...src].reverse()
-        const b = norm(suggestFieldMappings(reversed, tgt))
-        // Reversing can change which source "wins" a contested target, so we
-        // only assert the weaker invariant that the *count* is stable and no
-        // target is double-assigned in either ordering.
-        const aTargets = suggestFieldMappings(src, tgt).mappings.map(
-          (m) => m.target,
-        )
-        const bTargets = suggestFieldMappings(reversed, tgt).mappings.map(
-          (m) => m.target,
-        )
+        const targetsOf = (sources: string[]) =>
+          suggestFieldMappings(sources, tgt).mappings.map((m) => m.target)
+        const aTargets = targetsOf(src)
+        const bTargets = targetsOf([...src].reverse())
         expect(new Set(aTargets).size).toBe(aTargets.length)
         expect(new Set(bTargets).size).toBe(bTargets.length)
-        // When every source has a unique unambiguous home (distinct, disjoint),
-        // the mapping set is order-invariant.
-        if (a.length === src.length && b.length === src.length) {
-          // Both fully mapped: the same source→target pairing must hold.
-          expect(b).toEqual(a)
-        }
       }),
     )
   })


### PR DESCRIPTION
## Surface human-eval (korrektur) metrics in the evaluation results dropdown

### Problem
On the project Evaluations page, the "Ergebnisse pro Aufgabe" metric dropdown is built only from `results.evaluations` (automated `EvaluationRun`s). Human-graded methods (`korrektur_falloesung` / `korrektur_custom`) are graded by a person and are **not** emitted as a normal `EvaluationRun`, so they never appeared in the dropdown. Their grades then leaked into whatever automated metric's view happened to be shown — e.g. a raw `11.000`/`15.000` korrektur score sitting next to `0.42` LLM-judge values in one table.

### Fix
Build `availableMetricRuns` from the **union** of (a) configs that have evaluation runs (automated — unchanged, keep `runIds` + sample counts) and (b) the project's **enabled `evaluation_configs`** (which include the human-eval methods). Every configured method is now its own selectable table.

Human-eval entries carry empty `runIds`; the existing `by-task-model` fetch then sends only `?metric=`, and the endpoint already defaults to scanning **all** the project's runs filtered by that metric key (`results.py:1290-1299`), so the human grades populate the table. No backend change needed.

This also resolves the original cross-metric mixing report: each method is a distinct view, so LLM-judge and human-Korrektur scores are never shown in the same column.

### Tests
`EvaluationResults.metricSelector.test.tsx`: human-eval config surfaces with empty `runIds`; run-backed configs keep their `runIds` (not reset); disabled configs and the page-level `selectedConfigIds` filter are respected; drift guard for the new merge loop. Full `EvaluationResults` suite (136 tests) + metric-selector suite (15) green locally.

### Not in this PR (follow-up)
Normalizing `korrektur_falloesung` `value` to 0–1 (it currently stores the raw 0–100 rubric total, unlike `llm_judge_falloesung` which stores `raw_score/100`). That's an extended-repo scoring change + a one-time backfill + display-scale update — tracked separately.

---
*Also carries the already-on-`main` `[hotfix]` fieldMapping test fix (content-identical via cherry-pick `e9833cf` → no-op on merge).*

---
**Update:** also adds `scripts/backfill_korrektur_falloesung_normalize.py` — the platform companion to extended PR #47 (korrektur 0–1 normalization). Run with `--apply` after #47 deploys.