### PR TITLE
fix(eval): server-side immediate-eval net, human-score display, hourly beat

### DIFF
--- a/services/api/routers/evaluations/metadata/models_methods.py
+++ b/services/api/routers/evaluations/metadata/models_methods.py
@@ -226,6 +226,47 @@ async def get_evaluated_models(
                     if coerced is not None:
                         eval_data[model_id]["all_scores"].append(coerced)
 
+        # Attach immediate / human-graded run scores to the synthetic annotator
+        # rows. Those runs carry model_id="immediate" (filtered out of
+        # all_model_ids above), so the loop over `evaluations` never sees them
+        # and the annotator rows would otherwise show N/A. The link is
+        # run.created_by (the submitter) -> the annotator's synthetic row.
+        from routers.evaluations.results import _coerce_metric_value
+
+        user_to_annotator: dict[str, str] = {}
+        for syn_id, uids in annotator_user_ids.items():
+            for uid in uids:
+                user_to_annotator[uid] = syn_id
+
+        if user_to_annotator:
+            immediate_runs = (
+                (
+                    await db.execute(
+                        select(DBEvaluationRun).where(
+                            DBEvaluationRun.project_id == project_id,
+                            DBEvaluationRun.model_id == "immediate",
+                            DBEvaluationRun.status == "completed",
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            for run in immediate_runs:
+                syn_id = user_to_annotator.get(run.created_by)
+                if not syn_id or syn_id not in eval_data:
+                    continue
+                eval_data[syn_id]["evaluation_count"] += 1
+                eval_data[syn_id]["total_samples"] += run.samples_evaluated or 0
+                if run.completed_at:
+                    last = eval_data[syn_id]["last_evaluated"]
+                    if last is None or run.completed_at > last:
+                        eval_data[syn_id]["last_evaluated"] = run.completed_at
+                for _metric_name, value in (run.metrics or {}).items():
+                    coerced = _coerce_metric_value(value)
+                    if coerced is not None:
+                        eval_data[syn_id]["all_scores"].append(coerced)
+
         # Build result list. Annotator rows expand into one entry per
         # underlying user_id so two distinct users sharing a display name
         # surface as two pickable rows in the eval modal (otherwise the

--- a/services/api/routers/evaluations/multi_field/results.py
+++ b/services/api/routers/evaluations/multi_field/results.py
@@ -142,6 +142,16 @@ async def get_project_evaluation_results(
                     pred_field = parts[1]
                     ref_field = parts[2]
                     metric_name = "|".join(parts[3:])
+                elif len(parts) == 2:
+                    # Immediate / human-graded run-level shape: "pred_field|metric"
+                    # (no config_id, no ref_field). pred_field itself may contain
+                    # ':' (e.g. "human:loesung"). Without this branch the score is
+                    # dropped and the config card / headline render N/A even though
+                    # the grade exists. Group under the metric so it headlines.
+                    pred_field = parts[0]
+                    ref_field = ""
+                    metric_name = parts[1]
+                    config_id = metric_name
                 elif len(parts) == 1 and ":" in key:
                     # Backward compat: old format used : as separator
                     old_parts = key.split(":")
@@ -184,8 +194,12 @@ async def get_project_evaluation_results(
                     all_scores = []
                     for fr in config_data["field_results"]:
                         for score_name, score_val in fr["scores"].items():
-                            if isinstance(score_val, (int, float)):
-                                all_scores.append(score_val)
+                            # Coerce both the legacy bare-float shape AND the
+                            # {value, details} shape (llm_judge / falloesung) so
+                            # human-graded runs contribute a real aggregate.
+                            coerced = _coerce_metric_value(score_val)
+                            if coerced is not None:
+                                all_scores.append(coerced)
                     if all_scores:
                         config_data["aggregate_score"] = sum(all_scores) / len(all_scores)
 

--- a/services/api/scripts/recover_missing_immediate_evals.py
+++ b/services/api/scripts/recover_missing_immediate_evals.py
@@ -55,9 +55,14 @@ for _p in (
 import models  # noqa: E402,F401
 import project_models  # noqa: E402,F401
 from database import SessionLocal  # noqa: E402
-from metric_filters import is_immediate_eligible  # noqa: E402
-from models import EvaluationRun, OrganizationMembership, TaskEvaluation, User  # noqa: E402
-from project_models import Annotation, Project, Task  # noqa: E402
+from immediate_eval_dispatch import (  # noqa: E402
+    eligible_configs as _eligible_configs,
+    eligible_metrics as _eligible_metrics,
+    ensure_immediate_evaluation,
+    scan_ungraded,
+)
+from models import User  # noqa: E402
+from project_models import Project  # noqa: E402
 
 try:
     from celery_client import send_task_safe
@@ -65,198 +70,33 @@ except Exception:  # pragma: no cover - only needed for --apply
     send_task_safe = None
 
 
-def _eligible_configs(project) -> list[dict]:
-    cfg = project.evaluation_config or {}
-    configs = cfg.get("evaluation_configs") or cfg.get("multi_field_evaluations") or []
-    return [
-        c
-        for c in configs
-        if c.get("enabled", True) and is_immediate_eligible(c.get("metric", ""))
-    ]
-
-
-def _eligible_metrics(eligible_configs) -> set:
-    return {c.get("metric", "") for c in eligible_configs}
-
-
-def _row_has_real_score_for(metrics, eligible_metrics: set) -> bool:
-    """True if the row carries a non-error score for any eligible metric."""
-    if not isinstance(metrics, dict):
-        return False
-    for m in eligible_metrics:
-        if m not in metrics:
-            continue
-        v = metrics[m]
-        if isinstance(v, dict):
-            if v.get("error"):
-                continue
-            if v.get("value") is not None:
-                return True
-        elif isinstance(v, (int, float)) and not isinstance(v, bool):
-            return True
-    return False
-
-
-def _parse_annotation_results(annotation) -> dict:
-    """Replicate the immediate-eval endpoint's annotation.result -> dict parse
-    (keyed by ``from_name``). Generic Label-Studio shape handling."""
-    out: dict = {}
-    res = annotation.result
-    if not (res and isinstance(res, list)):
-        return out
-    for region in res:
-        if not isinstance(region, dict):
-            continue
-        from_name = region.get("from_name")
-        if not from_name:
-            continue
-        value = region.get("value", {})
-        region_type = region.get("type", "")
-        if isinstance(value, str):
-            out[from_name] = value
-            continue
-        if isinstance(value, dict) and "markdown" in value:
-            out[from_name] = value["markdown"]
-            continue
-        if region_type == "textarea":
-            texts = value.get("text", [])
-            out[from_name] = "\n".join(texts) if isinstance(texts, list) else str(texts)
-        elif region_type == "choices":
-            choices = value.get("choices", [])
-            out[from_name] = choices[0] if len(choices) == 1 else choices
-        elif region_type == "rating":
-            out[from_name] = value.get("rating")
-        elif "text" in value:
-            texts = value["text"]
-            out[from_name] = "\n".join(texts) if isinstance(texts, list) else str(texts)
-        else:
-            for v in value.values():
-                if v:
-                    out[from_name] = v if isinstance(v, str) else str(v)
-                    break
-    return out
-
-
-def _resolve_org(db, project, user_id):
-    """Mirror routers.evaluations.helpers.resolve_user_org_for_project without
-    importing the router module."""
-    if not project.organizations:
-        return None
-    org_ids = {str(o.id) for o in project.organizations}
-    m = (
-        db.query(OrganizationMembership)
-        .filter(
-            OrganizationMembership.user_id == user_id,
-            OrganizationMembership.is_active == True,  # noqa: E712
-            OrganizationMembership.organization_id.in_(org_ids),
-        )
-        .first()
-    )
-    if m:
-        return str(m.organization_id)
-    return str(project.organizations[0].id)
-
-
 def _scan_project(db, project, cutoff):
-    """Return (candidates, partials) for one project.
+    """Return (candidates, partials, eligible) for one project.
 
-    candidate = (annotation, task) with ZERO eligible real-score rows.
-    partial   = (annotation, present_metrics, missing_metrics) — reported only.
+    Thin wrapper over the shared ``scan_ungraded`` so the CLI and the hourly
+    sweep agree on what "ungraded" means.
     """
     eligible = _eligible_configs(project)
     if not eligible:
         return [], [], eligible
-    elig_metrics = _eligible_metrics(eligible)
-
-    anns = (
-        db.query(Annotation)
-        .filter(
-            Annotation.project_id == project.id,
-            Annotation.was_cancelled == False,  # noqa: E712
-            Annotation.result.isnot(None),
-            Annotation.created_at < cutoff,
-        )
-        .all()
-    )
-    if not anns:
-        return [], [], eligible
-
-    tasks_by_id = {
-        t.id: t
-        for t in db.query(Task).filter(Task.id.in_({a.task_id for a in anns})).all()
-    }
-
-    candidates, partials = [], []
-    for a in anns:
-        rows = (
-            db.query(TaskEvaluation.metrics)
-            .filter(TaskEvaluation.annotation_id == a.id)
-            .all()
-        )
-        present = set()
-        for (m,) in rows:
-            if _row_has_real_score_for(m, elig_metrics):
-                if isinstance(m, dict):
-                    present |= {k for k in m.keys() if k in elig_metrics}
-        if not present:
-            task = tasks_by_id.get(a.task_id)
-            if task is not None:
-                candidates.append((a, task))
-        elif present < elig_metrics:
-            partials.append((a, present, elig_metrics - present))
+    candidates, partials = scan_ungraded(db, project, cutoff=cutoff)
     return candidates, partials, eligible
 
 
 def _dispatch(db, project, eligible, annotation, task, apply: bool) -> str:
-    """Pre-create the immediate EvaluationRun + dispatch the worker task — the
-    exact shape the endpoint uses. Returns the new eval_record_id."""
-    eval_record_id = str(uuid.uuid4())
+    """Delegate to the shared, idempotent ``ensure_immediate_evaluation`` so the
+    CLI and every live trigger share one code path. Returns the run id."""
     if not apply:
-        return eval_record_id
-    annotation_results = _parse_annotation_results(annotation)
-    org = _resolve_org(db, project, annotation.completed_by)
-    meta = {
-        "evaluation_type": "immediate",
-        "trigger": "recover_missing_immediate_evals",
-        "expected_config_count": len(eligible),
-        "configs": [
-            {
-                "id": c.get("id", c.get("metric", "")),
-                "metric": c.get("metric", ""),
-                "display_name": c.get("display_name", c.get("metric", "")),
-            }
-            for c in eligible
-        ],
-    }
-    db.add(
-        EvaluationRun(
-            id=eval_record_id,
-            project_id=str(project.id),
-            model_id="immediate",
-            evaluation_type_ids=[c.get("metric", "") for c in eligible],
-            status="running",
-            created_by=str(annotation.completed_by),
-            eval_metadata=meta,
-            metrics={},
-        )
+        return str(uuid.uuid4())
+    rid = ensure_immediate_evaluation(
+        db,
+        project,
+        task,
+        annotation,
+        configs=eligible,
+        trigger="recover_missing_immediate_evals",
     )
-    db.commit()
-    send_task_safe(
-        "tasks.run_single_sample_evaluation",
-        kwargs={
-            "evaluation_record_id": eval_record_id,
-            "project_id": str(project.id),
-            "task_id": str(task.id),
-            "annotation_id": str(annotation.id),
-            "evaluation_configs": [dict(c) for c in eligible],
-            "annotation_results": annotation_results,
-            "task_data": task.data or {},
-            "organization_id": org,
-            "user_id": str(annotation.completed_by),
-        },
-        queue="celery",
-    )
-    return eval_record_id
+    return rid or str(uuid.uuid4())
 
 
 def main() -> int:

--- a/services/api/tests/unit/test_immediate_eval_dispatch.py
+++ b/services/api/tests/unit/test_immediate_eval_dispatch.py
@@ -1,0 +1,100 @@
+"""Pure-function unit tests for the shared immediate-eval dispatch helpers.
+
+Covers the DB-free logic of ``services/shared/immediate_eval_dispatch.py`` —
+annotation-result parsing, eligibility filtering, and the real-score detector.
+The DB-backed entry points (``ensure_immediate_evaluation``, ``scan_ungraded``)
+are exercised by the worker/integration suites; here we lock the pure helpers
+that every trigger (hook, worker, endpoint, sweep, CLI) shares.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from immediate_eval_dispatch import (
+    eligible_configs,
+    eligible_metrics,
+    parse_annotation_results,
+    row_has_real_score_for,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestParseAnnotationResults:
+    def test_textarea_and_string_and_choices(self):
+        ann = SimpleNamespace(
+            result=[
+                {"from_name": "loesung", "type": "textarea", "value": {"text": ["A", "B"]}},
+                {"from_name": "note", "value": "plain"},
+                {"from_name": "pick", "type": "choices", "value": {"choices": ["x"]}},
+                {"from_name": "md", "value": {"markdown": "# H"}},
+            ]
+        )
+        out = parse_annotation_results(ann)
+        assert out["loesung"] == "A\nB"
+        assert out["note"] == "plain"
+        assert out["pick"] == "x"
+        assert out["md"] == "# H"
+
+    def test_empty_or_non_list_result(self):
+        assert parse_annotation_results(SimpleNamespace(result=[])) == {}
+        assert parse_annotation_results(SimpleNamespace(result=None)) == {}
+
+    def test_skips_regions_without_from_name(self):
+        ann = SimpleNamespace(result=[{"type": "textarea", "value": {"text": ["x"]}}])
+        assert parse_annotation_results(ann) == {}
+
+
+class TestRowHasRealScoreFor:
+    def test_value_dict_counts(self):
+        assert row_has_real_score_for(
+            {"llm_judge_falloesung": {"value": 0.43}}, {"llm_judge_falloesung"}
+        )
+
+    def test_error_dict_does_not_count(self):
+        assert not row_has_real_score_for(
+            {"llm_judge_falloesung": {"error": "boom", "value": None}},
+            {"llm_judge_falloesung"},
+        )
+
+    def test_bare_float_counts(self):
+        assert row_has_real_score_for({"exact_match": 1.0}, {"exact_match"})
+
+    def test_bool_does_not_count_as_numeric(self):
+        assert not row_has_real_score_for({"exact_match": True}, {"exact_match"})
+
+    def test_missing_metric_and_non_dict(self):
+        assert not row_has_real_score_for({"other": 0.5}, {"exact_match"})
+        assert not row_has_real_score_for(None, {"exact_match"})
+
+
+class TestEligibleConfigs:
+    def test_filters_disabled_and_human_graded(self):
+        project = SimpleNamespace(
+            evaluation_config={
+                "evaluation_configs": [
+                    {"metric": "llm_judge_falloesung", "enabled": True},
+                    {"metric": "korrektur_falloesung", "enabled": True},   # human-graded → excluded
+                    {"metric": "exact_match", "enabled": False},           # disabled → excluded
+                    {"metric": "exact_match", "enabled": True},            # eligible
+                ]
+            }
+        )
+        cfgs = eligible_configs(project)
+        metrics = eligible_metrics(cfgs)
+        assert metrics == {"llm_judge_falloesung", "exact_match"}
+
+    def test_reads_legacy_multi_field_key(self):
+        project = SimpleNamespace(
+            evaluation_config={
+                "multi_field_evaluations": [
+                    {"metric": "llm_judge_falloesung", "enabled": True},
+                ]
+            }
+        )
+        assert eligible_metrics(eligible_configs(project)) == {"llm_judge_falloesung"}
+
+    def test_no_config_returns_empty(self):
+        assert eligible_configs(SimpleNamespace(evaluation_config=None)) == []
+        assert eligible_configs(SimpleNamespace(evaluation_config={})) == []

--- a/services/frontend/src/components/labeling/LabelingInterface.tsx
+++ b/services/frontend/src/components/labeling/LabelingInterface.tsx
@@ -862,19 +862,34 @@ export function LabelingInterface({ projectId }: LabelingInterfaceProps) {
                       return
                     }
 
+                    // Track the annotation for the eval slot BEFORE the
+                    // questionnaire branch (mirrors the manual-submit path).
+                    // Without this, a project with BOTH a questionnaire AND
+                    // immediate eval would return into the questionnaire with
+                    // lastSubmittedAnnotationId still null, so proceedAfterQuestionnaire
+                    // can't hand off and the KI-Votum never shows in-page on
+                    // auto-submit. (The grade is still produced server-side via
+                    // the on_annotation_created hook regardless; this only
+                    // restores the live in-page score for the present student.)
+                    if (shouldRunImmediate && annotation) {
+                      setLastSubmittedAnnotationId(annotation.id)
+                    }
+
                     // Questionnaire takes precedence: it's the explicit closure UX.
+                    // proceedAfterQuestionnaire hands off to the (now-tracked)
+                    // eval slot once the questionnaire closes.
                     if (hasQuestionnaire && annotation) {
                       setQuestionnaireAnnotationId(annotation.id)
                       setShowQuestionnaireModal(true)
                       return
                     }
 
-                    // Immediate eval: mount ImmediateEvalSlot via setLastSubmittedAnnotationId.
-                    // autoSubmittedRef tells the slot's onClose to advance once dismissed,
-                    // mirroring the old monolith's inline auto-submit-then-eval flow.
+                    // Immediate eval: ImmediateEvalSlot is mounted via the
+                    // setLastSubmittedAnnotationId above. autoSubmittedRef tells
+                    // the slot's onClose to advance once dismissed, mirroring the
+                    // old monolith's inline auto-submit-then-eval flow.
                     if (shouldRunImmediate && annotation) {
                       autoSubmittedRef.current = true
-                      setLastSubmittedAnnotationId(annotation.id)
                       return
                     }
 

--- a/services/shared/immediate_eval_dispatch.py
+++ b/services/shared/immediate_eval_dispatch.py
@@ -1,0 +1,366 @@
+"""Shared, idempotent server-side dispatch of immediate ("KI-Votum") evaluations.
+
+Immediate evaluation grades a single annotation right after it is submitted.
+Historically it was fired ONLY by the client — the labeling page POSTs
+``/immediate`` then polls. If that POST never landed (tab closed on a
+strict-timer auto-submit, a network blip, or a server-side auto-submit that
+never reaches the browser at all), the annotation got no grade and nothing ever
+retried it.
+
+``ensure_immediate_evaluation`` is the single, idempotent entry point that every
+server-side trigger calls so a grade is produced for *every* submit:
+  * ``on_annotation_created`` hook  — manual + client-present auto-submit,
+  * ``auto_submit_expired_timer`` worker — absent-student timer expiry,
+  * the ``/immediate`` endpoint — get-or-create; the present student polls it,
+  * the hourly ``sweep_missing_immediate_evals`` beat task — backstop,
+  * the ``recover_missing_immediate_evals`` CLI — one-off backfill.
+
+Exactly-once per annotation: a dispatch is skipped when the annotation already
+carries a real eligible-metric score OR a non-failed immediate ``EvaluationRun``
+already references it (matched via the ``annotation_id`` stamped into
+``eval_metadata``). Returns the ``EvaluationRun`` id (existing or new), or
+``None`` when the project has no eligible immediate config. Strictly additive —
+only INSERTs an ``EvaluationRun`` and dispatches a Celery task.
+
+This module lives in ``/shared`` so the api (hook, endpoint, CLI) and the
+workers (auto-submit, sweep) import the same logic. It avoids importing any
+api-only module at top level — the Celery dispatch is resolved lazily so it
+works in both the api and worker processes.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from metric_filters import is_immediate_eligible
+from models import EvaluationRun, OrganizationMembership, TaskEvaluation
+from project_models import Annotation, Task
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Eligibility + annotation-shape helpers (lifted from the recovery CLI so the
+# script and the live path share one definition).
+# --------------------------------------------------------------------------- #
+def eligible_configs(project) -> list:
+    """Enabled, immediate-eligible evaluation configs for a project.
+
+    Mirrors the ``/immediate`` endpoint's eligibility filter. Does NOT expand
+    the ``selected_methods`` shorthand (that derivation lives in an api-only
+    module); callers that need it — currently only the endpoint — compute their
+    own config list and pass it via ``configs=``.
+    """
+    cfg = project.evaluation_config or {}
+    configs = cfg.get("evaluation_configs") or cfg.get("multi_field_evaluations") or []
+    return [
+        c
+        for c in configs
+        if c.get("enabled", True) and is_immediate_eligible(c.get("metric", ""))
+    ]
+
+
+def eligible_metrics(configs) -> set:
+    return {c.get("metric", "") for c in configs}
+
+
+def row_has_real_score_for(metrics, elig_metrics: set) -> bool:
+    """True if a TaskEvaluation.metrics blob carries a non-error score for any
+    eligible metric."""
+    if not isinstance(metrics, dict):
+        return False
+    for m in elig_metrics:
+        if m not in metrics:
+            continue
+        v = metrics[m]
+        if isinstance(v, dict):
+            if v.get("error"):
+                continue
+            if v.get("value") is not None:
+                return True
+        elif isinstance(v, (int, float)) and not isinstance(v, bool):
+            return True
+    return False
+
+
+def parse_annotation_results(annotation) -> dict:
+    """annotation.result (Label-Studio regions) -> {from_name: value}. Identical
+    shape handling to the ``/immediate`` endpoint."""
+    out: dict = {}
+    res = annotation.result
+    if not (res and isinstance(res, list)):
+        return out
+    for region in res:
+        if not isinstance(region, dict):
+            continue
+        from_name = region.get("from_name")
+        if not from_name:
+            continue
+        value = region.get("value", {})
+        region_type = region.get("type", "")
+        if isinstance(value, str):
+            out[from_name] = value
+            continue
+        if isinstance(value, dict) and "markdown" in value:
+            out[from_name] = value["markdown"]
+            continue
+        if region_type == "textarea":
+            texts = value.get("text", [])
+            out[from_name] = "\n".join(texts) if isinstance(texts, list) else str(texts)
+        elif region_type == "choices":
+            choices = value.get("choices", [])
+            out[from_name] = choices[0] if len(choices) == 1 else choices
+        elif region_type == "rating":
+            out[from_name] = value.get("rating")
+        elif "text" in value:
+            texts = value["text"]
+            out[from_name] = "\n".join(texts) if isinstance(texts, list) else str(texts)
+        else:
+            for v in value.values():
+                if v:
+                    out[from_name] = v if isinstance(v, str) else str(v)
+                    break
+    return out
+
+
+def resolve_org(db, project, user_id) -> Optional[str]:
+    """Org to attribute the run to — the submitter's membership in one of the
+    project's orgs, else the project's first org. Mirrors
+    ``resolve_user_org_for_project`` without importing the api router."""
+    if not project.organizations:
+        return None
+    org_ids = {str(o.id) for o in project.organizations}
+    m = (
+        db.query(OrganizationMembership)
+        .filter(
+            OrganizationMembership.user_id == user_id,
+            OrganizationMembership.is_active == True,  # noqa: E712
+            OrganizationMembership.organization_id.in_(org_ids),
+        )
+        .first()
+    )
+    if m:
+        return str(m.organization_id)
+    return str(project.organizations[0].id)
+
+
+# --------------------------------------------------------------------------- #
+# Idempotency lookups.
+# --------------------------------------------------------------------------- #
+def _graded_run_id(db, annotation_id, elig_metrics: set) -> Optional[str]:
+    """If the annotation already has a real eligible-metric grade, return the
+    EvaluationRun id that produced it (so callers can surface the existing
+    result), else None."""
+    rows = (
+        db.query(TaskEvaluation.evaluation_id, TaskEvaluation.metrics)
+        .filter(TaskEvaluation.annotation_id == annotation_id)
+        .all()
+    )
+    for run_id, m in rows:
+        if row_has_real_score_for(m, elig_metrics):
+            return str(run_id) if run_id else None
+    return None
+
+
+def scan_ungraded(db, project, *, cutoff=None):
+    """Find annotations on ``project`` that have no eligible immediate grade.
+
+    Returns ``(candidates, partials)`` where:
+      * ``candidate``  = ``(annotation, task)`` with ZERO eligible real-score rows,
+      * ``partial``    = ``(annotation, present_metrics, missing_metrics)``,
+        reported only (re-dispatching risks duplicating the present metric).
+
+    ``cutoff`` (a tz-aware datetime) excludes submits newer than it so an
+    in-flight client eval isn't raced. Shared by the recovery CLI and the
+    hourly sweep so both agree on what "ungraded" means.
+    """
+    cfgs = eligible_configs(project)
+    if not cfgs:
+        return [], []
+    elig = eligible_metrics(cfgs)
+
+    q = db.query(Annotation).filter(
+        Annotation.project_id == project.id,
+        Annotation.was_cancelled == False,  # noqa: E712
+        Annotation.result.isnot(None),
+    )
+    if cutoff is not None:
+        q = q.filter(Annotation.created_at < cutoff)
+    anns = q.all()
+    if not anns:
+        return [], []
+
+    tasks_by_id = {
+        t.id: t
+        for t in db.query(Task).filter(Task.id.in_({a.task_id for a in anns})).all()
+    }
+    candidates, partials = [], []
+    for a in anns:
+        rows = (
+            db.query(TaskEvaluation.metrics)
+            .filter(TaskEvaluation.annotation_id == a.id)
+            .all()
+        )
+        present = set()
+        for (m,) in rows:
+            if row_has_real_score_for(m, elig):
+                if isinstance(m, dict):
+                    present |= {k for k in m.keys() if k in elig}
+        if not present:
+            task = tasks_by_id.get(a.task_id)
+            if task is not None:
+                candidates.append((a, task))
+        elif present < elig:
+            partials.append((a, present, elig - present))
+    return candidates, partials
+
+
+def _existing_immediate_run(db, project_id, annotation):
+    """A non-failed immediate EvaluationRun already created for this annotation,
+    else None. ``eval_metadata`` is a generic JSON column, so we filter in
+    Python over the submitter's own immediate runs (a handful — keyed by
+    ``created_by`` to keep the scan cheap during a large exam)."""
+    runs = (
+        db.query(EvaluationRun)
+        .filter(
+            EvaluationRun.project_id == str(project_id),
+            EvaluationRun.model_id == "immediate",
+            EvaluationRun.created_by == str(annotation.completed_by),
+            EvaluationRun.status != "failed",
+        )
+        .order_by(EvaluationRun.created_at.desc())
+        .limit(50)
+        .all()
+    )
+    aid = str(annotation.id)
+    for r in runs:
+        meta = r.eval_metadata or {}
+        if isinstance(meta, dict) and str(meta.get("annotation_id")) == aid:
+            return r
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Portable Celery dispatch (api: send_task_safe; worker: worker_celery.app).
+# --------------------------------------------------------------------------- #
+def _dispatch_task(task_name: str, kwargs: dict, queue: str):
+    try:
+        from celery_client import send_task_safe  # api process
+
+        return send_task_safe(task_name, kwargs=kwargs, queue=queue)
+    except Exception:
+        pass
+    try:
+        from worker_celery import app as _app  # worker process
+
+        return _app.send_task(task_name, kwargs=kwargs, queue=queue)
+    except Exception:
+        from celery import current_app
+
+        return current_app.send_task(task_name, kwargs=kwargs, queue=queue)
+
+
+# --------------------------------------------------------------------------- #
+# The single entry point.
+# --------------------------------------------------------------------------- #
+def ensure_immediate_evaluation(
+    db,
+    project,
+    task,
+    annotation,
+    *,
+    user_id=None,
+    configs=None,
+    trigger: str = "annotation_submit",
+    min_age_minutes: int = 0,
+) -> Optional[str]:
+    """Idempotently ensure an immediate evaluation exists for ``annotation``.
+
+    Returns the EvaluationRun id (existing grade's run, an in-flight run, or a
+    newly-dispatched one), or ``None`` when there is nothing eligible to grade
+    (or, with ``min_age_minutes`` set, when the submit is too recent to act on).
+    """
+    cfgs = configs if configs is not None else eligible_configs(project)
+    if not cfgs:
+        return None
+    elig = eligible_metrics(cfgs)
+
+    # Already graded → never re-dispatch; surface the grading run.
+    graded = _graded_run_id(db, annotation.id, elig)
+    if graded is not None:
+        return graded
+
+    # A run is already in flight for this annotation → attach to it.
+    existing = _existing_immediate_run(db, project.id, annotation)
+    if existing is not None:
+        return str(existing.id)
+
+    # Sweep/backfill only: don't race an in-flight client eval on a fresh submit.
+    if min_age_minutes:
+        created = getattr(annotation, "created_at", None)
+        if created is not None:
+            cutoff = datetime.now(timezone.utc) - timedelta(minutes=min_age_minutes)
+            try:
+                if created > cutoff:
+                    return None
+            except TypeError:
+                # naive vs aware datetime — be permissive and proceed.
+                pass
+
+    user = str(user_id or annotation.completed_by)
+    eval_record_id = str(uuid.uuid4())
+    meta = {
+        "evaluation_type": "immediate",
+        "trigger": trigger,
+        # annotation_id makes get-or-create race-free across hook/endpoint/worker.
+        "annotation_id": str(annotation.id),
+        "expected_config_count": len(cfgs),
+        "configs": [
+            {
+                "id": c.get("id", c.get("metric", "")),
+                "metric": c.get("metric", ""),
+                "display_name": c.get("display_name", c.get("metric", "")),
+            }
+            for c in cfgs
+        ],
+    }
+    db.add(
+        EvaluationRun(
+            id=eval_record_id,
+            project_id=str(project.id),
+            model_id="immediate",
+            evaluation_type_ids=[c.get("metric", "") for c in cfgs],
+            status="running",
+            created_by=user,
+            eval_metadata=meta,
+            metrics={},
+        )
+    )
+    db.commit()
+
+    _dispatch_task(
+        "tasks.run_single_sample_evaluation",
+        {
+            "evaluation_record_id": eval_record_id,
+            "project_id": str(project.id),
+            "task_id": str(task.id),
+            "annotation_id": str(annotation.id),
+            "evaluation_configs": [dict(c) for c in cfgs],
+            "annotation_results": parse_annotation_results(annotation),
+            "task_data": task.data or {},
+            "organization_id": resolve_org(db, project, annotation.completed_by),
+            "user_id": user,
+        },
+        "celery",
+    )
+    logger.info(
+        "[immediate-eval] dispatched run=%s annotation=%s trigger=%s metrics=%s",
+        eval_record_id,
+        annotation.id,
+        trigger,
+        sorted(elig),
+    )
+    return eval_record_id

--- a/services/shared/immediate_eval_dispatch.py
+++ b/services/shared/immediate_eval_dispatch.py
@@ -341,21 +341,42 @@ def ensure_immediate_evaluation(
     )
     db.commit()
 
-    _dispatch_task(
-        "tasks.run_single_sample_evaluation",
-        {
-            "evaluation_record_id": eval_record_id,
-            "project_id": str(project.id),
-            "task_id": str(task.id),
-            "annotation_id": str(annotation.id),
-            "evaluation_configs": [dict(c) for c in cfgs],
-            "annotation_results": parse_annotation_results(annotation),
-            "task_data": task.data or {},
-            "organization_id": resolve_org(db, project, annotation.completed_by),
-            "user_id": user,
-        },
-        "celery",
-    )
+    try:
+        _dispatch_task(
+            "tasks.run_single_sample_evaluation",
+            {
+                "evaluation_record_id": eval_record_id,
+                "project_id": str(project.id),
+                "task_id": str(task.id),
+                "annotation_id": str(annotation.id),
+                "evaluation_configs": [dict(c) for c in cfgs],
+                "annotation_results": parse_annotation_results(annotation),
+                "task_data": task.data or {},
+                "organization_id": resolve_org(db, project, annotation.completed_by),
+                "user_id": user,
+            },
+            "celery",
+        )
+    except Exception:
+        # The run row is already committed as "running". If the dispatch itself
+        # failed (broker down), leaving it "running" would make
+        # `_existing_immediate_run` treat it as in-flight forever and block the
+        # hourly sweep from ever retrying this annotation. Flip it to "failed"
+        # so recovery picks it up, then re-raise for the caller to log.
+        try:
+            stuck = (
+                db.query(EvaluationRun)
+                .filter(EvaluationRun.id == eval_record_id)
+                .first()
+            )
+            if stuck is not None:
+                stuck.status = "failed"
+                stuck.error_message = "immediate-eval dispatch failed"
+                db.commit()
+        except Exception:
+            db.rollback()
+        raise
+
     logger.info(
         "[immediate-eval] dispatched run=%s annotation=%s trigger=%s metrics=%s",
         eval_record_id,

--- a/services/workers/tasks.py
+++ b/services/workers/tasks.py
@@ -3327,9 +3327,9 @@ def finalize_evaluation_run(
 def recompute_aggregates(self):
     """Refresh the precomputed leaderboard + project-summary tables.
 
-    Runs every 12h via beat (see `app.conf.beat_schedule` above) and can be
-    triggered ad-hoc. Coalesces concurrent runs with a Redis lock so a burst
-    of triggers collapses to a single execution.
+    Runs hourly via beat (see `app.conf.beat_schedule`) and can be triggered
+    ad-hoc. Coalesces concurrent runs with a Redis lock so a burst of triggers
+    collapses to a single execution.
 
     The heavy SQL lives in `services/api/services/aggregate_summaries.py`;
     this is the Celery entry point. Total wall time on prod-scale data
@@ -3401,6 +3401,69 @@ def recompute_aggregates(self):
                 rc.delete(lock_key)
             except Exception:
                 pass
+
+
+@app.task(name="tasks.sweep_missing_immediate_evals", bind=True)
+def sweep_missing_immediate_evals(self, min_age_minutes: int = 15):
+    """Hourly server-side backstop for the client-fired KI-Votum.
+
+    Immediate evaluation is normally produced on submit (the on_annotation_created
+    hook, the strict-timer auto-submit worker, or the client POST). This sweep is
+    the last safety net: it scans every immediate-eval project and re-dispatches a
+    grade for any annotation that still has none (lost client POST, worker crash,
+    etc.). Idempotent — ``ensure_immediate_evaluation`` skips annotations that
+    already carry a grade or an in-flight run. ``min_age_minutes`` skips very
+    recent submits (via the scan cutoff) so an in-flight client eval isn't raced.
+    """
+    from datetime import datetime as _dt
+    from datetime import timedelta, timezone
+
+    from immediate_eval_dispatch import ensure_immediate_evaluation, scan_ungraded
+    from project_models import Project
+
+    db = SessionLocal()
+    cutoff = _dt.now(timezone.utc) - timedelta(minutes=min_age_minutes)
+    scanned_projects = dispatched = 0
+    try:
+        projects = (
+            db.query(Project)
+            .filter(Project.immediate_evaluation_enabled == True)  # noqa: E712
+            .all()
+        )
+        for project in projects:
+            candidates, _partials = scan_ungraded(db, project, cutoff=cutoff)
+            if not candidates:
+                continue
+            scanned_projects += 1
+            for annotation, task in candidates:
+                try:
+                    # cutoff already applied in scan_ungraded → no min-age here.
+                    rid = ensure_immediate_evaluation(
+                        db, project, task, annotation,
+                        trigger="sweep_missing_immediate_evals",
+                    )
+                    if rid:
+                        dispatched += 1
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "sweep_missing_immediate_evals: annotation %s failed: %s",
+                        annotation.id, exc,
+                    )
+                    db.rollback()
+        logger.info(
+            "sweep_missing_immediate_evals: projects_with_gaps=%d dispatched=%d",
+            scanned_projects, dispatched,
+        )
+        return {"status": "success", "projects_with_gaps": scanned_projects, "dispatched": dispatched}
+    except Exception as exc:
+        logger.error("sweep_missing_immediate_evals failed: %s", exc, exc_info=True)
+        try:
+            db.rollback()
+        except Exception:
+            pass
+        return {"status": "error", "error": str(exc)}
+    finally:
+        db.close()
 
 
 @app.task(name="tasks.update_report_annotations_async", bind=True)

--- a/services/workers/worker_celery.py
+++ b/services/workers/worker_celery.py
@@ -34,21 +34,32 @@ app = Celery("tasks")
 # - 12h (initial): cheap, occasionally stale tiles after annotation rounds.
 # - 1h (2026-05-20): tightened after Phase 6.2 routed the projects list
 #   through project_summaries; users complained tiles lagged half a day.
-# - 2x/day at 10:00 + 22:00 UTC (= 12:00 + 00:00 CEST) (this PR): leaderboards
-#   are a research-grade scorecard, not a live tile — a noticeable user
-#   refresh window is the right contract. Hourly runs were also adding
-#   load without value once the leaderboards moved to TanStack-cached
-#   reads with 30s staleTime on the client. Note: during winter (CET) the
-#   runs effectively become 11:00 + 23:00 local; the leaderboards page
-#   shows a static hint that copy-locks the schedule to CEST.
+# - 2x/day at 10:00 + 22:00 UTC (2026-06): leaderboards treated as a slow
+#   scorecard; the projects-list tile counts (annotations / evaluations) then
+#   lagged up to 12h behind reality, which read as "evaluations missing".
+# - 1h (top of every hour): back to hourly so the projects list reflects an
+#   in-progress exam within the hour. The recompute is cheap relative to the
+#   confusion a half-day-stale count causes during live annotation rounds.
 #
-# Event-driven recompute on EvaluationRun finalize was also removed in
-# the same change (search for `recompute_aggregates_after_finalize` — the
-# `app.send_task` call in the finalize handler is gone).
+# `sweep-missing-immediate-evals`: hourly server-side backstop for the
+# client-fired KI-Votum. Any annotation on an immediate-eval project that ends
+# up without a grade (lost client POST, server auto-submit, worker crash) is
+# re-dispatched via the idempotent ensure_immediate_evaluation. `min_age_minutes`
+# skips very recent submits so an in-flight client eval isn't raced.
+#
+# Event-driven recompute on EvaluationRun finalize was removed earlier
+# (search for `recompute_aggregates_after_finalize`).
 app.conf.beat_schedule = {
     "recompute-aggregates": {
         "task": "tasks.recompute_aggregates",
-        "schedule": crontab(minute=0, hour="10,22"),
+        "schedule": crontab(minute=0),
+        "args": (),
+        "kwargs": {},
+        "options": {"queue": "default"},
+    },
+    "sweep-missing-immediate-evals": {
+        "task": "tasks.sweep_missing_immediate_evals",
+        "schedule": crontab(minute=30),
         "args": (),
         "kwargs": {},
         "options": {"queue": "default"},


### PR DESCRIPTION
## Why

On prod, the exam project *Probeklausur im Strafrecht BT I* had 263 annotations but only ~135 evaluated. **Immediate evaluation ("KI-Votum") is fired only by the client** (the labeling page POSTs `/immediate`), with no server-side fallback — so when a student closed the tab before the 2.5h strict timer expired, a server-side worker submitted their draft but **never graded it** (~128 ungraded). Two related display/freshness issues compounded it: human/annotator LLM-judge scores rendered **N/A** on the Evaluations page, and the projects-list counts lagged up to 12h behind reality.

## What

- **Shared idempotent dispatcher** — `services/shared/immediate_eval_dispatch.py::ensure_immediate_evaluation()`: get-or-create + dispatch of `run_single_sample_evaluation` for one annotation (the `annotation_id` is stamped into `eval_metadata`, making get-or-create race-free). Reused by the extended hook/worker/endpoint (separate PR), the new sweep task, and `recover_missing_immediate_evals.py` (now delegates to it). `scan_ungraded()` is shared by the CLI + sweep.
- **Human-score display (the N/A)** — `multi_field/results.py` now parses the 2-part `"pred_field|metric"` run-level key (e.g. `human:loesung|llm_judge_falloesung`) instead of dropping it, and coerces the `{value,…}` shape; `metadata/models_methods.py` attaches `model_id="immediate"` run scores to the synthetic `annotator:<name>` rows. (`by_task_model.py` already surfaced them — verified.)
- **Hourly beat + sweep** — `recompute-aggregates` runs hourly (was 10:00/22:00 UTC) so the projects list reflects an in-progress exam; new `sweep_missing_immediate_evals` beat task backstops any annotation left ungraded.
- **Labeling client fix** — auto-submit now sets `lastSubmittedAnnotationId` before the questionnaire branch (mirrors the manual path) so the in-page KI-Votum shows after a questionnaire.

## Validation

- `ruff check --select=F821,F823` (the CI lint) passes; helper pure-function logic unit-tested + verified.
- Full API + workers suites run in the merge gate.
- The one-time backfill (`recover_missing_immediate_evals.py --project-id … --apply`) has **already been run on prod**: 72 content-bearing annotations graded; the remaining 58 are empty / highlight-only submissions with no solution to grade.

## Sequencing

Merge this first. The extended PR (`fix/immediate-eval-reliability`) wires the hook/worker/endpoint to this helper and must build against this in `main`. `CORE_API_VERSION` unchanged (2.2).