### PR TITLE
fix(annotations): stop strict-timer duplicate submissions; fix counts

### DIFF
--- a/services/api/routers/evaluations/results/by_task_model.py
+++ b/services/api/routers/evaluations/results/by_task_model.py
@@ -190,7 +190,10 @@ async def get_results_by_task_model(
                     )
                     .label("rn"),
                 )
-                .where(Annotation.completed_by.isnot(None))
+                .where(
+                    Annotation.completed_by.isnot(None),
+                    Annotation.was_cancelled == False,  # noqa: E712
+                )
                 .subquery()
             )
             latest_ann_ids = (
@@ -687,6 +690,7 @@ async def get_project_results_by_task_model(
                 )
                 .where(
                     Annotation.completed_by.isnot(None),
+                    Annotation.was_cancelled == False,  # noqa: E712
                     Annotation.task_id.in_(select(project_task_ids.c.id)),
                 )
                 .subquery()

--- a/services/api/routers/projects/annotations.py
+++ b/services/api/routers/projects/annotations.py
@@ -50,6 +50,41 @@ async def create_annotation(
     if project and not check_task_assigned_to_user(db, current_user, task_id, project):
         raise HTTPException(status_code=404, detail="Task not found")
 
+    # ---- Duplicate-submit guard (strict-timer race + auto-then-manual) ------
+    # A strict-timer task has two writers: the client auto-submit (this
+    # endpoint) AND the server-side timer worker (auto_submit_expired_timer),
+    # plus a manual submit can land after an auto-submit. Without coordination
+    # they each INSERT a near-identical row, so one student ends up with 2-4
+    # duplicate annotations on a single task (each then graded -> wasted tokens).
+    # Serialize concurrent submits for the SAME (task, user) with a
+    # transaction-scoped advisory lock (the worker takes the same lock), then,
+    # if an active annotation already exists, UPDATE it in place so the latest
+    # content wins and there is exactly one annotation per (task, user).
+    # Scoped to strict-timer projects: that is the only place the duplicate
+    # race exists (the server-side auto_submit_expired_timer worker runs only
+    # for strict timers), so non-timer annotation behavior is unchanged.
+    existing_annotation = None
+    if (
+        not (annotation.was_cancelled or False)
+        and getattr(project, "strict_timer_enabled", False)
+    ):
+        from sqlalchemy import text as _sql_text
+
+        db.execute(
+            _sql_text("SELECT pg_advisory_xact_lock(hashtext(:k))"),
+            {"k": f"annsubmit:{task_id}:{current_user.id}"},
+        )
+        existing_annotation = (
+            db.query(Annotation)
+            .filter(
+                Annotation.task_id == task_id,
+                Annotation.completed_by == current_user.id,
+                Annotation.was_cancelled == False,  # noqa: E712
+            )
+            .order_by(Annotation.created_at.desc())
+            .first()
+        )
+
     # Generate annotation ID
     import uuid
 
@@ -65,26 +100,41 @@ async def create_annotation(
                 ai_assisted = variant.get("ai_allowed", False)
                 break
 
-    # Create annotation
-    db_annotation = Annotation(
-        id=annotation_id,
-        task_id=task_id,  # Already a string now
-        project_id=task.project_id,
-        completed_by=current_user.id,
-        result=annotation.result,
-        draft=annotation.draft,
-        was_cancelled=annotation.was_cancelled or False,
-        lead_time=server_lead_time,
-        # Enhanced timing (Issue #1208)
-        active_duration_ms=annotation.active_duration_ms,
-        focused_duration_ms=annotation.focused_duration_ms,
-        tab_switches=annotation.tab_switches or 0,
-        instruction_variant=annotation.instruction_variant,
-        ai_assisted=ai_assisted,
-    )
+    # Create the annotation — or, when a duplicate submit lands, update the
+    # existing one in place (latest content wins, no second row).
+    if existing_annotation is not None:
+        db_annotation = existing_annotation
+        db_annotation.result = annotation.result
+        db_annotation.draft = annotation.draft
+        db_annotation.lead_time = server_lead_time
+        db_annotation.active_duration_ms = annotation.active_duration_ms
+        db_annotation.focused_duration_ms = annotation.focused_duration_ms
+        db_annotation.tab_switches = annotation.tab_switches or 0
+        db_annotation.instruction_variant = annotation.instruction_variant
+        db_annotation.ai_assisted = ai_assisted
+        db_annotation.auto_submitted = annotation.auto_submitted or False
+    else:
+        db_annotation = Annotation(
+            id=annotation_id,
+            task_id=task_id,  # Already a string now
+            project_id=task.project_id,
+            completed_by=current_user.id,
+            result=annotation.result,
+            draft=annotation.draft,
+            was_cancelled=annotation.was_cancelled or False,
+            lead_time=server_lead_time,
+            # Enhanced timing (Issue #1208)
+            active_duration_ms=annotation.active_duration_ms,
+            focused_duration_ms=annotation.focused_duration_ms,
+            tab_switches=annotation.tab_switches or 0,
+            instruction_variant=annotation.instruction_variant,
+            ai_assisted=ai_assisted,
+        )
 
-    # Enforce maximum annotations limit (if not a cancelled annotation)
-    if not annotation.was_cancelled and annotation.result and len(annotation.result) > 0:
+    # Enforce maximum annotations limit (if not a cancelled annotation).
+    # Skipped on the update-in-place path — it reuses the student's existing
+    # row, so it cannot push the task over its annotation limit.
+    if existing_annotation is None and not annotation.was_cancelled and annotation.result and len(annotation.result) > 0:
         # Count existing non-cancelled annotations for this task
         existing_annotations = (
             db.query(Annotation)
@@ -105,8 +155,10 @@ async def create_annotation(
                 detail=f"Maximum annotations limit reached ({project.maximum_annotations}). Cannot add more annotations to this task.",
             )
 
-    # Update task counters for submitted annotations (those with actual results)
-    if annotation.result and len(annotation.result) > 0:
+    # Update task counters for submitted annotations (those with actual
+    # results). Only on a NEW row — the update-in-place path adds no annotation,
+    # so the counters must not move.
+    if existing_annotation is None and annotation.result and len(annotation.result) > 0:
         # total_annotations = ALL completed annotations (cancelled + not cancelled)
         task.total_annotations += 1
 
@@ -134,7 +186,8 @@ async def create_annotation(
     # Task completion status is tracked on the task itself
     # No need to update project-level counter as it's calculated dynamically
 
-    db.add(db_annotation)
+    if existing_annotation is None:
+        db.add(db_annotation)
 
     # Clear server-side draft now that annotation is submitted
     from project_models import TaskDraft

--- a/services/api/tests/integration/test_annotations_integration.py
+++ b/services/api/tests/integration/test_annotations_integration.py
@@ -200,6 +200,82 @@ class TestCreateAnnotation:
         assert data["task_id"] == tasks[0].id
         assert data["result"] is not None
 
+    def test_strict_timer_duplicate_submit_updates_in_place(
+        self, client, test_db, test_users, auth_headers, test_org
+    ):
+        """On a strict-timer project, a second submit for the same (task, user)
+        — the client/worker auto-submit race or an auto-then-manual submit —
+        UPDATES the one annotation (latest content wins) instead of inserting a
+        duplicate row."""
+        project = Project(
+            id=_uid(), title="Timer Dup", created_by=test_users[0].id,
+            label_config='<View><Text name="text" value="$text"/></View>',
+            assignment_mode="open", maximum_annotations=10, min_annotations_per_task=1,
+            strict_timer_enabled=True,
+        )
+        test_db.add(project)
+        test_db.flush()
+        test_db.add(ProjectOrganization(
+            id=_uid(), project_id=project.id, organization_id=test_org.id,
+            assigned_by=test_users[0].id,
+        ))
+        task = Task(id=_uid(), project_id=project.id, data={"text": "sv"},
+                    inner_id=1, created_by=test_users[0].id)
+        test_db.add(task)
+        test_db.commit()
+
+        hdr = {**auth_headers["admin"], "X-Organization-Context": test_org.id}
+        url = f"/api/projects/tasks/{task.id}/annotations"
+        r1 = client.post(url, json={
+            "result": [{"from_name": "text", "to_name": "text", "type": "textarea",
+                        "value": {"text": ["short auto"]}}],
+            "auto_submitted": True,
+        }, headers=hdr)
+        r2 = client.post(url, json={
+            "result": [{"from_name": "text", "to_name": "text", "type": "textarea",
+                        "value": {"text": ["full manual answer"]}}],
+            "auto_submitted": False,
+        }, headers=hdr)
+        assert r1.status_code == 200, r1.text
+        assert r2.status_code == 200, r2.text
+
+        test_db.expire_all()
+        anns = (
+            test_db.query(Annotation)
+            .filter(Annotation.task_id == task.id,
+                    Annotation.completed_by == test_users[0].id,
+                    Annotation.was_cancelled == False)  # noqa: E712
+            .all()
+        )
+        assert len(anns) == 1, "duplicate submit must update in place, not insert"
+        assert "full manual answer" in str(anns[0].result), "latest content wins"
+        assert anns[0].auto_submitted is False
+        assert r1.json()["id"] == r2.json()["id"]
+        # counter must not double-count the in-place update
+        test_db.refresh(task)
+        assert task.total_annotations == 1
+
+    def test_non_timer_project_does_not_dedup(
+        self, client, test_db, test_users, auth_headers, test_org
+    ):
+        """Non-timer projects keep the prior behavior — the dedup guard is scoped
+        to strict-timer projects, so this path is unchanged."""
+        project, tasks = _setup(test_db, test_users[0], test_org)
+        hdr = {**auth_headers["admin"], "X-Organization-Context": test_org.id}
+        url = f"/api/projects/tasks/{tasks[0].id}/annotations"
+        body = {"result": [{"from_name": "text", "to_name": "text", "type": "textarea",
+                            "value": {"text": ["a"]}}]}
+        assert client.post(url, json=body, headers=hdr).status_code == 200
+        assert client.post(url, json=body, headers=hdr).status_code == 200
+        test_db.expire_all()
+        n = (
+            test_db.query(Annotation)
+            .filter(Annotation.task_id == tasks[0].id,
+                    Annotation.completed_by == test_users[0].id)
+            .count()
+        )
+        assert n == 2  # no dedup on non-timer projects
+
     def test_create_annotation_task_not_found(self, client, test_db, test_users, auth_headers, test_org):
         resp = client.post(
             "/api/projects/tasks/nonexistent-task/annotations",

--- a/services/shared/aggregate_summaries.py
+++ b/services/shared/aggregate_summaries.py
@@ -35,7 +35,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
-from sqlalchemy import cast, func, select, text
+from sqlalchemy import cast, func, or_, select, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -273,12 +273,19 @@ def _count_eval_pairs(db: Session, project_id: str, cutoff: Optional[datetime]) 
         )
         .select_from(TaskEvaluation)
         .join(EvaluationRun, EvaluationRun.id == TaskEvaluation.evaluation_id)
+        # Exclude grades whose annotation was soft-cancelled (e.g. deduped
+        # strict-timer copies), so the count reflects real, active submissions.
+        .outerjoin(Annotation, Annotation.id == TaskEvaluation.annotation_id)
         .where(
             EvaluationRun.project_id == project_id,
             EvaluationRun.status == "completed",
             subject_expr.isnot(None),
             TaskEvaluation.metrics.isnot(None),
             func.jsonb_typeof(metrics_jsonb) == "object",
+            or_(
+                TaskEvaluation.annotation_id.is_(None),
+                Annotation.was_cancelled == False,  # noqa: E712
+            ),
         )
         .distinct()
     )


### PR DESCRIPTION
## Why
On strict-timer exams, a single student ends up with **2–4 duplicate annotation rows** for one task. The client auto-submit (POST /annotations) and the server-side `auto_submit_expired_timer` worker both insert when the timer expires (a race), and a manual submit can land after an auto-submit. Each duplicate then gets its own KI-Votum → **inflated counts + wasted LLM tokens** (~69 wasted grades / ~1.27M tokens on the last Probeklausur). With the new server-side eval grading *every* submission, this compounds.

## What
- **`create_annotation`** (scoped to `strict_timer_enabled` projects only — that's the only place the race exists, so non-timer behavior is untouched): take a transaction-scoped `pg_advisory_xact_lock` on `(task, user)`; if an active annotation already exists, **UPDATE it in place (latest content wins)** instead of inserting a duplicate. Limit check + task counters skip the in-place path.
- **`auto_submit_expired_timer`** (extended PR): takes the *same* advisory lock before its existing-annotation check, so the worker can't race the client's not-yet-committed insert.
- **`_count_eval_pairs`**: exclude grades on soft-cancelled annotations → the projects-card "Evaluations" count reflects real active submissions (not deduped copies).
- **`by_task_model` `latest_ann`**: exclude cancelled so the per-student "latest" never resolves to a deduped copy.

## Data cleanup (already done, separately)
The 124 existing duplicates on *Probeklausur im Strafrecht BT I* were **soft-cancelled** (kept each student's graded, most-complete, latest answer; backup table `annotation_dedup_backup_20260630`, reversible). Verified: table shows 147 scored / 0 N/A. Benchathon’s research data was **not** touched.

## Tests
Strict-timer dedup-in-place (latest content wins, one row, counters not double-moved) + non-timer-unchanged.

## Sequencing
Merge platform first, then the extended PR (`fix/annotation-dedup-race`). No `CORE_API_VERSION` change; the two sides only share the advisory-lock key convention `annsubmit:<task>:<user>`.