### PR TITLE
fix(annotations): guarantee one active annotation per task+user (dup race root cause)

### DIFF
--- a/services/api/alembic/versions/064_annotation_active_unique_index.py
+++ b/services/api/alembic/versions/064_annotation_active_unique_index.py
@@ -1,0 +1,130 @@
+"""one active annotation per (task, user): partial unique index
+
+Strict-timer exam tasks have two concurrent writers for the same (task, user):
+the client auto-submit (``POST /annotations`` -> ``create_annotation``) and the
+server-side timer worker (``tasks.auto_submit_expired_timer``). They were
+coordinated only by a transaction-scoped advisory lock, which turned out to be
+fragile: the worker task name ``tasks.auto_submit_expired_timer`` is registered
+by BOTH the platform ``tasks.py`` (no lock) and the extended overlay's
+``register_tasks`` (locked), and which implementation wins at worker startup —
+and therefore whether the lock is taken at all — is non-deterministic. When the
+unlocked implementation wins, the worker races the client and both INSERT a row,
+so a single student ends up with 2+ duplicate annotations (each then graded ->
+wasted tokens, inflated counts).
+
+This adds the DB-level guarantee the advisory lock couldn't reliably provide: a
+partial unique index over ``(task_id, completed_by)`` where ``was_cancelled =
+false``. The second concurrent INSERT now fails with IntegrityError, which both
+writers catch and resolve (the endpoint updates the surviving row in place —
+latest content wins; the worker treats it as "client beat us" and skips).
+Partial on ``was_cancelled = false`` so a withdrawn annotation never blocks a
+legitimate resubmit.
+
+Before creating the index we dedup any pre-existing duplicates so the unique
+constraint can be built: keep the richest row per (task, user) (most grades,
+then longest result, then newest), reassign the duplicates' unique
+``(evaluation_id, field_name)`` task_evaluations onto the kept row (preserving
+multi-run grading data — this matters for research projects like Benchathon),
+drop the now-redundant grades, and soft-cancel the duplicate annotations.
+
+Idempotent — ``CREATE UNIQUE INDEX IF NOT EXISTS`` + the dedup only touches rows
+that are still duplicated, so re-running is a no-op.
+
+Revision ID: 064_annotation_active_unique_index
+Revises: 063_generation_pause_resume_retry
+Create Date: 2026-06-30
+"""
+
+from sqlalchemy import inspect
+
+from alembic import op
+
+
+revision = "064_annotation_active_unique_index"
+down_revision = "063_generation_pause_resume_retry"
+branch_labels = None
+depends_on = None
+
+
+INDEX_NAME = "uq_annotations_active_task_user"
+
+# Rank duplicates: per (task, completed_by), rn=1 is the row we keep (most
+# grades, then longest result, then newest); rn>1 are the duplicates to fold in.
+_RANKED = """
+    WITH ranked AS (
+        SELECT a.id, a.task_id, a.completed_by,
+               row_number() OVER (
+                   PARTITION BY a.task_id, a.completed_by
+                   ORDER BY (SELECT count(*) FROM task_evaluations te
+                             WHERE te.annotation_id = a.id) DESC,
+                            length(a.result::text) DESC,
+                            a.created_at DESC
+               ) AS rn
+        FROM annotations a
+        WHERE a.was_cancelled = false AND a.completed_by IS NOT NULL
+    ),
+    keep AS (
+        SELECT task_id, completed_by, id AS keep_id FROM ranked WHERE rn = 1
+    ),
+    dup AS (
+        SELECT r.id AS dup_id, k.keep_id
+        FROM ranked r JOIN keep k USING (task_id, completed_by)
+        WHERE r.rn > 1
+    )
+"""
+
+
+def _index_exists() -> bool:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    return INDEX_NAME in {ix["name"] for ix in insp.get_indexes("annotations")}
+
+
+def upgrade() -> None:
+    # 1. Reassign each duplicate's grades to the kept row, but only those the
+    #    kept row doesn't already carry (preserve distinct multi-run gradings).
+    op.execute(
+        _RANKED
+        + """
+        UPDATE task_evaluations te
+        SET annotation_id = dup.keep_id
+        FROM dup
+        WHERE te.annotation_id = dup.dup_id
+          AND NOT EXISTS (
+              SELECT 1 FROM task_evaluations x
+              WHERE x.annotation_id = dup.keep_id
+                AND x.evaluation_id = te.evaluation_id
+                AND x.field_name IS NOT DISTINCT FROM te.field_name
+          );
+        """
+    )
+    # 2. Drop the now-redundant grades still pointing at the duplicates.
+    op.execute(
+        _RANKED
+        + """
+        DELETE FROM task_evaluations te
+        USING dup
+        WHERE te.annotation_id = dup.dup_id;
+        """
+    )
+    # 3. Soft-cancel the duplicate annotations (reversible; the partial index
+    #    ignores was_cancelled = true rows).
+    op.execute(
+        _RANKED
+        + """
+        UPDATE annotations
+        SET was_cancelled = true
+        WHERE id IN (SELECT dup_id FROM dup);
+        """
+    )
+    # 4. Build the guarantee.
+    op.execute(
+        f"CREATE UNIQUE INDEX IF NOT EXISTS {INDEX_NAME} "
+        "ON annotations (task_id, completed_by) "
+        "WHERE was_cancelled = false;"
+    )
+
+
+def downgrade() -> None:
+    if _index_exists():
+        op.execute(f"DROP INDEX IF EXISTS {INDEX_NAME};")

--- a/services/api/routers/projects/annotations.py
+++ b/services/api/routers/projects/annotations.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import String, cast, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
@@ -50,24 +51,27 @@ async def create_annotation(
     if project and not check_task_assigned_to_user(db, current_user, task_id, project):
         raise HTTPException(status_code=404, detail="Task not found")
 
-    # ---- Duplicate-submit guard (strict-timer race + auto-then-manual) ------
-    # A strict-timer task has two writers: the client auto-submit (this
-    # endpoint) AND the server-side timer worker (auto_submit_expired_timer),
-    # plus a manual submit can land after an auto-submit. Without coordination
-    # they each INSERT a near-identical row, so one student ends up with 2-4
-    # duplicate annotations on a single task (each then graded -> wasted tokens).
-    # Serialize concurrent submits for the SAME (task, user) with a
-    # transaction-scoped advisory lock (the worker takes the same lock), then,
-    # if an active annotation already exists, UPDATE it in place so the latest
-    # content wins and there is exactly one annotation per (task, user).
-    # Scoped to strict-timer projects: that is the only place the duplicate
-    # race exists (the server-side auto_submit_expired_timer worker runs only
-    # for strict timers), so non-timer annotation behavior is unchanged.
+    # ---- Duplicate-submit guard (one active annotation per task+user) -------
+    # "Submitted is submitted": a given user has exactly one active annotation
+    # per task. A strict-timer task has two concurrent writers — the client
+    # auto-submit (this endpoint) AND the server-side timer worker
+    # (tasks.auto_submit_expired_timer) — and a manual resubmit can land after
+    # an auto-submit. Without coordination they each INSERT a near-identical
+    # row, so one student ends up with 2-4 duplicate annotations (each then
+    # graded -> wasted tokens, inflated counts).
+    #
+    # Two layers enforce the invariant, for ALL projects (not just timed ones —
+    # a user resubmitting on any project should update, never duplicate):
+    #   1. A transaction-scoped advisory lock serializes concurrent submits for
+    #      the SAME (task, user); if an active annotation already exists we
+    #      UPDATE it in place (latest content wins).
+    #   2. The partial unique index uq_annotations_active_task_user is the
+    #      backstop the lock can't guarantee alone — the timer worker's task is
+    #      registered non-deterministically (platform vs extended overlay) and
+    #      may not hold the same lock. If a concurrent INSERT slips through, the
+    #      index trips IntegrityError and we fall back to update-in-place below.
     existing_annotation = None
-    if (
-        not (annotation.was_cancelled or False)
-        and getattr(project, "strict_timer_enabled", False)
-    ):
+    if not (annotation.was_cancelled or False):
         from sqlalchemy import text as _sql_text
 
         db.execute(
@@ -100,19 +104,25 @@ async def create_annotation(
                 ai_assisted = variant.get("ai_allowed", False)
                 break
 
+    # Copy the submitted fields onto an annotation row. Used both for the
+    # in-place update of an existing row and for the IntegrityError fallback
+    # below when a concurrent writer wins the INSERT race.
+    def _apply_submission(target):
+        target.result = annotation.result
+        target.draft = annotation.draft
+        target.lead_time = server_lead_time
+        target.active_duration_ms = annotation.active_duration_ms
+        target.focused_duration_ms = annotation.focused_duration_ms
+        target.tab_switches = annotation.tab_switches or 0
+        target.instruction_variant = annotation.instruction_variant
+        target.ai_assisted = ai_assisted
+        target.auto_submitted = annotation.auto_submitted or False
+
     # Create the annotation — or, when a duplicate submit lands, update the
     # existing one in place (latest content wins, no second row).
     if existing_annotation is not None:
         db_annotation = existing_annotation
-        db_annotation.result = annotation.result
-        db_annotation.draft = annotation.draft
-        db_annotation.lead_time = server_lead_time
-        db_annotation.active_duration_ms = annotation.active_duration_ms
-        db_annotation.focused_duration_ms = annotation.focused_duration_ms
-        db_annotation.tab_switches = annotation.tab_switches or 0
-        db_annotation.instruction_variant = annotation.instruction_variant
-        db_annotation.ai_assisted = ai_assisted
-        db_annotation.auto_submitted = annotation.auto_submitted or False
+        _apply_submission(db_annotation)
     else:
         db_annotation = Annotation(
             id=annotation_id,
@@ -197,7 +207,37 @@ async def create_annotation(
         TaskDraft.user_id == current_user.id,
     ).delete()
 
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # A concurrent writer (the timer worker, or another in-flight request)
+        # inserted the active row for this (task, user) first, tripping
+        # uq_annotations_active_task_user. Adopt the surviving row and update it
+        # in place — latest content wins. The winner already moved the task
+        # counters, so we must NOT re-apply them here (hence no counter work on
+        # this path); just fold in this submission's content.
+        db.rollback()
+        existing_annotation = (
+            db.query(Annotation)
+            .filter(
+                Annotation.task_id == task_id,
+                Annotation.completed_by == current_user.id,
+                Annotation.was_cancelled == False,  # noqa: E712
+            )
+            .order_by(Annotation.created_at.desc())
+            .first()
+        )
+        if existing_annotation is None:
+            # No surviving row — the IntegrityError was not the dup race; re-raise.
+            raise
+        db_annotation = existing_annotation
+        _apply_submission(db_annotation)
+        db.query(TaskDraft).filter(
+            TaskDraft.task_id == task_id,
+            TaskDraft.user_id == current_user.id,
+        ).delete()
+        db.commit()
+
     db.refresh(db_annotation)
 
     # Notify extended features (e.g. timer session completion)

--- a/services/api/tests/container/test_progress_in_container.py
+++ b/services/api/tests/container/test_progress_in_container.py
@@ -9,7 +9,7 @@ from datetime import datetime
 import pytest
 from sqlalchemy.orm import Session
 
-from models import Organization
+from models import Organization, User
 from project_models import Annotation, Project, Task
 
 
@@ -326,13 +326,25 @@ class TestProgressAlignment:
             self.db.add(task)
             self.db.commit()
 
-            # Add exactly the minimum required annotations
+            # Add exactly the minimum required annotations, each from a DISTINCT
+            # annotator — one active annotation per (task, user) is enforced by
+            # the uq_annotations_active_task_user index, so a multi-annotation
+            # task is reached across distinct annotators (the real-world shape).
             for j in range(expected_min):
+                annotator = User(
+                    id=str(uuid.uuid4()),
+                    username=f"prog-annotator-{uuid.uuid4().hex[:8]}",
+                    email=f"{uuid.uuid4().hex[:8]}@example.com",
+                    name=f"Annotator {j + 1}",
+                    is_active=True,
+                )
+                self.db.add(annotator)
+                self.db.flush()
                 ann = Annotation(
                     id=str(uuid.uuid4()),
                     task_id=task.id,
                     project_id=project.id,
-                    completed_by=self.admin.id,
+                    completed_by=annotator.id,
                     result=[{"value": {"text": f"Annotation {j+1}"}}],
                     was_cancelled=False,
                 )

--- a/services/api/tests/fixtures/database.py
+++ b/services/api/tests/fixtures/database.py
@@ -69,6 +69,18 @@ def _create_tables():
                     "AND (eval_metadata ->> 'evaluation_type') = 'korrektur_custom'"
                 )
             )
+            # Migration 064: one active annotation per (task, user). Declared on
+            # the Annotation model, but force it in idempotently too so a
+            # long-lived test DB bootstrapped before it landed still gets the
+            # backstop the IntegrityError path depends on.
+            conn.execute(
+                text(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS "
+                    "uq_annotations_active_task_user "
+                    "ON annotations (task_id, completed_by) "
+                    "WHERE was_cancelled = false"
+                )
+            )
             conn.execute(
                 text(
                     "ALTER TABLE task_evaluations "

--- a/services/api/tests/integration/test_analytics_service_db_branches.py
+++ b/services/api/tests/integration/test_analytics_service_db_branches.py
@@ -244,15 +244,16 @@ class TestCalculateQualityMetrics:
     def test_distribution_percentages(self, test_db: Session, test_users: List[User]):
         project = _make_project(test_db, test_users[0].id)
         task = _make_task(test_db, project.id, test_users[0].id, 1)
-        # 3 completed, 1 cancelled -> 75% / 25%.
-        for _ in range(3):
+        # 3 completed (distinct annotators — one active row per (task, user)) +
+        # 1 cancelled -> 75% / 25%.
+        for annotator in (test_users[1], test_users[2], test_users[3]):
             _make_annotation(
                 test_db, task_id=task.id, project_id=project.id,
-                completed_by=test_users[1].id, result=[{"value": {"text": "ok"}}],
+                completed_by=annotator.id, result=[{"value": {"text": "ok"}}],
             )
         _make_annotation(
             test_db, task_id=task.id, project_id=project.id,
-            completed_by=test_users[2].id, result=[{"value": {"text": "bad"}}],
+            completed_by=test_users[0].id, result=[{"value": {"text": "bad"}}],
             was_cancelled=True,
         )
         test_db.commit()
@@ -300,15 +301,20 @@ class TestInterAnnotatorAgreement:
         assert svc._calculate_inter_annotator_agreement(test_db, project.id, []) == 1.0
 
     def test_single_annotator_short_circuit(self, test_db: Session, test_users: List[User]):
-        """One task annotated twice by the SAME user -> <2 distinct annotators
-        -> 1.0."""
+        """One task with one active + one withdrawn annotation from the SAME
+        user -> <2 distinct annotators -> 1.0. (The index forbids two ACTIVE
+        rows per (task, user), so the duplicate is the cancelled one.)"""
         project = _make_project(test_db, test_users[0].id)
         task = _make_task(test_db, project.id, test_users[0].id, 1)
-        for _ in range(2):
-            _make_annotation(
-                test_db, task_id=task.id, project_id=project.id,
-                completed_by=test_users[1].id, result=[{"value": {"text": "same"}}],
-            )
+        _make_annotation(
+            test_db, task_id=task.id, project_id=project.id,
+            completed_by=test_users[1].id, result=[{"value": {"text": "same"}}],
+        )
+        _make_annotation(
+            test_db, task_id=task.id, project_id=project.id,
+            completed_by=test_users[1].id, result=[{"value": {"text": "same"}}],
+            was_cancelled=True,
+        )
         test_db.commit()
 
         svc = AnalyticsService()

--- a/services/api/tests/integration/test_annotations_integration.py
+++ b/services/api/tests/integration/test_annotations_integration.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from auth_module.dependencies import require_user
 from auth_module.models import User as AuthUser
@@ -255,26 +256,67 @@ class TestCreateAnnotation:
         test_db.refresh(task)
         assert task.total_annotations == 1
 
-    def test_non_timer_project_does_not_dedup(
+    def test_non_timer_project_also_dedups(
         self, client, test_db, test_users, auth_headers, test_org
     ):
-        """Non-timer projects keep the prior behavior — the dedup guard is scoped
-        to strict-timer projects, so this path is unchanged."""
+        """The one-active-annotation-per-(task, user) invariant holds for ALL
+        projects, not just strict-timer ones: a second submit on a non-timer
+        project updates the row in place (latest content wins) rather than
+        inserting a duplicate. "Submitted is submitted."""
         project, tasks = _setup(test_db, test_users[0], test_org)
         hdr = {**auth_headers["admin"], "X-Organization-Context": test_org.id}
         url = f"/api/projects/tasks/{tasks[0].id}/annotations"
-        body = {"result": [{"from_name": "text", "to_name": "text", "type": "textarea",
-                            "value": {"text": ["a"]}}]}
-        assert client.post(url, json=body, headers=hdr).status_code == 200
-        assert client.post(url, json=body, headers=hdr).status_code == 200
+        first = {"result": [{"from_name": "text", "to_name": "text", "type": "textarea",
+                             "value": {"text": ["first"]}}]}
+        second = {"result": [{"from_name": "text", "to_name": "text", "type": "textarea",
+                              "value": {"text": ["second wins"]}}]}
+        r1 = client.post(url, json=first, headers=hdr)
+        r2 = client.post(url, json=second, headers=hdr)
+        assert r1.status_code == 200, r1.text
+        assert r2.status_code == 200, r2.text
         test_db.expire_all()
-        n = (
+        anns = (
             test_db.query(Annotation)
             .filter(Annotation.task_id == tasks[0].id,
-                    Annotation.completed_by == test_users[0].id)
-            .count()
+                    Annotation.completed_by == test_users[0].id,
+                    Annotation.was_cancelled == False)  # noqa: E712
+            .all()
         )
-        assert n == 2  # no dedup on non-timer projects
+        assert len(anns) == 1, "second submit must update in place, not duplicate"
+        assert "second wins" in str(anns[0].result), "latest content wins"
+        assert r1.json()["id"] == r2.json()["id"]
+
+    def test_active_annotation_unique_index_rejects_duplicate(
+        self, test_db, test_users, test_org
+    ):
+        """The partial unique index uq_annotations_active_task_user is the
+        DB-level backstop behind the advisory lock: it rejects a second ACTIVE
+        annotation for the same (task, user) regardless of which writer (client
+        endpoint, platform worker, extended worker) attempts the INSERT. A
+        cancelled row for the same pair is still allowed (partial index)."""
+        project, tasks = _setup(test_db, test_users[0], test_org)
+        test_db.add(Annotation(
+            id=_uid(), task_id=tasks[0].id, project_id=project.id,
+            completed_by=test_users[0].id, result=[{"x": 1}], was_cancelled=False,
+        ))
+        test_db.commit()
+
+        test_db.add(Annotation(
+            id=_uid(), task_id=tasks[0].id, project_id=project.id,
+            completed_by=test_users[0].id, result=[{"x": 2}], was_cancelled=False,
+        ))
+        with pytest.raises(IntegrityError):
+            test_db.commit()
+        test_db.rollback()
+
+        # A cancelled annotation for the same (task, user) is permitted — the
+        # index is partial on was_cancelled = false, so resubmits after a
+        # withdrawal are never blocked.
+        test_db.add(Annotation(
+            id=_uid(), task_id=tasks[0].id, project_id=project.id,
+            completed_by=test_users[0].id, result=[{"x": 3}], was_cancelled=True,
+        ))
+        test_db.commit()  # no IntegrityError
 
     def test_create_annotation_task_not_found(self, client, test_db, test_users, auth_headers, test_org):
         resp = client.post(

--- a/services/api/tests/integration/test_annotations_router_branches.py
+++ b/services/api/tests/integration/test_annotations_router_branches.py
@@ -182,14 +182,16 @@ async def _make_task_async(db, project, *, inner_id=1, **overrides):
     return task
 
 
-async def _seed_annotation_async(db, task, project, completed_by, result=None):
+async def _seed_annotation_async(
+    db, task, project, completed_by, result=None, was_cancelled=False
+):
     ann = Annotation(
         id=str(uuid.uuid4()),
         task_id=task.id,
         project_id=project.id,
         completed_by=completed_by,
         result=result if result is not None else [{"value": {"choices": ["x"]}}],
-        was_cancelled=False,
+        was_cancelled=was_cancelled,
     )
     db.add(ann)
     await db.flush()
@@ -265,8 +267,14 @@ class TestListLatestAndEmpty:
         admin = await _make_user(async_test_db, is_superadmin=True)
         project = await _make_project_async(async_test_db, created_by=admin.id)
         task = await _make_task_async(async_test_db, project)
+        # One active + one withdrawn (cancelled) annotation from the same user.
+        # Both carry a non-empty result so both appear in the list; only one
+        # active row is permitted per (task, user) by the unique index, so the
+        # cancelled row is the realistic source of a per-annotator duplicate.
         await _seed_annotation_async(async_test_db, task, project, admin.id)
-        await _seed_annotation_async(async_test_db, task, project, admin.id)
+        await _seed_annotation_async(
+            async_test_db, task, project, admin.id, was_cancelled=True
+        )
         await async_test_db.commit()
 
         with _as_user(admin):
@@ -276,7 +284,7 @@ class TestListLatestAndEmpty:
             )
         assert resp.status_code == 200, resp.text
         body = resp.json()
-        # Two annotations from one user collapse to a single latest row.
+        # The two rows from one annotator collapse to a single latest row.
         assert len(body) == 1
         assert body[0]["completed_by"] == admin.id
 
@@ -285,12 +293,16 @@ class TestListLatestAndEmpty:
         self, async_test_client, async_test_db
     ):
         admin = await _make_user(async_test_db, is_superadmin=True)
+        other = await _make_user(async_test_db, is_superadmin=True)
         project = await _make_project_async(async_test_db, created_by=admin.id)
         task = await _make_task_async(async_test_db, project)
         real = await _seed_annotation_async(async_test_db, task, project, admin.id)
         # result == [] is filtered by the `cast(result, String) != '[]'` clause.
+        # Seeded under a different user so the active-annotation unique index
+        # (one per task+user) isn't violated — the exclusion is about the empty
+        # result, not the annotator.
         await _seed_annotation_async(
-            async_test_db, task, project, admin.id, result=[]
+            async_test_db, task, project, other.id, result=[]
         )
         await async_test_db.commit()
 
@@ -349,6 +361,7 @@ class TestCreateSideEffects:
         self, client, test_db, test_users, auth_headers
     ):
         admin = test_users[0]
+        other = test_users[1]
         project = _make_project(
             test_db,
             created_by=admin.id,
@@ -357,26 +370,32 @@ class TestCreateSideEffects:
         )
         task = _make_task(test_db, project)
 
-        first = client.post(
-            f"/api/projects/tasks/{task.id}/annotations",
-            json=_payload(),
-            headers=auth_headers["admin"],
-        )
-        assert first.status_code == 200, first.text
+        # One annotator's annotation -> 1 of 2 -> below the min -> not labeled.
+        # One active annotation per (task, user) means the min of 2 can only be
+        # reached across DISTINCT annotators, so seed the other annotator's row.
+        test_db.add(Annotation(
+            id=str(uuid.uuid4()),
+            task_id=task.id,
+            project_id=project.id,
+            completed_by=other.id,
+            result=[{"value": {"choices": ["y"]}}],
+            was_cancelled=False,
+        ))
+        test_db.commit()
         test_db.expire_all()
         after_one = test_db.query(Task).filter(Task.id == task.id).first()
-        # One non-cancelled annotation is below the min of 2 -> not labeled.
         assert after_one.is_labeled is False
 
-        second = client.post(
+        # A second, distinct annotator (admin) submits via create_annotation ->
+        # 2 of 2 -> meets the min -> the new insert flips is_labeled.
+        resp = client.post(
             f"/api/projects/tasks/{task.id}/annotations",
             json=_payload(),
             headers=auth_headers["admin"],
         )
-        assert second.status_code == 200, second.text
+        assert resp.status_code == 200, resp.text
         test_db.expire_all()
         after_two = test_db.query(Task).filter(Task.id == task.id).first()
-        # Second non-cancelled annotation meets the min -> labeled.
         assert after_two.is_labeled is True
 
 

--- a/services/api/tests/integration/test_comprehensive_round_trip.py
+++ b/services/api/tests/integration/test_comprehensive_round_trip.py
@@ -80,6 +80,20 @@ class TestComprehensiveRoundTrip:
         )
         session.add(test_user)
 
+        # A second annotator. One active annotation per (task, user) is enforced
+        # by the uq_annotations_active_task_user index, so the two annotations
+        # per task below come from DISTINCT annotators (the real shape for a
+        # project with min_annotations_per_task=2).
+        second_user = User(
+            id=str(uuid.uuid4()),
+            email="test2@example.com",
+            username="testuser2",
+            name="Test User Two",
+            is_active=True,
+            is_superadmin=True,
+        )
+        session.add(second_user)
+
         # Create evaluation types referenced by metrics. Idempotent: ids like
         # "accuracy" are part of the committed base catalog in the shared test
         # DB; re-inserting would raise evaluation_types_pkey UniqueViolation, so
@@ -154,6 +168,23 @@ class TestComprehensiveRoundTrip:
         )
         session.add(project_member)
 
+        # The second annotator's org + project memberships, so the round-trip
+        # export/import carries the user its annotations reference.
+        session.add(OrganizationMembership(
+            id=str(uuid.uuid4()),
+            organization_id=test_org.id,
+            user_id=second_user.id,
+            role=OrganizationRole.ANNOTATOR,
+            is_active=True,
+        ))
+        session.add(ProjectMember(
+            id=str(uuid.uuid4()),
+            project_id=project.id,
+            user_id=second_user.id,
+            role="annotator",
+            is_active=True,
+        ))
+
         # Create tasks
         tasks = []
         for i in range(5):
@@ -188,7 +219,7 @@ class TestComprehensiveRoundTrip:
                     result=[{"value": {"text": f"Annotation {j+1} for task {i+1}"}}],
                     draft=None,
                     was_cancelled=False,
-                    completed_by=test_user.id,
+                    completed_by=(test_user.id if j == 0 else second_user.id),
                     ground_truth=(j == 0),
                 )
                 annotations.append(annotation)

--- a/services/api/tests/migration/test_038_korrektur_backfill.py
+++ b/services/api/tests/migration/test_038_korrektur_backfill.py
@@ -193,11 +193,26 @@ def _seed_orphan_run_with_eval(
     # with NULL annotation_id would be exact cell duplicates — the replayed
     # migration would die on the index. Distinct annotations also match the
     # real korrektur shape (one grade per annotation).
+    #
+    # The annotation's author is a distinct SUBMITTER (a student), NOT the
+    # grader: migration 064's uq_annotations_active_task_user allows one active
+    # annotation per (task, user), so the same grader grading the same task
+    # twice must grade two different submitters' annotations. The grader is
+    # tracked via judge_prompts_used.grader_user_id below, not completed_by.
+    submitter = User(
+        id=str(uuid.uuid4()),
+        username=f"sub-{uuid.uuid4().hex[:10]}",
+        email=f"{uuid.uuid4().hex[:10]}@example.com",
+        name="Submitter",
+        is_active=True,
+    )
+    db.add(submitter)
+    db.flush()
     annotation = Annotation(
         id=str(uuid.uuid4()),
         task_id=task.id,
         project_id=project.id,
-        completed_by=grader.id,
+        completed_by=submitter.id,
         result=[],
         was_cancelled=False,
     )

--- a/services/api/tests/routers/projects/test_bulk_export_tasks.py
+++ b/services/api/tests/routers/projects/test_bulk_export_tasks.py
@@ -85,6 +85,23 @@ class TestBulkExportTasks:
         return user
 
     @pytest.fixture
+    def second_user(self, test_db_session):
+        """A second annotator — one active annotation per (task, user) means a
+        multi-annotation task is reached across distinct annotators."""
+        session = test_db_session
+        user = User(
+            id=str(uuid.uuid4()),
+            email="test2@example.com",
+            username="testuser2",
+            name="Test User Two",
+            is_active=True,
+            is_superadmin=True,
+        )
+        session.add(user)
+        session.commit()
+        return user
+
+    @pytest.fixture
     def test_project(self, test_db_session, test_user):
         """Create a test project."""
         session = test_db_session
@@ -102,9 +119,10 @@ class TestBulkExportTasks:
         return project
 
     @pytest.fixture
-    def tasks_with_annotations(self, test_db_session, test_project, test_user):
+    def tasks_with_annotations(self, test_db_session, test_project, test_user, second_user):
         """Create tasks with annotations."""
         session = test_db_session
+        annotators = [test_user, second_user]
 
         tasks = []
         annotations = []
@@ -123,14 +141,14 @@ class TestBulkExportTasks:
             session.add(task)
             session.flush()
 
-            # Add 2 annotations per task
+            # Add 2 annotations per task, from distinct annotators.
             for j in range(2):
                 annotation = Annotation(
                     id=str(uuid.uuid4()),
                     task_id=task.id,
                     project_id=test_project.id,
                     result=[{"value": {"text": [f"Label {j+1}"]}}],
-                    completed_by=test_user.id,
+                    completed_by=annotators[j].id,
                     was_cancelled=False,
                     ground_truth=(j == 0),
                     lead_time=5.5 + j,

--- a/services/shared/project_models.py
+++ b/services/shared/project_models.py
@@ -245,6 +245,26 @@ class Annotation(Base):
 
     __tablename__ = "annotations"
 
+    # One active (non-cancelled) annotation per (task, user). This is the
+    # DB-level guarantee against duplicate submissions: a strict-timer task has
+    # two concurrent writers — the client auto-submit (POST /annotations) and
+    # the server-side timer worker (tasks.auto_submit_expired_timer) — and an
+    # advisory lock alone proved fragile (the worker task name is registered by
+    # both platform and the extended overlay, so which implementation wins, and
+    # whether it holds the lock, is non-deterministic). This partial unique
+    # index rejects the second INSERT regardless; both writers catch the
+    # IntegrityError and fall back to update-in-place / skip. Partial on
+    # `was_cancelled = false` so a withdrawn annotation never blocks a resubmit.
+    __table_args__ = (
+        sa.Index(
+            "uq_annotations_active_task_user",
+            "task_id",
+            "completed_by",
+            unique=True,
+            postgresql_where=sa.text("was_cancelled = false"),
+        ),
+    )
+
     # Core fields
     id = Column(String, primary_key=True, index=True)
     task_id = Column(

--- a/services/workers/tasks.py
+++ b/services/workers/tasks.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import redis
 from dotenv import load_dotenv
-from sqlalchemy.exc import DBAPIError, OperationalError
+from sqlalchemy.exc import DBAPIError, IntegrityError, OperationalError
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -773,6 +773,45 @@ def cleanup_project_data(project_id: str) -> Dict[str, Any]:
         return {"status": "error", "project_id": project_id, "message": str(e)}
 
 
+def _dispatch_immediate_eval(db, annotation) -> None:
+    """Fire the immediate (KI-Votum) evaluation for a server-auto-submitted
+    annotation, so an absent student's grade is produced at submit time rather
+    than waiting for the hourly missing-only sweep.
+
+    No-op unless the project has ``immediate_evaluation_enabled`` AND an eligible
+    metric, so it is inert in the community edition (no immediate metrics). The
+    underlying ``ensure_immediate_evaluation`` is an idempotent get-or-create, so
+    this never double-dispatches even when the present-student client path also
+    fired it. Never raises — an eval-dispatch failure must not fail auto-submit.
+    """
+    try:
+        from project_models import Project, Task
+
+        project = (
+            db.query(Project).filter(Project.id == annotation.project_id).first()
+        )
+        if not project or not getattr(project, "immediate_evaluation_enabled", False):
+            return
+        task = db.query(Task).filter(Task.id == annotation.task_id).first()
+        if not task:
+            return
+        from immediate_eval_dispatch import ensure_immediate_evaluation
+
+        ensure_immediate_evaluation(
+            db,
+            project,
+            task,
+            annotation,
+            user_id=annotation.completed_by,
+            trigger="timer_auto_submit",
+        )
+    except Exception as e:  # noqa: BLE001 — dispatch must never fail auto-submit
+        logger.warning(
+            f"immediate-eval dispatch on auto-submit failed "
+            f"(annotation {getattr(annotation, 'id', None)}): {e}"
+        )
+
+
 @app.task(name="tasks.auto_submit_expired_timer")
 def auto_submit_expired_timer(session_id: str) -> Dict[str, Any]:
     """Server-side auto-submit when a strict timer expires.
@@ -815,16 +854,34 @@ def auto_submit_expired_timer(session_id: str) -> Dict[str, Any]:
                 "reason": "korrektur sessions don't auto-grade",
             }
 
-        # Check if user already has an annotation for this task (client beat us)
+        # Serialize against the client auto-submit using the SAME advisory key
+        # the /annotations endpoint uses, so a present student's client POST and
+        # this worker can't both INSERT a row for this (task, user). The partial
+        # unique index uq_annotations_active_task_user is the hard backstop if
+        # the lock is ever bypassed (handled below) — this task name is
+        # registered by BOTH platform and the extended overlay, so which
+        # implementation wins (and whether it locks) is non-deterministic.
+        from sqlalchemy import text as _sql_text
+        db.execute(
+            _sql_text("SELECT pg_advisory_xact_lock(hashtext(:k))"),
+            {"k": f"annsubmit:{session.task_id}:{session.user_id}"},
+        )
+
+        # Check if user already has an active annotation for this task (client
+        # beat us). Fire the immediate eval on it too: the present-student
+        # client path also dispatches, but ensure_immediate_evaluation is an
+        # idempotent get-or-create, so this never double-grades.
         existing = db.query(Annotation).filter(
             Annotation.task_id == session.task_id,
             Annotation.completed_by == session.user_id,
+            Annotation.was_cancelled == False,  # noqa: E712
         ).first()
         if existing:
             now = datetime.now(timezone.utc)
             session.completed_at = now
             session.auto_submitted = True
             db.commit()
+            _dispatch_immediate_eval(db, existing)
             return {"status": "skipped", "reason": "annotation already exists"}
 
         # Use draft if available: try timer session first, then task_drafts table
@@ -870,9 +927,36 @@ def auto_submit_expired_timer(session_id: str) -> Dict[str, Any]:
         # Complete the timer session
         session.completed_at = now
         session.auto_submitted = True
-        db.commit()
+        try:
+            db.commit()
+        except IntegrityError:
+            # Lost the INSERT race to the client despite the advisory lock (a
+            # bypassed/duplicate worker registration can skip it). The client's
+            # row is authoritative: adopt it, complete the session, and fire the
+            # eval on the surviving annotation.
+            db.rollback()
+            session = db.query(TimerSession).filter(
+                TimerSession.id == session_id
+            ).first()
+            existing = (
+                db.query(Annotation).filter(
+                    Annotation.task_id == session.task_id,
+                    Annotation.completed_by == session.user_id,
+                    Annotation.was_cancelled == False,  # noqa: E712
+                ).first()
+                if session
+                else None
+            )
+            if session and not session.completed_at:
+                session.completed_at = datetime.now(timezone.utc)
+                session.auto_submitted = True
+                db.commit()
+            if existing:
+                _dispatch_immediate_eval(db, existing)
+            return {"status": "skipped", "reason": "client beat us (integrity)"}
 
         logger.info(f"Server-side auto-submit for session {session_id}: annotation {annotation.id}")
+        _dispatch_immediate_eval(db, annotation)
         return {"status": "submitted", "annotation_id": annotation.id}
 
     except Exception as e:

--- a/services/workers/tests/test_tasks_handlers_coverage.py
+++ b/services/workers/tests/test_tasks_handlers_coverage.py
@@ -549,6 +549,11 @@ class _TimerFakeSession:
             return entry()
         return entry if entry is not None else _TimerFakeQuery()
 
+    def execute(self, *args, **kwargs):
+        # advisory-lock acquisition (SELECT pg_advisory_xact_lock(...)) — no-op
+        # in the fake session.
+        return None
+
     def add(self, obj):
         self.added.append(obj)
 
@@ -618,10 +623,14 @@ class TestAutoSubmitExpiredTimer:
 
     def test_existing_annotation_skips_autosubmit(self):
         ts = _make_timer_session()
-        existing = types.SimpleNamespace(id="ann-existing")
+        existing = types.SimpleNamespace(
+            id="ann-existing", project_id="proj-1", task_id="task-1",
+            completed_by="user-1",
+        )
         session = _TimerFakeSession({
             "TimerSession": _TimerFakeQuery(first=ts),
             "Annotation": _TimerFakeQuery(first=existing),
+            # No Project row -> _dispatch_immediate_eval no-ops cleanly.
         })
         with patch.object(tasks_module, "HAS_DATABASE", True):
             with _patch_timer_session(session):
@@ -631,6 +640,77 @@ class TestAutoSubmitExpiredTimer:
         assert session.commits == 1
         # No new annotation row added when the client already submitted.
         assert session.added == []
+
+    def test_autosubmit_dispatches_immediate_eval(self):
+        """A server-auto-submitted annotation fires the immediate (KI-Votum)
+        evaluation when the project has it enabled — so an absent student's
+        grade is produced at submit time, not only by the hourly sweep."""
+        ts = _make_timer_session(draft_result=[{"from_name": "answer"}])
+        task = types.SimpleNamespace(
+            id="task-1", total_annotations=0, is_labeled=False,
+        )
+        project = types.SimpleNamespace(
+            id="proj-1", min_annotations_per_task=1,
+            immediate_evaluation_enabled=True,
+        )
+        ann_calls = {"n": 0}
+
+        def annotation_query():
+            ann_calls["n"] += 1
+            if ann_calls["n"] == 1:
+                return _TimerFakeQuery(first=None)
+            return _TimerFakeQuery(count=0)
+
+        session = _TimerFakeSession({
+            "TimerSession": _TimerFakeQuery(first=ts),
+            "Annotation": annotation_query,
+            "TaskDraft": _TimerFakeQuery(first=None),
+            "Task": _TimerFakeQuery(first=task),
+            "Project": _TimerFakeQuery(first=project),
+        })
+        with patch.object(tasks_module, "HAS_DATABASE", True):
+            with _patch_timer_session(session):
+                with patch(
+                    "immediate_eval_dispatch.ensure_immediate_evaluation"
+                ) as mock_eval:
+                    out = auto_submit_expired_timer("ts-1")
+        assert out["status"] == "submitted"
+        mock_eval.assert_called_once()
+
+    def test_autosubmit_skips_eval_when_disabled(self):
+        """No immediate eval is dispatched when the project doesn't enable it
+        (community edition / non-immediate projects)."""
+        ts = _make_timer_session(draft_result=[{"from_name": "answer"}])
+        task = types.SimpleNamespace(
+            id="task-1", total_annotations=0, is_labeled=False,
+        )
+        project = types.SimpleNamespace(
+            id="proj-1", min_annotations_per_task=1,
+            immediate_evaluation_enabled=False,
+        )
+        ann_calls = {"n": 0}
+
+        def annotation_query():
+            ann_calls["n"] += 1
+            if ann_calls["n"] == 1:
+                return _TimerFakeQuery(first=None)
+            return _TimerFakeQuery(count=0)
+
+        session = _TimerFakeSession({
+            "TimerSession": _TimerFakeQuery(first=ts),
+            "Annotation": annotation_query,
+            "TaskDraft": _TimerFakeQuery(first=None),
+            "Task": _TimerFakeQuery(first=task),
+            "Project": _TimerFakeQuery(first=project),
+        })
+        with patch.object(tasks_module, "HAS_DATABASE", True):
+            with _patch_timer_session(session):
+                with patch(
+                    "immediate_eval_dispatch.ensure_immediate_evaluation"
+                ) as mock_eval:
+                    out = auto_submit_expired_timer("ts-1")
+        assert out["status"] == "submitted"
+        mock_eval.assert_not_called()
 
     def test_autosubmit_from_draft_flips_is_labeled(self):
         ts = _make_timer_session(draft_result=[{"from_name": "answer"}])


### PR DESCRIPTION
## Problem

The strict-timer duplicate-submission race **survived** the earlier advisory-lock fix. Root cause (verified on prod): `tasks.auto_submit_expired_timer` is registered under the same name by **both** the platform `tasks.py` (no lock) and the extended overlay's `register_tasks` (locked). Which implementation wins at worker startup — and therefore whether the lock is held — is **non-deterministic**. When the unlocked platform worker wins, it races the client auto-submit and both `INSERT` a row → one student ends up with 2+ duplicate annotations (each graded → wasted tokens, inflated counts).

Evidence: a fresh duplicate formed in prod (`franka.hellstern`, two rows **1.6 ms apart**) **1h43m after** the lock fix deployed. The lock mechanism works, the keys match, the pods were the fixed images, isolation is READ COMMITTED — the only explanation was a writer not holding the lock, which the two competing registrations confirmed.

## Fix (platform-only)

1. **Partial unique index** `uq_annotations_active_task_user` on `annotations(task_id, completed_by) WHERE NOT was_cancelled` — the DB-level guarantee immune to the registration race. **Migration 064** dedups any pre-existing duplicates first (reassigning distinct multi-run gradings to the kept row), declared on the `Annotation` model, and forced into the test DB. Verified on real prod data (builds cleanly, 0 active dups).
2. **`create_annotation`** — widen the dedup guard from strict-timer-only to **all projects** (one active annotation per task+user everywhere, latest content wins) + an `IntegrityError` fallback that adopts the surviving row when a concurrent writer wins the INSERT.
3. **Platform `tasks.auto_submit_expired_timer`** — take the same advisory lock the endpoint uses + an `IntegrityError` backstop (client beat us → skip) + dispatch the immediate (KI-Votum) evaluation so an absent student's grade is produced at submit time, not only by the hourly sweep.

No `CORE_API_VERSION` change (no contract change). The extended overlay's own worker already had the lock + eval dispatch; with platform now also correct, whichever registration wins is correct, and the index is the hard guarantee.

## Tests

- DB-level index enforcement (rejects a 2nd active row, allows an active+cancelled pair).
- Widen: latest-wins on a non-timer project.
- Worker: immediate-eval dispatch fires when enabled, no-ops when disabled.
- Updated pre-existing tests that assumed one user could hold multiple annotations on a task to the real multi-annotator shape (distinct users) / active+cancelled pairs.