### PR TITLE
fix(tests): index-legal annotators in auto-submit + progress tests (follow-up to #229)

### DIFF
--- a/services/api/tests/container/test_progress_in_container.py
+++ b/services/api/tests/container/test_progress_in_container.py
@@ -36,6 +36,35 @@ class TestProgressAlignment:
             self.db.add(self.org)
             self.db.commit()
 
+    def _seed_annotations(self, task, project, n, choice):
+        """Seed n annotations for a task, each from a DISTINCT annotator. One
+        active annotation per (task, user) is enforced by the
+        uq_annotations_active_task_user index, so a multi-annotation task is
+        reached across distinct annotators (the real-world shape)."""
+        for k in range(n):
+            annotator = User(
+                id=str(uuid.uuid4()),
+                username=f"compl-{uuid.uuid4().hex[:8]}",
+                email=f"{uuid.uuid4().hex[:8]}@example.com",
+                name=f"Annotator {k + 1}",
+                is_active=True,
+            )
+            self.db.add(annotator)
+            self.db.flush()
+            self.db.add(Annotation(
+                id=str(uuid.uuid4()),
+                task_id=task.id,
+                project_id=project.id,
+                completed_by=annotator.id,
+                result=[{
+                    "value": {"choices": [choice]},
+                    "from_name": "sentiment",
+                    "to_name": "text",
+                    "type": "choices",
+                }],
+                was_cancelled=False,
+            ))
+
     def test_multi_annotation_progress_tracking(self):
         """Test progress tracking with multiple annotations per task"""
         # Create project requiring 3 annotations per task
@@ -99,23 +128,7 @@ class TestProgressAlignment:
         self.db.commit()
 
         # Scenario 1: Task with 3 annotations (complete)
-        for j in range(3):
-            ann = Annotation(
-                id=str(uuid.uuid4()),
-                task_id=tasks[0].id,
-                project_id=project.id,
-                completed_by=self.admin.id,
-                result=[
-                    {
-                        "value": {"choices": ["positive"]},
-                        "from_name": "sentiment",
-                        "to_name": "text",
-                        "type": "choices",
-                    }
-                ],
-                was_cancelled=False,
-            )
-            self.db.add(ann)
+        self._seed_annotations(tasks[0], project, 3, "positive")
         tasks[0].total_annotations = 3
         tasks[0].is_labeled = True
         self.db.commit()
@@ -124,23 +137,7 @@ class TestProgressAlignment:
         assert tasks[0].total_annotations == 3
 
         # Scenario 2: Task with 2 annotations (incomplete)
-        for j in range(2):
-            ann = Annotation(
-                id=str(uuid.uuid4()),
-                task_id=tasks[1].id,
-                project_id=project.id,
-                completed_by=self.admin.id,
-                result=[
-                    {
-                        "value": {"choices": ["negative"]},
-                        "from_name": "sentiment",
-                        "to_name": "text",
-                        "type": "choices",
-                    }
-                ],
-                was_cancelled=False,
-            )
-            self.db.add(ann)
+        self._seed_annotations(tasks[1], project, 2, "negative")
         tasks[1].total_annotations = 2
         tasks[1].is_labeled = False  # Should not be labeled with only 2 annotations
         self.db.commit()
@@ -149,23 +146,7 @@ class TestProgressAlignment:
         assert tasks[1].total_annotations == 2
 
         # Scenario 3: Task with 4 annotations (exceeds requirement)
-        for j in range(4):
-            ann = Annotation(
-                id=str(uuid.uuid4()),
-                task_id=tasks[2].id,
-                project_id=project.id,
-                completed_by=self.admin.id,
-                result=[
-                    {
-                        "value": {"choices": ["neutral"]},
-                        "from_name": "sentiment",
-                        "to_name": "text",
-                        "type": "choices",
-                    }
-                ],
-                was_cancelled=False,
-            )
-            self.db.add(ann)
+        self._seed_annotations(tasks[2], project, 4, "neutral")
         tasks[2].total_annotations = 4
         tasks[2].is_labeled = True  # Should be labeled with 4 annotations (exceeds minimum)
         self.db.commit()

--- a/services/workers/tests/test_tasks_helpers_remaining.py
+++ b/services/workers/tests/test_tasks_helpers_remaining.py
@@ -584,6 +584,10 @@ class _AutoSubmitDB:
             q.filter.return_value.first.return_value = None
         return q
 
+    def execute(self, *args, **kwargs):
+        # advisory-lock acquisition (SELECT pg_advisory_xact_lock(...)) — no-op.
+        return None
+
     def add(self, obj):
         self.added.append(obj)
 


### PR DESCRIPTION
Follow-up to #229. The prod gate caught **3 test setups** that seeded multiple annotations for one `(task, user)`, which the new `uq_annotations_active_task_user` index correctly rejects:

- **workers** `TestAutoSubmitExpiredTimerCounterBranches` (2 tests): the `_AutoSubmitDB` fake session lacked `execute()`, so the worker's new advisory-lock `SELECT pg_advisory_xact_lock` raised `AttributeError` → caught → `"error"` instead of `"submitted"`. Added a no-op `execute()` (mirrors the fake in `test_tasks_handlers_coverage.py`).
- **container** `test_task_completion_scenarios`: seeded 3/2/4 annotations per task all from the same admin → `IntegrityError`. Reseeded across distinct annotators via a `_seed_annotations` helper.

All 3 pass locally. The other gate shards were already green; this unblocks the prod dispatch.