### PR TITLE
fix: unblock prod gate (dev-body test drift)

### DIFF
--- a/services/api/routers/auth/verification.py
+++ b/services/api/routers/auth/verification.py
@@ -45,7 +45,7 @@ async def verify_email_with_token(token: str, db: Session = Depends(get_db)):
 @router.post("/resend-verification")
 async def resend_verification_email(
     resend_request: ResendVerificationRequest,
-    request: Request,
+    request: Request = None,
     db: Session = Depends(get_db),
 ):
     """Resend email verification link"""
@@ -69,7 +69,11 @@ async def resend_verification_email(
         }
 
     try:
-        resend_host = request.headers.get("x-forwarded-host") or request.headers.get("host")
+        resend_host = (
+            (request.headers.get("x-forwarded-host") or request.headers.get("host"))
+            if request
+            else None
+        )
         success = await email_verification_service.send_verification_email(
             db=db, user=user, language=resend_request.language, host=resend_host
         )

--- a/services/api/tests/unit/test_auth_router_extended.py
+++ b/services/api/tests/unit/test_auth_router_extended.py
@@ -244,6 +244,7 @@ class TestBuildUserProfileResponse:
         mock_user.ki_experience_scores = {"item1": 4}
         mock_user.mandatory_profile_completed = True
         mock_user.profile_confirmed_at = datetime(2025, 6, 1, tzinfo=timezone.utc)
+        mock_user.preferred_ui_mode = None
 
         with patch("routers.auth.user.get_user_primary_role") as mock_role:
             mock_role.return_value = "CONTRIBUTOR"
@@ -269,6 +270,7 @@ class TestBuildUserProfileResponse:
         mock_user.updated_at = None
         mock_user.profile_confirmed_at = None
         # Set all optional fields to None to avoid Mock object validation errors
+        mock_user.preferred_ui_mode = None
         mock_user.pseudonym = None
         mock_user.use_pseudonym = True
         mock_user.age = None

--- a/services/api/tests/unit/test_evaluation_multifield_coverage.py
+++ b/services/api/tests/unit/test_evaluation_multifield_coverage.py
@@ -139,6 +139,14 @@ async def _seed_eval_run(db, project, owner, *, eval_metadata, metrics=None, **k
 
 
 class TestRunEvaluation:
+    @pytest.fixture(autouse=True)
+    def _noop_write_window(self):
+        # Dev-body addition: run_evaluation now calls enforce_project_write_window
+        # before the config-validation branches. No-op it so these mock-db unit
+        # tests exercise the 400/403/404/200 logic they target.
+        with patch("routers.evaluations.multi_field.run.enforce_project_write_window"):
+            yield
+
     def test_project_not_found(self):
         client = TestClient(app)
         user = _make_user()

--- a/services/api/tests/unit/test_evaluation_multifield_extended.py
+++ b/services/api/tests/unit/test_evaluation_multifield_extended.py
@@ -144,6 +144,14 @@ async def _seed_eval_run(db, project, owner, *, eval_metadata, metrics=None, **k
 
 
 class TestRunEvaluation:
+    @pytest.fixture(autouse=True)
+    def _noop_write_window(self):
+        # Dev-body addition: run_evaluation now calls enforce_project_write_window
+        # before the config-validation branches. No-op it so these mock-db unit
+        # tests exercise the 400/403/404/200 logic they target.
+        with patch("routers.evaluations.multi_field.run.enforce_project_write_window"):
+            yield
+
     def test_project_not_found(self):
         client = TestClient(app)
         user = _make_user()


### PR DESCRIPTION
Fixes the api-unit-al failures from PR #231's gate: resend request param + UserProfile mock + evaluations enforce_project_write_window patch. Local: 135 passed.