### PR TITLE
fix: CORE_API_VERSION test assertion (unblock prod gate)

### DIFF
--- a/services/api/tests/unit/test_extensions.py
+++ b/services/api/tests/unit/test_extensions.py
@@ -65,7 +65,7 @@ class TestExtensionLoader:
         from extensions import CORE_API_VERSION
 
         assert isinstance(CORE_API_VERSION, str)
-        assert CORE_API_VERSION == "2.2"
+        assert CORE_API_VERSION == "2.6"
 
     def test_tasks_with_feedback_for_user_empty_without_package(self):
         """Community edition: no human-feedback workflow -> empty set."""


### PR DESCRIPTION
Last al-shard failure: stale 2.2 assertion vs dev-body 2.6. Full local unit suite: 4897 passed.